### PR TITLE
categorize create external account ops as Sent

### DIFF
--- a/@shared/api/types.ts
+++ b/@shared/api/types.ts
@@ -71,12 +71,7 @@ export interface AssetIcons {
 export type Balances = Types.BalanceMap | null;
 
 /* eslint-disable camelcase */
-export type HorizonOperation = (
-  | Horizon.PaymentOperationResponse
-  | Horizon.PathPaymentOperationResponse
-) & {
-  transaction_attr: Horizon.TransactionResponse;
-};
+export type HorizonOperation = any;
 /* eslint-enable camelcase */
 
 export interface AccountBalancesInterface {

--- a/extension/src/popup/components/accountHistory/HistoryItem/index.tsx
+++ b/extension/src/popup/components/accountHistory/HistoryItem/index.tsx
@@ -17,6 +17,7 @@ import "./styles.scss";
 export const historyItemDetailViewProps: TransactionDetailProps = {
   operation: {} as HorizonOperation,
   headerTitle: "",
+  isCreateExternalAccount: false,
   isPayment: false,
   isRecipient: false,
   isSwap: false,
@@ -26,6 +27,7 @@ export const historyItemDetailViewProps: TransactionDetailProps = {
 };
 
 export type HistoryItemOperation = HorizonOperation & {
+  isCreateExternalAccount: boolean;
   isPayment: boolean;
   isSwap: boolean;
 };
@@ -47,14 +49,17 @@ export const HistoryItem = ({
 }: HistoryItemProps) => {
   const { t } = useTranslation();
   const {
+    account,
     amount,
     asset_code: assetCode,
     created_at: createdAt,
     id,
     to,
     from,
+    starting_balance: startingBalance,
     type,
     transaction_attr: { operation_count: operationCount },
+    isCreateExternalAccount = false,
     isPayment = false,
     isSwap = false,
   } = operation;
@@ -83,6 +88,7 @@ export const HistoryItem = ({
 
   let transactionDetailProps: TransactionDetailProps = {
     operation,
+    isCreateExternalAccount,
     isRecipient,
     isPayment,
     isSwap,
@@ -137,6 +143,22 @@ export const HistoryItem = ({
       operationText: `${paymentDifference}${new BigNumber(
         amount,
       )} ${destAssetCode}`,
+    };
+  } else if (isCreateExternalAccount) {
+    PaymentComponent = <>-{new BigNumber(startingBalance).toFixed(2, 1)} XLM</>;
+    IconComponent = <Icon.ArrowUp className="HistoryItem__icon--sent" />;
+    rowText = "XLM";
+    dateText = `${t("Sent")} \u2022 ${date}`;
+    transactionDetailProps = {
+      ...transactionDetailProps,
+      headerTitle: t("Create Account"),
+      isPayment: true,
+      operation: {
+        ...operation,
+        asset_type: "native",
+        to: account,
+      },
+      operationText: `-${new BigNumber(startingBalance)} XLM`,
     };
   } else {
     rowText = operationString;

--- a/extension/src/popup/components/accountHistory/TransactionDetail/index.tsx
+++ b/extension/src/popup/components/accountHistory/TransactionDetail/index.tsx
@@ -20,6 +20,7 @@ import "./styles.scss";
 export interface TransactionDetailProps {
   operation: HorizonOperation;
   headerTitle: string;
+  isCreateExternalAccount: boolean;
   isRecipient: boolean;
   isPayment: boolean;
   isSwap: boolean;

--- a/extension/src/popup/locales/en/translation.json
+++ b/extension/src/popup/locales/en/translation.json
@@ -84,6 +84,7 @@
   "COPY": "COPY",
   "Create a new Stellar address": "Create a new Stellar address",
   "Create a password": "Create a password",
+  "Create Account": "Create Account",
   "CREATE WALLET": "CREATE WALLET",
   "Custom": "Custom",
   "Date": "Date",

--- a/extension/src/popup/locales/pt/translation.json
+++ b/extension/src/popup/locales/pt/translation.json
@@ -84,6 +84,7 @@
   "COPY": "COPY",
   "Create a new Stellar address": "Create a new Stellar address",
   "Create a password": "Create a password",
+  "Create Account": "Create Account",
   "CREATE WALLET": "CREATE WALLET",
   "Custom": "Custom",
   "Date": "Date",

--- a/extension/src/popup/views/AccountHistory/index.tsx
+++ b/extension/src/popup/views/AccountHistory/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { Loader } from "@stellar/design-system";
+import { Horizon } from "stellar-sdk";
 
 import { getAccountHistory } from "@shared/api/internal";
 import { HorizonOperation } from "@shared/api/types";
@@ -80,13 +81,26 @@ export const AccountHistory = () => {
       operations.forEach((operation) => {
         const isPayment = getIsPayment(operation.type);
         const isSwap = getIsSwap(operation);
-        const historyOperation = { ...operation, isPayment, isSwap };
+        const isCreateExternalAccount =
+          operation.type === Horizon.OperationResponseType.createAccount &&
+          operation.account !== publicKey;
+        const historyOperation = {
+          ...operation,
+          isPayment,
+          isSwap,
+          isCreateExternalAccount,
+        };
+
         if (isPayment && !isSwap) {
           if (operation.source_account === publicKey) {
             segments[SELECTOR_OPTIONS.SENT].push(historyOperation);
           } else if (operation.to === publicKey) {
             segments[SELECTOR_OPTIONS.RECEIVED].push(historyOperation);
           }
+        }
+
+        if (isCreateExternalAccount) {
+          segments[SELECTOR_OPTIONS.SENT].push(historyOperation);
         }
 
         segments[SELECTOR_OPTIONS.ALL].push(historyOperation);


### PR DESCRIPTION
https://user-images.githubusercontent.com/6789586/183221527-541a9308-8d4a-4878-b23a-26e96f16a6e9.mov

The first op (`Create Account`) is the account being created.
The second `XLM` is me sending 5 XLM to another account to create it