### PR TITLE
fix Firefox UI inconsistencies

### DIFF
--- a/extension/src/popup/basics/Buttons.tsx
+++ b/extension/src/popup/basics/Buttons.tsx
@@ -45,6 +45,7 @@ const ButtonEl = styled(BasicButton)<ButtonProps>`
   border: none;
   -webkit-appearance: none;
   transition: all ${ANIMATION_TIMES.fast} ease-in-out;
+  white-space: nowrap;
 
   &:hover {
     background: ${COLOR_PALETTE.darkPrimaryGradient};

--- a/extension/src/popup/views/Account.tsx
+++ b/extension/src/popup/views/Account.tsx
@@ -73,6 +73,7 @@ const QrButton = styled(BasicButton)`
   margin-right: 1rem;
   width: 1rem;
   height: 1rem;
+  vertical-align: text-top;
 `;
 
 const VerticalCenterLink = styled(Link)`


### PR DESCRIPTION
<img width="422" alt="Screen Shot 2020-12-09 at 5 39 23 PM" src="https://user-images.githubusercontent.com/6789586/101697258-7ed56200-3a45-11eb-9f8d-213eaaafb580.png">

Prevent line break in button

<img width="461" alt="Screen Shot 2020-12-09 at 5 39 11 PM" src="https://user-images.githubusercontent.com/6789586/101697259-7ed56200-3a45-11eb-8f6a-3f666bac8278.png">

Align identicon and copy buttons
