### PR TITLE
use asset canonical ID for key in cache

### DIFF
--- a/@shared/api/helpers/getIconUrlFromIssuer.ts
+++ b/@shared/api/helpers/getIconUrlFromIssuer.ts
@@ -42,7 +42,7 @@ export const getIconUrlFromIssuer = async ({
   try {
     /* First, check our localStorage cache in Background to see if we've found this url before */
     ({ iconUrl } = await sendMessageToBackground({
-      assetCode: code,
+      assetCanonical: `${code}:${key}`,
       type: SERVICE_TYPES.GET_CACHED_ASSET_ICON,
     }));
     if (iconUrl) {
@@ -88,7 +88,7 @@ export const getIconUrlFromIssuer = async ({
           iconUrl = image;
           /* And also save into the cache to prevent having to do this process again */
           await sendMessageToBackground({
-            assetCode: code,
+            assetCanonical: `${code}:${key}`,
             iconUrl,
             type: SERVICE_TYPES.CACHE_ASSET_ICON,
           });

--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -322,7 +322,7 @@ export const getAssetIcons = async ({
         } = token;
         // eslint-disable-next-line no-await-in-loop
         icon = await getIconUrlFromIssuer({ key, code, networkDetails });
-        assetIcons[code] = icon;
+        assetIcons[`${code}:${key}`] = icon;
       }
     }
   }
@@ -343,7 +343,7 @@ export const retryAssetIcon = async ({
   const newAssetIcons = { ...assetIcons };
   try {
     await sendMessageToBackground({
-      assetCode: code,
+      assetCanonical: `${code}:${key}`,
       iconUrl: null,
       type: SERVICE_TYPES.CACHE_ASSET_ICON,
     });
@@ -351,7 +351,7 @@ export const retryAssetIcon = async ({
     return assetIcons;
   }
   const icon = await getIconUrlFromIssuer({ key, code, networkDetails });
-  newAssetIcons[code] = icon;
+  newAssetIcons[`${code}:${key}`] = icon;
   return newAssetIcons;
 };
 

--- a/@shared/api/types.ts
+++ b/@shared/api/types.ts
@@ -34,6 +34,7 @@ export interface Response {
   allAccounts: Array<Account>;
   accountName: string;
   assetCode: string;
+  assetCanonical: string;
   iconUrl: string;
   network: string;
   recentAddresses: Array<string>;

--- a/extension/src/background/messageListener/popupMessageListener.ts
+++ b/extension/src/background/messageListener/popupMessageListener.ts
@@ -637,24 +637,24 @@ export const popupMessageListener = (request: Request) => {
   };
 
   const getCachedAssetIcon = () => {
-    const { assetCode } = request;
+    const { assetCanonical } = request;
 
     const assetIconCache = JSON.parse(
       localStorage.getItem(CACHED_ASSET_ICONS_ID) || "{}",
     );
 
     return {
-      iconUrl: assetIconCache[assetCode] || "",
+      iconUrl: assetIconCache[assetCanonical] || "",
     };
   };
 
   const cacheAssetIcon = () => {
-    const { assetCode, iconUrl } = request;
+    const { assetCanonical, iconUrl } = request;
 
     const assetIconCache = JSON.parse(
       localStorage.getItem(CACHED_ASSET_ICONS_ID) || "{}",
     );
-    assetIconCache[assetCode] = iconUrl;
+    assetIconCache[assetCanonical] = iconUrl;
     localStorage.setItem(CACHED_ASSET_ICONS_ID, JSON.stringify(assetIconCache));
   };
 

--- a/extension/src/popup/components/account/AccountAssets/index.tsx
+++ b/extension/src/popup/components/account/AccountAssets/index.tsx
@@ -5,6 +5,7 @@ import { BigNumber } from "bignumber.js";
 import { AssetIcons } from "@shared/api/types";
 import { retryAssetIcon } from "@shared/api/internal";
 
+import { getCanonicalFromAsset } from "helpers/stellar";
 import StellarLogo from "popup/assets/stellar-logo.png";
 import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
 
@@ -21,11 +22,15 @@ export const AssetIcon = ({
   issuerKey: string;
   retryAssetIconFetch?: (arg: { key: string; code: string }) => void;
 }) =>
-  assetIcons[code] || code === "XLM" ? (
+  assetIcons[getCanonicalFromAsset(code, issuerKey)] || code === "XLM" ? (
     <img
       className="AccountAssets__asset--logo"
       alt={`${code} logo`}
-      src={code === "XLM" ? StellarLogo : assetIcons[code] || ""}
+      src={
+        code === "XLM"
+          ? StellarLogo
+          : assetIcons[getCanonicalFromAsset(code, issuerKey)] || ""
+      }
       onError={() => {
         if (retryAssetIconFetch) {
           retryAssetIconFetch({ key: issuerKey, code });
@@ -77,7 +82,10 @@ export const AccountAssets = ({
   return (
     <>
       {sortedBalances.map(({ token: { issuer, code }, total }) => (
-        <div className="AccountAssets__asset" key={code}>
+        <div
+          className="AccountAssets__asset"
+          key={`${code}:${issuer?.key || ""}`}
+        >
           <div className="AccountAssets__copy-left">
             <AssetIcon
               assetIcons={assetIcons}

--- a/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
@@ -8,8 +8,8 @@ import { ROUTES } from "popup/constants/routes";
 import { sortBalances } from "popup/helpers/account";
 import { transactionSubmissionSelector } from "popup/ducks/transactionSubmission";
 import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
-
 import { SubviewHeader } from "popup/components/SubviewHeader";
+import { getCanonicalFromAsset } from "helpers/stellar";
 
 import { Balances } from "@shared/api/types";
 
@@ -57,7 +57,7 @@ export const ChooseAsset = ({ balances, setErrorAsset }: ChooseAssetProps) => {
           collection.push({
             code,
             issuer: issuer?.key || "",
-            image: assetIcons[code],
+            image: assetIcons[getCanonicalFromAsset(code, issuer?.key)],
             domain,
           });
         }

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
@@ -143,9 +143,9 @@ export const ManageAssetRows = ({
           const isActionPending = submitStatus === ActionStatus.PENDING;
 
           return (
-            <div className="ManageAssetRows__row" key={code}>
+            <div className="ManageAssetRows__row" key={canonicalAsset}>
               <AssetIcon
-                assetIcons={code !== "XLM" ? { [code]: image } : {}}
+                assetIcons={code !== "XLM" ? { [canonicalAsset]: image } : {}}
                 code={code}
                 issuerKey={issuer}
               />

--- a/extension/src/popup/components/sendPayment/SendAmount/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/index.tsx
@@ -338,7 +338,7 @@ export const SendAmount = ({ previous }: { previous: ROUTES }) => {
             <div className="SendAmount__input-amount__asset-copy">
               {getAssetFromCanonical(formik.values.asset).code}
             </div>
-            {destinationAsset && (
+            {destinationAsset && formik.values.amount !== "0" && (
               <ConversionRate
                 loading={loadingRate}
                 source={getAssetFromCanonical(formik.values.asset).code}

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
@@ -205,7 +205,10 @@ export const TransactionDetails = ({ goBack }: { goBack: () => void }) => {
             assetIcons={assetIcons}
             sortedBalances={[
               {
-                token: { issuer: sourceAsset.issuer, code: sourceAsset.code },
+                token: {
+                  issuer: { key: sourceAsset.issuer },
+                  code: sourceAsset.code,
+                },
                 total: amount || "0",
               },
             ]}
@@ -218,7 +221,7 @@ export const TransactionDetails = ({ goBack }: { goBack: () => void }) => {
               sortedBalances={[
                 {
                   token: {
-                    issuer: destAsset.issuer,
+                    issuer: { key: destAsset.issuer },
                     code: destAsset.code,
                   },
                   total: destinationAmount || "0",

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
@@ -8,6 +8,7 @@ import { Card, Loader, Icon } from "@stellar/design-system";
 
 import {
   getAssetFromCanonical,
+  getCanonicalFromAsset,
   xlmToStroop,
   getConversionRate,
   truncatedFedAddress,
@@ -76,7 +77,9 @@ export const TransactionDetails = ({ goBack }: { goBack: () => void }) => {
         code: destAsset.code,
         networkDetails,
       });
-      setDestAssetIcons({ [destAsset.code]: iconURL });
+      setDestAssetIcons({
+        [getCanonicalFromAsset(destAsset.code, destAsset.issuer)]: iconURL,
+      });
     })();
   }, [destAsset.code, destAsset.issuer, networkDetails]);
 


### PR DESCRIPTION
**WHAT**
uses canonical ID when caching the asset image url, instead of the asset code.

**WHY**
so storing assets with same code don't conflict

also, don't show "no path found" if send amount input is 0

closes https://github.com/stellar/freighter/issues/494, https://github.com/stellar/freighter/issues/477