### PR TITLE
optional chaining to make sure missing values don't cause errors

### DIFF
--- a/extension/src/popup/components/signTransaction/Operations.tsx
+++ b/extension/src/popup/components/signTransaction/Operations.tsx
@@ -144,11 +144,11 @@ export const Operations = ({
               {amount ? (
                 <KeyValueList
                   operationKey="Amount"
-                  operationValue={`${amount} ${asset.code}`}
+                  operationValue={`${amount}`}
                 />
               ) : null}
 
-              {signer.ed25519PublicKey ? (
+              {signer?.ed25519PublicKey ? (
                 <>
                   <KeyValueList
                     operationKey="Signer"
@@ -160,11 +160,11 @@ export const Operations = ({
                   />
                 </>
               ) : null}
-              {signer.sha256Hash ? (
+              {signer?.sha256Hash ? (
                 <>
                   <KeyValueList
                     operationKey="Signer"
-                    operationValue={formattedBuffer(signer.sha256Hash.data)}
+                    operationValue={formattedBuffer(signer?.sha256Hash?.data)}
                   />
                   <KeyValueList
                     operationKey="Weight"
@@ -172,7 +172,7 @@ export const Operations = ({
                   />
                 </>
               ) : null}
-              {signer.preAuthTx ? (
+              {signer?.preAuthTx ? (
                 <>
                   <KeyValueList
                     operationKey="Signer"


### PR DESCRIPTION
Oversight on my part, not checking for parent values first was causing breaking errors