### PR TITLE
begin using wallet-sdk to get account details

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -201,7 +201,7 @@ export const getAccountDetails = async (
     const transactionData = await dataProvider.fetchPayments({
       limit: TRANSACTIONS_LIMIT,
     });
-    payments = transactionData?.records || {};
+    payments = transactionData?.records || null;
   } catch (e) {
     console.error(e);
   }

--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -1,11 +1,11 @@
-import StellarSdk from "stellar-sdk";
-import { Account } from "./types";
-import { NETWORK_URL } from "../constants/stellar";
+import { DataProvider } from "@stellar/wallet-sdk";
+import { Account, AccountDetailsInterface } from "./types";
+import { NETWORK_PASSPHRASE, NETWORK_URL } from "../constants/stellar";
 import { SERVICE_TYPES } from "../constants/services";
 import { APPLICATION_STATE } from "../constants/applicationState";
 import { sendMessageToBackground } from "./helpers";
 
-const server = new StellarSdk.Server(NETWORK_URL);
+const TRANSACTIONS_LIMIT = 15;
 
 export const createAccount = async (
   password: string,
@@ -183,32 +183,40 @@ export const confirmPassword = async (
   return response;
 };
 
-export const getAccountBalance = async (
+export const getAccountDetails = async (
   publicKey: string,
-): Promise<{
-  balance: string;
-  isFunded: boolean;
-}> => {
-  let response = {
-    balances: [{ asset_code: "", balance: "" }],
-    isFunded: true,
-  };
+): Promise<AccountDetailsInterface> => {
+  const dataProvider = new DataProvider({
+    serverUrl: NETWORK_URL,
+    accountOrKey: publicKey,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  });
+
+  let payments = null;
+  let balances = null;
+  let isFunded = null;
 
   try {
-    response = await server.loadAccount(publicKey);
+    ({ balances } = await dataProvider.fetchAccountDetails());
+    const transactionData = await dataProvider.fetchPayments({
+      limit: TRANSACTIONS_LIMIT,
+    });
+    payments = transactionData?.records || {};
   } catch (e) {
     console.error(e);
-    // TODO: Check that this is indeed a 404 before returning 0
-    return { balance: "0", isFunded: false };
   }
 
-  const { balance: nativeBalance } = response.balances.filter(
-    // eslint-disable-next-line camelcase
-    (balance: { asset_code?: string }) => !balance.asset_code,
-  )[0];
+  try {
+    isFunded = await dataProvider.isAccountFunded();
+  } catch (e) {
+    isFunded = false;
+    console.error(e);
+  }
+
   return {
-    isFunded: true,
-    balance: nativeBalance,
+    balances,
+    isFunded,
+    payments,
   };
 };
 

--- a/@shared/api/package.json
+++ b/@shared/api/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "@stellar/wallet-sdk": "^0.1.0-rc.10",
     "prettier": "^2.0.5",
     "stellar-sdk": "5.0.1",
     "typescript": "~3.7.2",

--- a/@shared/api/types.ts
+++ b/@shared/api/types.ts
@@ -1,3 +1,5 @@
+import { Types } from "@stellar/wallet-sdk";
+
 import { SERVICE_TYPES, EXTERNAL_SERVICE_TYPES } from "../constants/services";
 import { APPLICATION_STATE } from "../constants/applicationState";
 
@@ -35,4 +37,12 @@ export interface Account {
   publicKey: string;
   name: string;
   imported: boolean;
+}
+
+export type Balances = Types.BalanceMap | null;
+
+export interface AccountDetailsInterface {
+  balances: Balances;
+  isFunded: boolean | null;
+  payments: Array<Types.Payment> | null;
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -31,6 +31,7 @@
     "@types/react-router-dom": "^5.1.3",
     "@types/redux": "^3.6.0",
     "@types/yup": "^0.29.2",
+    "bignumber.js": "^9.0.1",
     "buffer": "^5.6.0",
     "concurrently": "^5.1.0",
     "copy-webpack-plugin": "^5.1.1",

--- a/extension/src/popup/components/account/AccountAssets.tsx
+++ b/extension/src/popup/components/account/AccountAssets.tsx
@@ -1,24 +1,24 @@
 import React from "react";
 import styled from "styled-components";
+import { BigNumber } from "bignumber.js";
 
 import { COLOR_PALETTE, FONT_WEIGHT } from "popup/constants/styles";
+import { Balances } from "@shared/api/types";
 
 import StellarLogo from "popup/assets/stellar-logo.png";
 
-const AccountAssetsHeaderEl = styled.h3`
-  color: ${COLOR_PALETTE.greyDark};
-  font-size: 1rem;
-  font-weight: ${FONT_WEIGHT.normal};
-  margin: 0;
-`;
-
 const AssetWrapper = styled.div`
-  align-items: center;
-  display: flex;
   height: 4rem;
 `;
 
-const StellarLogoEl = styled.img`
+const AssetEl = styled.div`
+  align-items: center;
+  border-bottom: 1px solid ${COLOR_PALETTE.greyFaded};
+  display: flex;
+  padding: 0 1rem;
+`;
+
+const AssetLogoEl = styled.img`
   margin-right: 0.75rem;
   width: 1.625rem;
 `;
@@ -34,18 +34,16 @@ const AssetTypeEl = styled.span`
   font-weight: ${FONT_WEIGHT.normal};
 `;
 
-interface AccountAssetsProps {
-  accountBalance: string;
-}
-
-export const AccountAssets = ({ accountBalance }: AccountAssetsProps) => (
-  <>
-    <AccountAssetsHeaderEl>Account assets</AccountAssetsHeaderEl>
-    <AssetWrapper>
-      <StellarLogoEl alt="Stellar logo" src={StellarLogo} />
-      <LumenBalanceEl>
-        {accountBalance} <AssetTypeEl>XLM</AssetTypeEl>
-      </LumenBalanceEl>
-    </AssetWrapper>
-  </>
+export const AccountAssets = ({ balances }: { balances: Balances }) => (
+  <AssetWrapper>
+    {balances &&
+      Object.values(balances).map(({ token: { code, type }, total }) => (
+        <AssetEl key={type}>
+          <AssetLogoEl alt="Asset logo" src={StellarLogo} />
+          <LumenBalanceEl>
+            {new BigNumber(total).toString()} <AssetTypeEl>{code}</AssetTypeEl>
+          </LumenBalanceEl>
+        </AssetEl>
+      ))}
+  </AssetWrapper>
 );

--- a/extension/src/popup/components/account/AccountDetails.tsx
+++ b/extension/src/popup/components/account/AccountDetails.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+import { useSelector } from "react-redux";
+
+import { COLOR_PALETTE, FONT_WEIGHT } from "popup/constants/styles";
+
+import { BasicButton } from "popup/basics/Buttons";
+
+import { publicKeySelector } from "popup/ducks/authServices";
+import { getAccountDetails } from "@shared/api/internal";
+import { AccountDetailsInterface } from "@shared/api/types";
+
+import { AccountAssets } from "./AccountAssets";
+import { AccountHistory } from "./AccountHistory";
+import { NotFundedMessage } from "./NotFundedMessage";
+
+const AccountHeaderEl = styled.section`
+  align-items: center;
+  display: flex;
+`;
+
+interface AccountToggleBtnElProps {
+  isActive: boolean;
+}
+
+const AccountToggleBtnEl = styled(BasicButton)`
+  border-bottom: 2px solid
+    ${({ isActive }: AccountToggleBtnElProps) =>
+      isActive ? COLOR_PALETTE.primary : COLOR_PALETTE.background};
+  color: ${({ isActive }: AccountToggleBtnElProps) =>
+    isActive ? COLOR_PALETTE.primary : COLOR_PALETTE.greyDark};
+  font-size: 1rem;
+  font-weight: ${FONT_WEIGHT.normal};
+  margin: 0;
+  padding: 0 1rem 1.25rem 1rem;
+  width: 50%;
+`;
+
+const defaultAccountDetails = {
+  balances: null,
+  isFunded: null,
+  payments: null,
+} as AccountDetailsInterface;
+
+export const AccountDetails = () => {
+  const [isAccountAssetsActive, setIsAccountAssetsActive] = useState(true);
+
+  const [accountDetails, setAccountDetails] = useState(defaultAccountDetails);
+  const publicKey = useSelector(publicKeySelector);
+
+  useEffect(() => {
+    const fetchAccountDetails = async () => {
+      try {
+        const res = await getAccountDetails(publicKey);
+        setAccountDetails(res);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+
+    fetchAccountDetails();
+  }, [publicKey]);
+
+  const { isFunded, balances } = accountDetails;
+
+  const handleDetailToggle = (isAssetsActive: boolean) => {
+    if (isAccountAssetsActive !== isAssetsActive) {
+      setIsAccountAssetsActive(isAssetsActive);
+    }
+  };
+
+  if (isFunded === null) {
+    return null;
+  }
+
+  return isFunded ? (
+    <>
+      <AccountHeaderEl>
+        <AccountToggleBtnEl
+          isActive={isAccountAssetsActive}
+          onClick={() => handleDetailToggle(true)}
+        >
+          Account assets
+        </AccountToggleBtnEl>
+        <AccountToggleBtnEl
+          isActive={!isAccountAssetsActive}
+          onClick={() => handleDetailToggle(false)}
+        >
+          History
+        </AccountToggleBtnEl>
+      </AccountHeaderEl>
+      {isAccountAssetsActive ? (
+        <AccountAssets balances={balances} />
+      ) : (
+        <AccountHistory />
+      )}
+    </>
+  ) : (
+    <NotFundedMessage />
+  );
+};

--- a/extension/src/popup/components/account/AccountHistory.tsx
+++ b/extension/src/popup/components/account/AccountHistory.tsx
@@ -1,0 +1,3 @@
+import React from "react";
+
+export const AccountHistory = () => <></>;

--- a/extension/src/popup/views/Account.tsx
+++ b/extension/src/popup/views/Account.tsx
@@ -1,10 +1,8 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import CopyToClipboard from "react-copy-to-clipboard";
 import styled from "styled-components";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
-
-import { getAccountBalance } from "@shared/api/internal";
 
 import { emitMetric } from "helpers/metrics";
 import {
@@ -22,9 +20,8 @@ import { METRIC_NAMES } from "popup/constants/metricsNames";
 import { BasicButton } from "popup/basics/Buttons";
 
 import { Header } from "popup/components/Header";
-import { AccountAssets } from "popup/components/account/AccountAssets";
+import { AccountDetails } from "popup/components/account/AccountDetails";
 import { AccountDropdown } from "popup/components/account/AccountDropdown";
-import { NotFundedMessage } from "popup/components/account/NotFundedMessage";
 import { Toast } from "popup/components/Toast";
 import { Menu } from "popup/components/Menu";
 
@@ -37,7 +34,7 @@ const AccountEl = styled.div`
   width: 100%;
   max-width: ${POPUP_WIDTH}px;
   box-sizing: border-box;
-  padding: 1.75rem 1rem;
+  padding: 1.75rem 0;
 `;
 
 const AccountHeaderEl = styled.div`
@@ -74,7 +71,7 @@ const VerticalCenterLink = styled(Link)`
   vertical-align: middle;
 `;
 
-const AccountDetailsEl = styled.section`
+const AccountDetailsWrapperEl = styled.section`
   padding-bottom: 6rem;
 `;
 
@@ -85,29 +82,12 @@ const CopiedToastWrapperEl = styled.div`
 `;
 
 export const Account = () => {
-  const [accountBalance, setaccountBalance] = useState("");
   const [isCopied, setIsCopied] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [isAccountFunded, setIsAccountFunded] = useState(true);
   const publicKey = useSelector(publicKeySelector);
   const allAccounts = useSelector(allAccountsSelector);
   const currentAccountName = useSelector(accountNameSelector);
   const accountDropDownRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    let res = { balance: "", isFunded: true };
-    const fetchAccountBalance = async () => {
-      try {
-        res = await getAccountBalance(publicKey);
-      } catch (e) {
-        console.error(e);
-      }
-      const { balance, isFunded } = res;
-      setaccountBalance(balance);
-      setIsAccountFunded(isFunded);
-    };
-    fetchAccountBalance();
-  }, [publicKey]);
 
   const closeDropdown = (e: React.ChangeEvent<any>) => {
     if (
@@ -118,7 +98,7 @@ export const Account = () => {
     }
   };
 
-  return accountBalance ? (
+  return (
     <section onClick={closeDropdown}>
       <Header>
         <Menu />
@@ -155,14 +135,10 @@ export const Account = () => {
         </VerticalCenterLink>
       </AccountHeaderEl>
       <AccountEl>
-        <AccountDetailsEl>
-          {isAccountFunded ? (
-            <AccountAssets accountBalance={accountBalance} />
-          ) : (
-            <NotFundedMessage />
-          )}
-        </AccountDetailsEl>
+        <AccountDetailsWrapperEl>
+          <AccountDetails />
+        </AccountDetailsWrapperEl>
       </AccountEl>
     </section>
-  ) : null;
+  );
 };

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@stellar/eslint-config": "^1.0.3",
     "@stellar/prettier-config": "^1.0.1",
     "@stellar/tsconfig": "^1.0.2",
+    "@stellar/wallet-sdk": "^0.1.0-rc.10",
     "@testing-library/dom": "^7.22.2",
     "@testing-library/jest-dom": "^4.2.4",
     "@types/jest": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@stellar/eslint-config": "^1.0.3",
     "@stellar/prettier-config": "^1.0.1",
     "@stellar/tsconfig": "^1.0.2",
-    "@stellar/wallet-sdk": "^0.1.0-rc.10",
     "@testing-library/dom": "^7.22.2",
     "@testing-library/jest-dom": "^4.2.4",
     "@types/jest": "^24.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4437,6 +4437,11 @@ bignumber.js@^4.0.0:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.1.0.tgz#db6f14067c140bd46624815a7916c92d9b6c24b1"
   integrity sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==
 
+bignumber.js@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
+  integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==
+
 binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"


### PR DESCRIPTION
Breaking the Account view overhaul into smaller parts to make code review easier. This PR mostly focuses on using wallet-sdk instead of stellar-sdk to get the model for account data and subsequently updating components to ingest the new model