### PR TITLE
remove network from onboarding screens

### DIFF
--- a/extension/src/popup/components/Header/index.tsx
+++ b/extension/src/popup/components/Header/index.tsx
@@ -1,7 +1,4 @@
 import React from "react";
-import { useSelector } from "react-redux";
-
-import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
 
 import FreighterLogoLockup from "popup/assets/logo-lockup-freighter.svg";
 
@@ -11,25 +8,10 @@ interface HeaderProps {
   isPopupView?: boolean;
 }
 
-export const Header = ({ isPopupView = false }: HeaderProps) => {
-  const { isTestnet, networkName } = useSelector(
-    settingsNetworkDetailsSelector,
-  );
-  return (
-    <header className={`Header ${isPopupView ? "Header__popup" : ""}`}>
-      <div className={isPopupView ? "" : "Header__fullscreen"}>
-        <img alt="Freighter logo" src={FreighterLogoLockup} />
-        {isPopupView ? null : (
-          <div className="Header__network">
-            <div
-              className={`Header__network__icon ${
-                isTestnet ? "Header__network__icon--testnet" : ""
-              }`}
-            />
-            <div className="Header__network__name">{networkName}</div>
-          </div>
-        )}
-      </div>
-    </header>
-  );
-};
+export const Header = ({ isPopupView = false }: HeaderProps) => (
+  <header className={`Header ${isPopupView ? "Header__popup" : ""}`}>
+    <div className={isPopupView ? "" : "Header__fullscreen"}>
+      <img alt="Freighter logo" src={FreighterLogoLockup} />
+    </div>
+  </header>
+);

--- a/extension/src/popup/components/Header/styles.scss
+++ b/extension/src/popup/components/Header/styles.scss
@@ -15,31 +15,4 @@
     margin: 0 auto;
     max-width: var(--fullscreen--max-width);
   }
-
-  &__network {
-    background: var(--pal-background-secondary);
-    border-radius: 8rem;
-    align-items: center;
-    display: flex;
-    padding: 0.5rem 0.875rem;
-
-    &__icon {
-      background: var(--pal-success);
-      border-radius: 2rem;
-      height: 0.6875rem;
-      margin-right: 0.5rem;
-      position: relative;
-      width: 0.6875rem;
-
-      &--testnet {
-        background: var(--pal-warning);
-      }
-    }
-
-    &__name {
-      font-size: 0.875rem;
-      font-weight: var(--font-weight-medium);
-      text-transform: uppercase;
-    }
-  }
 }


### PR DESCRIPTION
the network doesn't matter when onboarding, and actually could add confusion when signing up (eg. https://stellarfoundation.slack.com/archives/C016CPSLVLG/p1651167470442669)

closes https://github.com/stellar/freighter/issues/521