### PR TITLE
use toFixed instead of toString for bignumber values

### DIFF
--- a/extension/src/popup/components/account/AccountAssets/index.tsx
+++ b/extension/src/popup/components/account/AccountAssets/index.tsx
@@ -139,7 +139,7 @@ export const AccountAssets = ({
           </div>
           <div className="AccountAssets__copy-right">
             <div>
-              {new BigNumber(total).toString()} <span>{code}</span>
+              {new BigNumber(total).toFixed()} <span>{code}</span>
             </div>
           </div>
         </div>

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
@@ -86,7 +86,7 @@ export const ManageAssetRows = ({
     setAssetSubmitting(canonicalAsset);
 
     const transactionXDR = new StellarSdk.TransactionBuilder(sourceAccount, {
-      fee: xlmToStroop(recommendedFee).toString(),
+      fee: xlmToStroop(recommendedFee).toFixed(),
       networkPassphrase: networkDetails.networkPassphrase,
     })
       .addOperation(

--- a/extension/src/popup/components/sendPayment/SendAmount/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/index.tsx
@@ -123,16 +123,16 @@ export const SendAmount = ({
 
           // needed for different wallet-sdk bignumber.js version
           const currentBal = new BigNumber(
-            accountBalances.balances[selectedAsset].total.toString(),
+            accountBalances.balances[selectedAsset].total.toFixed(),
           );
           availBalance = currentBal
             .minus(new BigNumber(baseReserve))
             .minus(new BigNumber(Number(recommendedFee)))
-            .toString();
+            .toFixed();
         } else {
           availBalance = accountBalances.balances[
             selectedAsset
-          ].total.toString();
+          ].total.toFixed();
         }
       }
 

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
@@ -202,7 +202,7 @@ export const TransactionDetails = ({ goBack }: { goBack: () => void }) => {
       const transactionXDR = await new StellarSdk.TransactionBuilder(
         sourceAccount,
         {
-          fee: xlmToStroop(transactionFee).toString(),
+          fee: xlmToStroop(transactionFee).toFixed(),
           networkPassphrase: networkDetails.networkPassphrase,
         },
       )

--- a/extension/src/popup/helpers/useNetworkFees.ts
+++ b/extension/src/popup/helpers/useNetworkFees.ts
@@ -26,7 +26,7 @@ export const useNetworkFees = () => {
           max_fee: maxFee,
           ledger_capacity_usage: ledgerCapacityUsage,
         } = await server.feeStats();
-        setRecommendedFee(stroopToXlm(maxFee.mode).toString());
+        setRecommendedFee(stroopToXlm(maxFee.mode).toFixed());
         if (ledgerCapacityUsage > 0.5 && ledgerCapacityUsage <= 0.75) {
           setNetworkCongestion(NetworkCongestion.MEDIUM);
         } else if (ledgerCapacityUsage > 0.75) {


### PR DESCRIPTION
according to [bignumber docs](https://mikemcl.github.io/bignumber.js/#toS), toString may round to exponential notation for example in a large decimal (.0000001 => 1e-7), but toFixed() will always return in normal notation (.0000001 => .0000001)

so I think we should always use `toFixed()` when dealing with amounts that are used for computations to avoid unintended exponential notation bugs like[ this one](https://stellarorg.atlassian.net/browse/WAL-383?atlOrigin=eyJpIjoiOGFjMWU3MDY5NzViNGYzM2I1YjM0NzE5Y2ExNzg0MTIiLCJwIjoiaiJ9) (for UI toString is fine)