### PR TITLE
Hotfix for broken builds

### DIFF
--- a/@stellar/lyra-api/webpack.config.js
+++ b/@stellar/lyra-api/webpack.config.js
@@ -9,6 +9,7 @@ const config = {
   entry: {
     index: path.resolve(__dirname, "./src/index.ts"),
   },
+  devtool: "source-map",
   output: {
     globalObject: "this",
     library: "lyra-api",


### PR DESCRIPTION
`@stellar/lyra-api` was being built in `yarn start` in a way that was incompatible with installing the extension, because it was using `eval` source maps (the default for `mode: "development`). Can test this change locally by letting `yarn start` settle, then running
```sh
grep 'eval(' extension/build/background.min.js | wc -l
```
On this branch, it returns 0, on `master`, it returns 8