### PR TITLE
Adding reusable component for account identicons

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -47,6 +47,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-copy-to-clipboard": "^5.0.2",
+    "react-identicons": "^1.2.4",
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.1.2",
     "redux": "^4.0.5",

--- a/extension/src/custom.d.ts
+++ b/extension/src/custom.d.ts
@@ -4,3 +4,5 @@ declare module "*.svg" {
 }
 
 declare module "qrcode.react";
+
+declare module "react-identicons";

--- a/extension/src/popup/basics/TransactionList.tsx
+++ b/extension/src/popup/basics/TransactionList.tsx
@@ -13,12 +13,13 @@ export const TransactionList = styled.ul`
   margin-bottom: 1.33em;
 
   li {
+    align-items: center;
     display: flex;
-    margin: 1.25rem 0;
+    min-height: 2.1875rem;
     color: ${COLOR_PALETTE.secondaryText};
 
-    div:first-child {
-      padding-right: 0.75rem;
+    > div {
+      margin-right: 0.75rem;
     }
   }
 

--- a/extension/src/popup/components/KeyIdenticon.tsx
+++ b/extension/src/popup/components/KeyIdenticon.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import Identicon from "react-identicons";
+import styled from "styled-components";
+
+import { COLOR_PALETTE } from "popup/constants/styles";
+
+import { truncatedPublicKey } from "helpers/stellar";
+
+const KeyIdenticonWrapperEl = styled.div`
+  align-items: center;
+  display: flex;
+`;
+
+const IdenticonWrapperEl = styled.div`
+  background: ${COLOR_PALETTE.white};
+  border: 0.125rem solid #d2d5db;
+  border-radius: 2rem;
+  padding: 0.5rem;
+  height: 2.1875rem;
+  margin-right: 0.5rem;
+  width: 2.1875rem;
+`;
+
+const IdenticonEl = styled(Identicon)`
+  height: 100% !important;
+  width: 100% !important;
+`;
+
+const PublicKeyEl = styled.span`
+  font-size: 0.875rem;
+  color: ${({ color }) => color || COLOR_PALETTE.secondaryText};
+  margin-right: 1rem;
+  opacity: 0.7;
+`;
+
+interface KeyIdenticonProps {
+  color?: string;
+  publicKey: string;
+}
+
+export const KeyIdenticon = ({
+  color = "",
+  publicKey = "",
+  ...props
+}: KeyIdenticonProps) => {
+  const shortPublicKey = truncatedPublicKey(publicKey);
+  return (
+    <KeyIdenticonWrapperEl>
+      <IdenticonWrapperEl>
+        <IdenticonEl string={shortPublicKey} />
+      </IdenticonWrapperEl>
+      <PublicKeyEl color={color} {...props}>
+        {shortPublicKey}
+      </PublicKeyEl>
+    </KeyIdenticonWrapperEl>
+  );
+};

--- a/extension/src/popup/components/signTransaction/Operations.tsx
+++ b/extension/src/popup/components/signTransaction/Operations.tsx
@@ -8,6 +8,8 @@ import { COLOR_PALETTE, FONT_WEIGHT } from "popup/constants/styles";
 
 import { TransactionList } from "popup/basics/TransactionList";
 
+import { KeyIdenticon } from "popup/components/KeyIdenticon";
+
 interface Path {
   code: string;
   issuer?: string;
@@ -43,6 +45,7 @@ interface TransactionInfoResponse {
 const OperationBoxEl = styled.div`
   text-align: left;
 `;
+
 const OperationBoxHeaderEl = styled.h4`
   color: ${COLOR_PALETTE.primary};
   font-size: 1.25rem;
@@ -57,11 +60,12 @@ const OperationBoxHeaderEl = styled.h4`
     font-weight: ${FONT_WEIGHT.bold};
   }
 `;
+
 const OperationsListEl = styled(TransactionList)`
   padding-left: 1.25rem;
 
   li {
-    div {
+    & > div {
       width: 50%;
 
       &:first-child {
@@ -97,7 +101,7 @@ const KeyValueList = ({
   operationValue,
 }: {
   operationKey: string;
-  operationValue: string | number;
+  operationValue: string | number | React.ReactNode;
 }) => (
   <li>
     <div>{operationKey}:</div>
@@ -181,7 +185,7 @@ export const Operations = ({
               {destination ? (
                 <KeyValueList
                   operationKey="Destination"
-                  operationValue={truncatedPublicKey(destination)}
+                  operationValue={<KeyIdenticon publicKey={destination} />}
                 />
               ) : null}
 
@@ -219,7 +223,9 @@ export const Operations = ({
                 <>
                   <KeyValueList
                     operationKey="Signer"
-                    operationValue={truncatedPublicKey(signer.ed25519PublicKey)}
+                    operationValue={
+                      <KeyIdenticon publicKey={signer.ed25519PublicKey} />
+                    }
                   />
                   <KeyValueList
                     operationKey="Weight"
@@ -279,7 +285,7 @@ export const Operations = ({
               {inflationDest ? (
                 <KeyValueList
                   operationKey="Inflation Destination"
-                  operationValue={truncatedPublicKey(inflationDest)}
+                  operationValue={<KeyIdenticon publicKey={inflationDest} />}
                 />
               ) : null}
               {setFlags ? (

--- a/extension/src/popup/views/Account.tsx
+++ b/extension/src/popup/views/Account.tsx
@@ -6,19 +6,18 @@ import { Link } from "react-router-dom";
 
 import { getAccountBalance } from "@shared/api/internal";
 
-import { truncatedPublicKey } from "helpers/stellar";
 import { emitMetric } from "helpers/metrics";
 import { publicKeySelector } from "popup/ducks/authServices";
 
 import { POPUP_WIDTH } from "constants/dimensions";
 import { ROUTES } from "popup/constants/routes";
 
-import { COLOR_PALETTE } from "popup/constants/styles";
 import { METRIC_NAMES } from "popup/constants/metricsNames";
 
 import { BasicButton } from "popup/basics/Buttons";
 
 import { Header } from "popup/components/Header";
+import { KeyIdenticon } from "popup/components/KeyIdenticon";
 import { Toast } from "popup/components/Toast";
 import { Menu } from "popup/components/Menu";
 
@@ -28,6 +27,7 @@ import StellarLogo from "popup/assets/stellar-logo.png";
 import { Footer } from "popup/components/Footer";
 
 import "popup/metrics/authServices";
+import { COLOR_PALETTE } from "popup/constants/styles";
 
 const AccountEl = styled.div`
   width: 100%;
@@ -37,8 +37,6 @@ const AccountEl = styled.div`
 `;
 
 const PublicKeyDisplayEl = styled.div`
-  position: relative;
-  display: inline-block;
   padding-right: 0.45rem;
   font-size: 0.81rem;
   text-align: right;
@@ -49,17 +47,14 @@ const PublicKeyDisplayEl = styled.div`
   }
 `;
 
-const PublicKeyEl = styled.span`
-  font-size: 0.875rem;
-  color: ${COLOR_PALETTE.secondaryText};
-  margin-right: 1rem;
-  opacity: 0.7;
+const PublicKeyButtonsEl = styled.div`
+  align-items: center;
+  display: flex;
 `;
 
 const CopyButtonEl = styled(BasicButton)`
   padding: 0;
   margin: 0;
-  vertical-align: middle;
 
   img {
     width: 1rem;
@@ -134,21 +129,26 @@ export const Account = () => {
           <Menu />
           <PublicKeyDisplayEl>
             <p>Your public key</p>
-            <PublicKeyEl>{truncatedPublicKey(publicKey)}</PublicKeyEl>
-            <VerticalCenterLink to={ROUTES.viewPublicKey}>
-              <QrButton />
-            </VerticalCenterLink>
-            <CopyToClipboard
-              text={publicKey}
-              onCopy={() => {
-                setIsCopied(true);
-                emitMetric(METRIC_NAMES.copyPublickKey);
-              }}
-            >
-              <CopyButtonEl>
-                <img src={CopyColorIcon} alt="copy button" />
-              </CopyButtonEl>
-            </CopyToClipboard>
+            <PublicKeyButtonsEl>
+              <KeyIdenticon
+                color={COLOR_PALETTE.primary}
+                publicKey={publicKey}
+              />
+              <VerticalCenterLink to={ROUTES.viewPublicKey}>
+                <QrButton />
+              </VerticalCenterLink>
+              <CopyToClipboard
+                text={publicKey}
+                onCopy={() => {
+                  setIsCopied(true);
+                  emitMetric(METRIC_NAMES.copyPublickKey);
+                }}
+              >
+                <CopyButtonEl>
+                  <img src={CopyColorIcon} alt="copy button" />
+                </CopyButtonEl>
+              </CopyToClipboard>
+            </PublicKeyButtonsEl>
             <CopiedToastWrapperEl>
               <Toast
                 message="Copied to your clipboard 👌"

--- a/extension/src/popup/views/GrantAccess.tsx
+++ b/extension/src/popup/views/GrantAccess.tsx
@@ -4,7 +4,6 @@ import styled from "styled-components";
 import { useLocation } from "react-router-dom";
 
 import { getUrlHostname, parsedSearchParam } from "helpers/urls";
-import { truncatedPublicKey } from "helpers/stellar";
 
 import { COLOR_PALETTE, FONT_WEIGHT } from "popup/constants/styles";
 import { rejectAccess, grantAccess } from "popup/ducks/access";
@@ -16,6 +15,7 @@ import { FirstTimeWarningMessage } from "popup/components/warningMessages/FirstT
 import { PunycodedDomain } from "popup/components/PunycodedDomain";
 
 import { Header } from "popup/components/Header";
+import { KeyIdenticon } from "popup/components/KeyIdenticon";
 
 import "popup/metrics/access";
 
@@ -31,9 +31,6 @@ const SubheaderEl = styled.h3`
   font-weight: ${FONT_WEIGHT.bold};
   font-size: 0.95rem;
   letter-spacing: 0.1px;
-  color: ${COLOR_PALETTE.primary}};
-`;
-const PublicKeyEl = styled.p`
   color: ${COLOR_PALETTE.primary}};
 `;
 const ButtonContainerEl = styled.div`
@@ -79,7 +76,7 @@ export const GrantAccess = () => {
         <FirstTimeWarningMessage />
         <PunycodedDomain domain={domain} />
         <SubheaderEl>This website wants to know your public key:</SubheaderEl>
-        <PublicKeyEl>&#9675; {truncatedPublicKey(publicKey)}</PublicKeyEl>
+        <KeyIdenticon color={COLOR_PALETTE.primary} publicKey={publicKey} />
         <ButtonContainerEl>
           <RejectButtonEl size="small" onClick={rejectAndClose}>
             Reject

--- a/extension/src/popup/views/SignTransaction.tsx
+++ b/extension/src/popup/views/SignTransaction.tsx
@@ -3,11 +3,7 @@ import { useLocation } from "react-router-dom";
 import { useDispatch } from "react-redux";
 import styled from "styled-components";
 
-import {
-  truncatedPublicKey,
-  getTransactionInfo,
-  stroopToXlm,
-} from "helpers/stellar";
+import { getTransactionInfo, stroopToXlm } from "helpers/stellar";
 import { decodeMemo } from "popup/helpers/decodeMemo";
 
 import { rejectTransaction, signTransaction } from "popup/ducks/access";
@@ -25,6 +21,7 @@ import { TransactionList } from "popup/basics/TransactionList";
 
 import { FirstTimeWarningMessage } from "popup/components/warningMessages/FirstTimeWarningMessage";
 import { Header } from "popup/components/Header";
+import { KeyIdenticon } from "popup/components/KeyIdenticon";
 import { Operations } from "popup/components/signTransaction/Operations";
 import { PunycodedDomain } from "popup/components/PunycodedDomain";
 import { WarningMessage } from "popup/components/WarningMessage";
@@ -129,7 +126,7 @@ export const SignTransaction = () => {
             <div>
               <strong>Source account:</strong>
             </div>
-            <div>{truncatedPublicKey(_source)}</div>
+            <KeyIdenticon publicKey={_source} />
           </li>
           {_fee ? (
             <li>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11538,7 +11538,7 @@ react-dev-utils@^10.2.1:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
-react-dom@^16.12.0, react-dom@^16.8.4:
+react-dom@^16.12.0, react-dom@^16.13.0, react-dom@^16.8.4:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
   integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
@@ -11572,6 +11572,14 @@ react-helmet@^6.0.0-beta:
     prop-types "^15.7.2"
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
+
+react-identicons@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/react-identicons/-/react-identicons-1.2.4.tgz#d913e6ff7523bbb4dd328abff4a07ddf96dd0e0f"
+  integrity sha512-my4CFMlO88kWjhX/y5qiGjQE9KgVLLeUKEM2wilUko6UzUTmzHJvl0rjkcftG9bMq3WLkpJkB2qwFMRllS+NmQ==
+  dependencies:
+    react "^16.13.0"
+    react-dom "^16.13.0"
 
 react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
@@ -11678,7 +11686,7 @@ react-toggle@^4.1.1:
   dependencies:
     classnames "^2.2.5"
 
-react@^16.12.0, react@^16.8.4:
+react@^16.12.0, react@^16.13.0, react@^16.8.4:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==


### PR DESCRIPTION
<img width="460" alt="Screen Shot 2020-12-14 at 8 05 51 PM" src="https://user-images.githubusercontent.com/6789586/102154700-f9d4b900-3e47-11eb-8046-d456004a7384.png">
<img width="457" alt="Screen Shot 2020-12-14 at 8 05 35 PM" src="https://user-images.githubusercontent.com/6789586/102154703-fa6d4f80-3e47-11eb-9c54-fb138404a2d6.png">
<img width="460" alt="Screen Shot 2020-12-14 at 8 04 08 PM" src="https://user-images.githubusercontent.com/6789586/102154704-fa6d4f80-3e47-11eb-9414-98c8b349faa5.png">
