### PR TITLE
return bipPath from confirmPassword

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -244,12 +244,14 @@ export const confirmPassword = async (
   hasPrivateKey: boolean;
   applicationState: APPLICATION_STATE;
   allAccounts: Array<Account>;
+  bipPath: string;
 }> => {
   let response = {
     publicKey: "",
     hasPrivateKey: false,
     applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
     allAccounts: [] as Array<Account>,
+    bipPath: "",
   };
   try {
     response = await sendMessageToBackground({

--- a/extension/src/background/messageListener/__tests__/popupMessageListener.test.js
+++ b/extension/src/background/messageListener/__tests__/popupMessageListener.test.js
@@ -164,8 +164,10 @@ describe("adding hardware wallets", () => {
       r.type = SERVICE_TYPES.CONFIRM_PASSWORD;
       r.password = "test";
 
-      await popupMessageListener(r);
+      const resp = await popupMessageListener(r);
       expect(console.error).not.toHaveBeenCalled();
+
+      expect(resp.bipPath).toBe("44'/148'/1'");
     });
   });
   describe("LOAD_ACCOUNT", () => {

--- a/extension/src/background/messageListener/popupMessageListener.ts
+++ b/extension/src/background/messageListener/popupMessageListener.ts
@@ -632,6 +632,7 @@ export const popupMessageListener = (request: Request) => {
       hasPrivateKey: hasPrivateKeySelector(store.getState()),
       applicationState: localStorage.getItem(APPLICATION_ID) || "",
       allAccounts: allAccountsSelector(store.getState()),
+      bipPath: getBipPath(),
     };
   };
 

--- a/extension/src/popup/ducks/accountServices.ts
+++ b/extension/src/popup/ducks/accountServices.ts
@@ -212,6 +212,7 @@ export const confirmPassword = createAsyncThunk<
     hasPrivateKey: boolean;
     applicationState: APPLICATION_STATE;
     allAccounts: Array<Account>;
+    bipPath: string;
   },
   string,
   { rejectValue: ErrorMessage }
@@ -221,6 +222,7 @@ export const confirmPassword = createAsyncThunk<
     hasPrivateKey: false,
     applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
     allAccounts: [] as Array<Account>,
+    bipPath: "",
   };
   try {
     res = await confirmPasswordService(phrase);
@@ -521,11 +523,13 @@ const authSlice = createSlice({
         applicationState,
         hasPrivateKey,
         allAccounts,
+        bipPath,
       } = action.payload || {
         publicKey: "",
         hasPrivateKey: false,
         applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
         allAccounts: [""],
+        bipPath: "",
       };
       return {
         ...state,
@@ -534,6 +538,7 @@ const authSlice = createSlice({
           applicationState || APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
         publicKey,
         allAccounts,
+        bipPath,
         error: "",
       };
     });


### PR DESCRIPTION
fixes edge case where if you are using hardware wallet, log out, then log back and try to send a tx the bipPath was missing