### PR TITLE
freighterApiMessageListener: update the collectedTags array if isValidatingSafety is false

### DIFF
--- a/extension/src/background/messageListener/freighterApiMessageListener.ts
+++ b/extension/src/background/messageListener/freighterApiMessageListener.ts
@@ -115,7 +115,7 @@ export const freighterApiMessageListener = (
         accountData.forEach(
           ({ address, tags }: { address: string; tags: Array<string> }) => {
             if (address === operation.destination) {
-              const collectedTags = [...tags];
+              let collectedTags = [...tags];
 
               /* if the user has opted out of validation, remove applicable tags */
               if (!isValidatingMemo) {
@@ -124,10 +124,10 @@ export const freighterApiMessageListener = (
                 );
               }
               if (!isValidatingSafety) {
-                collectedTags.filter(
+                collectedTags = collectedTags.filter(
                   (tag) => tag !== TRANSACTION_WARNING.unsafe,
                 );
-                collectedTags.filter(
+                collectedTags = collectedTags.filter(
                   (tag) => tag !== TRANSACTION_WARNING.malicious,
                 );
               }


### PR DESCRIPTION
right now the array isn't updating, so turning isValidatingSafety to false still shows the warnings

closes https://github.com/stellar/freighter/issues/519