### PR TITLE
Properly decode and show a Fee Bump transaction

### DIFF
--- a/extension/src/background/messageListener/freighterApiMessageListener.ts
+++ b/extension/src/background/messageListener/freighterApiMessageListener.ts
@@ -101,7 +101,8 @@ export const freighterApiMessageListener = (
     const directoryLookupJson = await cachedFetch(STELLAR_DIRECTORY_URL);
     const accountData = directoryLookupJson?._embedded?.records || [];
 
-    const { _operations } = transaction;
+    const _operations =
+      transaction._operations || transaction._innerTransaction._operations;
 
     const flaggedKeys: FlaggedKeys = {};
 

--- a/extension/src/popup/basics/Modal.tsx
+++ b/extension/src/popup/basics/Modal.tsx
@@ -1,0 +1,14 @@
+import styled from "styled-components";
+
+import { SubmitButton as BasicSubmitButton } from "./Forms";
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: space-around;
+  padding-top: 3rem;
+  padding-bottom: 1.5rem;
+`;
+
+export const SubmitButton = styled(BasicSubmitButton)`
+  width: 12.43rem;
+`;

--- a/extension/src/popup/components/signTransaction/Transaction.tsx
+++ b/extension/src/popup/components/signTransaction/Transaction.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import styled from "styled-components";
+
+import { COLOR_PALETTE } from "popup/constants/styles";
+import { FlaggedKeys } from "types/transactions";
+
+import { decodeMemo } from "popup/helpers/decodeMemo";
+
+import { Operations } from "popup/components/signTransaction/Operations";
+
+import { TransactionHeader } from "./TransactionHeader";
+
+const OperationsHeader = styled.h2`
+  color: ${COLOR_PALETTE.primary};
+  font-size: 1.375rem;
+  margin: 0;
+  padding: 0;
+  padding-top: 2.25rem;
+`;
+
+interface TransactionProps {
+  flaggedKeys: FlaggedKeys;
+  isMemoRequired: boolean;
+  transaction: { [key: string]: any };
+}
+
+export const Transaction = ({
+  flaggedKeys,
+  isMemoRequired,
+  transaction,
+}: TransactionProps) => {
+  const { _fee, _operations, _memo, _sequence, _source } = transaction;
+  console.log(transaction);
+
+  const operationText =
+    _operations && _operations.length > 1 ? "Operations:" : "Operation:";
+  const memo = decodeMemo(_memo);
+
+  return (
+    <>
+      <TransactionHeader
+        _fee={_fee}
+        _sequence={_sequence}
+        source={_source}
+        memo={memo}
+        isMemoRequired={isMemoRequired}
+      />
+      {_operations ? (
+        <>
+          <OperationsHeader>
+            {_operations.length} {operationText}
+          </OperationsHeader>
+          <Operations
+            flaggedKeys={flaggedKeys}
+            isMemoRequired={isMemoRequired}
+            operations={_operations}
+          />
+        </>
+      ) : null}
+    </>
+  );
+};

--- a/extension/src/popup/components/signTransaction/Transaction.tsx
+++ b/extension/src/popup/components/signTransaction/Transaction.tsx
@@ -30,7 +30,6 @@ export const Transaction = ({
   transaction,
 }: TransactionProps) => {
   const { _fee, _operations, _memo, _sequence, _source } = transaction;
-  console.log(transaction);
 
   const operationText =
     _operations && _operations.length > 1 ? "Operations:" : "Operation:";

--- a/extension/src/popup/components/signTransaction/TransactionHeader.tsx
+++ b/extension/src/popup/components/signTransaction/TransactionHeader.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+
+import { IconWithLabel, TransactionList } from "popup/basics/TransactionList";
+
+import { stroopToXlm } from "helpers/stellar";
+
+import { KeyIdenticon } from "popup/components/identicons/KeyIdenticon";
+
+import IconExcalamtion from "popup/assets/icon-exclamation.svg";
+
+const getMemoDisplay = ({
+  memo,
+  isMemoRequired,
+}: {
+  memo: string;
+  isMemoRequired: boolean;
+}) => {
+  if (isMemoRequired) {
+    return (
+      <IconWithLabel isHighAlert alt="exclamation icon" icon={IconExcalamtion}>
+        Not defined
+      </IconWithLabel>
+    );
+  }
+  if (memo) {
+    return <span>{`${memo} (MEMO_TEXT)`}</span>;
+  }
+
+  return null;
+};
+
+interface TransactionListProps {
+  _fee: number;
+  _sequence: string;
+  source: string;
+  isFeeBump?: boolean;
+  isMemoRequired: boolean;
+  memo?: string;
+}
+
+export const TransactionHeader = ({
+  _fee,
+  _sequence,
+  source,
+  isFeeBump,
+  isMemoRequired,
+  memo,
+}: TransactionListProps) => (
+  <TransactionList>
+    <li>
+      <div>
+        <strong>Source account:</strong>
+      </div>
+      <KeyIdenticon publicKey={source} />
+    </li>
+    {_fee ? (
+      <li>
+        <div>
+          <strong>Base fee:</strong>
+        </div>
+        <div> {stroopToXlm(_fee)} XLM</div>
+      </li>
+    ) : null}
+    {memo ? (
+      <li>
+        <div>
+          <strong>Memo:</strong>
+        </div>
+        <div> {getMemoDisplay({ memo, isMemoRequired })} </div>
+      </li>
+    ) : null}
+
+    {_sequence ? (
+      <li>
+        <div>
+          <strong>Transaction sequence number:</strong>
+        </div>
+        <div> {_sequence}</div>
+      </li>
+    ) : null}
+    {isFeeBump ? (
+      <li>
+        <div>
+          <strong>Inner Transaction:</strong>
+        </div>
+      </li>
+    ) : null}
+  </TransactionList>
+);


### PR DESCRIPTION
<img width="457" alt="Screen Shot 2021-04-29 at 7 16 47 PM" src="https://user-images.githubusercontent.com/6789586/116747906-99947d00-a9cc-11eb-8b3e-2c19280bc63c.png">

(inner transaction is scrollable)