### PR TITLE
when fetching balances filter out liquidity pool shares

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -250,7 +250,7 @@ export const getAccountBalances = async ({
 
   try {
     ({ balances, subentryCount } = await dataProvider.fetchAccountDetails());
-    // let's filter out liquidity pool assets until freighter and wallet-sdk support
+    // let's filter out liquidity pool shares until freighter and wallet-sdk support
     balances = omitBy(balances, (b: any) => b.liquidity_pool_id) as Balances;
     isFunded = true;
   } catch (e) {

--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -1,3 +1,4 @@
+import omitBy from "lodash/omitBy";
 import StellarSdk from "stellar-sdk";
 import { DataProvider } from "@stellar/wallet-sdk";
 import {
@@ -249,6 +250,8 @@ export const getAccountBalances = async ({
 
   try {
     ({ balances, subentryCount } = await dataProvider.fetchAccountDetails());
+    // let's filter out liquidity pool assets until freighter and wallet-sdk support
+    balances = omitBy(balances, (b: any) => b.liquidity_pool_id) as Balances;
     isFunded = true;
   } catch (e) {
     console.error(e);


### PR DESCRIPTION
wallet-sdk doesn't filter these out, and freighter currently isn't supporting, so filter them out after retrieving using the wallet-sdk.

currently because the shares don't have a `token` field it throws a runtime error in the send flow


closes https://github.com/stellar/freighter/issues/485