### PR TITLE
Added custom.d.ts for typescript to recognize svg; added stylings for <Menu/>

### DIFF
--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,0 +1,4 @@
+declare module "*.svg" {
+  const content: string;
+  export default content;
+}

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -8,7 +8,7 @@ import { createGlobalStyle } from "styled-components";
 import { COLOR_PALETTE } from "popup/styles";
 import { reducer as auth } from "popup/ducks/authServices";
 import { POPUP_WIDTH } from "popup/constants";
-import Header from "popup/components/Layout/Header";
+import { Header } from "popup/components/Layout/Header";
 import Menu from "popup/components/Menu";
 import Router from "./Router";
 

--- a/src/popup/assets/icon-close.svg
+++ b/src/popup/assets/icon-close.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2.05 2.05"><path d="M.18.18l1.7 1.7m-1.7 0l1.7-1.7" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width=".35" data-name="Layer 2"/></svg>

--- a/src/popup/components/Layout/Header/index.tsx
+++ b/src/popup/components/Layout/Header/index.tsx
@@ -1,15 +1,14 @@
 import React from "react";
 import styled from "styled-components";
+
 import { COLOR_PALETTE } from "popup/styles";
 
 const HeaderEl = styled.header`
   background: ${COLOR_PALETTE.primaryGradient};
-  box-sizing: border-box;
   font-family: "Muli";
   display: flex;
-  height: 6.2rem;
   justify-content: space-between;
-  padding: 26px 54px;
+  padding: 2.375rem 3.375rem;
   text-align: left;
 `;
 
@@ -17,7 +16,7 @@ const HeaderH1 = styled.h1`
   color: #fff;
   font-size: 2rem;
   font-weight: 200;
-  line-height: 41px;
+  line-height: 1;
   margin: 0;
 `;
 
@@ -26,14 +25,16 @@ const NetworkEl = styled.h3`
   color: #fff;
   font-size: 1rem;
   font-weight: 800;
-  line-height: 21px;
+  line-height: 1;
 `;
 
-const Header = () => (
-  <HeaderEl>
+type HeaderProps = {
+  className?: string;
+};
+
+export const Header = ({ className }: HeaderProps) => (
+  <HeaderEl className={className}>
     <HeaderH1>Lyra</HeaderH1>
     <NetworkEl>Test net</NetworkEl>
   </HeaderEl>
 );
-
-export default Header;

--- a/src/popup/components/Menu/index.tsx
+++ b/src/popup/components/Menu/index.tsx
@@ -1,24 +1,38 @@
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { history } from "popup/App";
-import { applicationStateSelector, signOut } from "popup/ducks/authServices";
 import styled from "styled-components";
 import { APPLICATION_STATE } from "statics";
+
 import { Button } from "popup/basics";
+import { Z_INDEXES, COLOR_PALETTE } from "popup/styles";
+import { POPUP_WIDTH } from "popup/constants";
+
+import { history } from "popup/App";
+import { applicationStateSelector, signOut } from "popup/ducks/authServices";
+import { Header } from "popup/components/Layout/Header";
+
+import CloseIcon from "popup/assets/icon-close.svg";
 import MenuIcon from "popup/assets/menu.png";
 
 const SlideoutNav = styled.nav`
-  background: purple;
+  background: ${COLOR_PALETTE.menuGradient};
   height: 100%;
+  width: 100%;
+  max-width: ${POPUP_WIDTH}px;
   overflow: hidden;
   transition: margin 0.75s;
   margin-left: ${(props: { isOpen: boolean }) =>
     props.isOpen ? "0" : "-100%"};
   position: absolute;
   top: 0;
-  width: 100%;
+  z-index: ${Z_INDEXES.nav};
 `;
-
+const MenuHeader = styled(Header)`
+  background: none;
+`;
+const MenuEl = styled.div`
+  padding: 0.675rem 3.375rem;
+`;
 const MenuOpenButton = styled(Button)`
   display: inline-block;
   background: url(${MenuIcon});
@@ -27,15 +41,31 @@ const MenuOpenButton = styled(Button)`
   height: 1.625rem;
   width: 1.625rem;
 `;
-
 const SlideOutCloseButton = styled.button`
   display: block;
-`;
+  background: none;
+  border: none;
+  padding: 0;
 
-const SlideoutNavItem = styled.a`
-  color: white;
+  img {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+`;
+const SlideoutNavList = styled.ul`
+  list-style-type: none;
+  padding: 1.25rem 2rem;
+`;
+const SlideoutNavListItem = styled.li`
   display: block;
-  margin: 10px 0;
+  padding: 2rem 0;
+  font-size: 1.5rem;
+  font-weight: 200;
+  color: white;
+
+  a {
+    color: white;
+  }
 `;
 
 const Menu = () => {
@@ -49,20 +79,30 @@ const Menu = () => {
     setIsOpen(false);
     history.push("/");
   };
+
   return (
     <>
       {applicationState === APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED ? (
         <>
           <MenuOpenButton onClick={() => setIsOpen(true)} />
           <SlideoutNav isOpen={isOpen}>
-            <SlideOutCloseButton onClick={() => setIsOpen(false)}>
-              X
-            </SlideOutCloseButton>
-            <SlideoutNavItem href="/">Show backup Phrase</SlideoutNavItem>
-            <SlideoutNavItem href="/">Help</SlideoutNavItem>
-            <SlideoutNavItem onClick={(e) => signOutAndClose(e)} href="/">
-              Sign out
-            </SlideoutNavItem>
+            <MenuHeader />
+            <MenuEl>
+              <SlideOutCloseButton onClick={() => setIsOpen(false)}>
+                <img src={CloseIcon} alt="close icon" />
+              </SlideOutCloseButton>
+              <SlideoutNavList>
+                <SlideoutNavListItem>
+                  <a href="/">Show backup phrase</a>
+                </SlideoutNavListItem>
+                <SlideoutNavListItem>
+                  <a href="/">Help</a>
+                </SlideoutNavListItem>
+                <SlideoutNavListItem onClick={(e) => signOutAndClose(e)}>
+                  Sign out
+                </SlideoutNavListItem>
+              </SlideoutNavList>
+            </MenuEl>
           </SlideoutNav>
         </>
       ) : null}

--- a/src/popup/styles/index.tsx
+++ b/src/popup/styles/index.tsx
@@ -4,7 +4,13 @@ export const COLOR_PALETTE = {
   secondaryText: "#748098",
   primary: "#391EDA",
   primaryGradient: "linear-gradient(90deg, #391EDA 100%, #5339ED 0%)",
+  menuGradient: "linear-gradient(180deg, #564df0 0%,#2d18b5 100%)",
   secondary: "#654CF7",
   error: "#F42703",
   inputBackground: "rgba(210, 216, 229, 0.4)",
+};
+
+export const Z_INDEXES = {
+  body: 0,
+  nav: 10,
 };


### PR DESCRIPTION
<img width="452" alt="access-settings-menu" src="https://user-images.githubusercontent.com/3912060/84307895-9fbb0a00-ab2b-11ea-9287-8a3f99a50f5b.png">

- `src/custom.d.ts` - added for typescript to recognize `.svg` files
- Updated `Header` to be `export const` instead of `export default` following our [product conventions](https://github.com/stellar/product-conventions/blob/master/STYLEGUIDE.md#exports)
- `<Header/>` to allow modifications. In this case, I added `className` to allow modification because on `<Menu/>` its gradient covers `<Header/>` not just the body
- Added `Z_INDEXES` in `popup/styles`