### PR TITLE
base 64 encode account name list to obfuscate any sensitive data

### DIFF
--- a/extension/src/background/helpers/account.ts
+++ b/extension/src/background/helpers/account.ts
@@ -3,8 +3,12 @@ import { ACCOUNT_NAME_LIST_ID, KEY_ID_LIST } from "constants/localStorageTypes";
 export const getKeyIdList = () =>
   JSON.parse(localStorage.getItem(KEY_ID_LIST) || "[]");
 
-export const getAccountNameList = () =>
-  JSON.parse(localStorage.getItem(ACCOUNT_NAME_LIST_ID) || "{}");
+export const getAccountNameList = () => {
+  const encodedaccountNameList =
+    localStorage.getItem(ACCOUNT_NAME_LIST_ID) || btoa("{}");
+
+  return JSON.parse(atob(encodedaccountNameList));
+};
 
 export const addAccountName = ({
   keyId,
@@ -17,5 +21,7 @@ export const addAccountName = ({
 
   accountNameList[keyId] = accountName;
 
-  localStorage.setItem(ACCOUNT_NAME_LIST_ID, JSON.stringify(accountNameList));
+  const encodedaccountNameList = btoa(JSON.stringify(accountNameList));
+
+  localStorage.setItem(ACCOUNT_NAME_LIST_ID, encodedaccountNameList);
 };

--- a/extension/src/background/messageListener/popupMessageListener.ts
+++ b/extension/src/background/messageListener/popupMessageListener.ts
@@ -11,7 +11,6 @@ import { Account, Response as Request } from "@shared/api/types";
 import { MessageResponder } from "background/types";
 
 import {
-  ACCOUNT_NAME_LIST_ID,
   ALLOWLIST_ID,
   APPLICATION_ID,
   DATA_SHARING_ID,
@@ -374,10 +373,7 @@ export const popupMessageListener = (request: Request) => {
         keyIdList.push(keyId);
         localStorage.setItem(KEY_ID_LIST, JSON.stringify(keyIdList));
         localStorage.setItem(KEY_DERIVATION_NUMBER_ID, "0");
-        localStorage.setItem(
-          ACCOUNT_NAME_LIST_ID,
-          JSON.stringify({ [keyId]: "Account 1" }),
-        );
+        addAccountName({ keyId, accountName: "Account 1" });
       }
     }
     /* end migration script */


### PR DESCRIPTION
simply base64 encode account name list, just so any user entered data is not stored in plaint text. This could be more intricate, but not sure that it's necessary right now