### PR TITLE
Find the asset image for code and issuer combination

### DIFF
--- a/@shared/api/helpers/getIconUrlFromIssuer.ts
+++ b/@shared/api/helpers/getIconUrlFromIssuer.ts
@@ -78,12 +78,14 @@ export const getIconUrlFromIssuer = async ({
     toml.CURRENCIES.every(
       async ({
         code: currencyCode,
+        issuer,
         image,
       }: {
         code: string;
+        issuer: string;
         image: string;
       }) => {
-        if (currencyCode === code && image) {
+        if (currencyCode === code && issuer == key && image) {
           /* We found the currency listing in the toml. 3. Get the image url from it */
           iconUrl = image;
           /* And also save into the cache to prevent having to do this process again */


### PR DESCRIPTION
I hope this code is working since I was not able to build the extension...

It solves an issue when the same asset code is used multiple times in the same TOML for different assets, in this case the first asset image is returned for all assets with the same code.