### PR TITLE
use domain when available for isScamAsset calc, change hook to useIsOwnedScamAsset

### DIFF
--- a/extension/src/popup/components/account/AssetDetail/index.tsx
+++ b/extension/src/popup/components/account/AssetDetail/index.tsx
@@ -36,7 +36,7 @@ import { SlideupModal } from "popup/components/SlideupModal";
 import { SubviewHeader } from "popup/components/SubviewHeader";
 import { saveAsset } from "popup/ducks/transactionSubmission";
 import { AppDispatch } from "popup/App";
-import { useIsScamAsset } from "popup/helpers/useIsScamAsset";
+import { useIsOwnedScamAsset } from "popup/helpers/useIsOwnedScamAsset";
 
 import StellarLogo from "popup/assets/stellar-logo.png";
 
@@ -62,7 +62,7 @@ export const AssetDetail = ({
   const dispatch: AppDispatch = useDispatch();
   const isNative = selectedAsset === "native";
   const assetCode = getAssetFromCanonical(selectedAsset).code;
-  const isScamAsset = useIsScamAsset(
+  const isOwnedScamAsset = useIsOwnedScamAsset(
     assetCode,
     getAssetFromCanonical(selectedAsset).issuer,
   );
@@ -172,7 +172,7 @@ export const AssetDetail = ({
         </div>
         <SimpleBar>
           <div className="AssetDetail__scam-warning">
-            {isScamAsset && (
+            {isOwnedScamAsset && (
               <InfoBlock variant={InfoBlock.variant.error}>
                 <p>
                   This asset was tagged as fraudulent by stellar.expert, a

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
@@ -23,7 +23,6 @@ import { LoadingBackground } from "popup/basics/LoadingBackground";
 
 import { METRIC_NAMES } from "popup/constants/metricsNames";
 import { ROUTES } from "popup/constants/routes";
-import { useIsScamAsset } from "popup/helpers/useIsScamAsset";
 import {
   publicKeySelector,
   hardwareWalletTypeSelector,
@@ -362,8 +361,10 @@ export const ManageAssetRow = ({
   image,
   domain,
 }: AssetRowData) => {
+  const { blockedDomains } = useSelector(transactionSubmissionSelector);
   const canonicalAsset = getCanonicalFromAsset(code, issuer);
-  const isScamAsset = useIsScamAsset(code, issuer);
+  const isScamAsset = !!blockedDomains.domains[domain];
+
   return (
     <>
       <AssetIcon

--- a/extension/src/popup/components/manageAssets/SelectAssetRows/index.tsx
+++ b/extension/src/popup/components/manageAssets/SelectAssetRows/index.tsx
@@ -32,7 +32,6 @@ export const SelectAssetRows = ({
   const {
     accountBalances: { balances = {} },
     assetSelect,
-    assetDomains,
     blockedDomains,
   } = useSelector(transactionSubmissionSelector);
   const dispatch: AppDispatch = useDispatch();
@@ -54,62 +53,61 @@ export const SelectAssetRows = ({
     assetSelect.type === AssetSelectType.PATH_PAY &&
     assetSelect.isSource === false;
 
-    return (
-      <SimpleBar
-        className="SelectAssetRows__scrollbar"
-        style={{
-          maxHeight: `${maxHeight}px`,
-        }}
-      >
-        <div className="SelectAssetRows__content">
-          {assetRows.map(({ code, domain, image, issuer }) => {
-            const assetDomain = assetDomains[getCanonicalFromAsset(code, issuer)];
-            const isScamAsset = !!blockedDomains.domains[assetDomain];
-            
-            return (
-              <div
-                className="SelectAssetRows__row selectable"
-                key={getCanonicalFromAsset(code, issuer)}
-                onClick={() => {
-                  if (assetSelect.isSource) {
-                    dispatch(saveAsset(getCanonicalFromAsset(code, issuer)));
-                    history.goBack();
-                  } else {
-                    dispatch(
-                      saveDestinationAsset(getCanonicalFromAsset(code, issuer)),
-                    );
-                    history.goBack();
-                  }
-                }}
-              >
-                <AssetIcon
-                  assetIcons={
-                    code !== "XLM"
-                      ? { [getCanonicalFromAsset(code, issuer)]: image }
-                      : {}
-                  }
-                  code={code}
-                  issuerKey={issuer}
-                />
-                <div className="SelectAssetRows__row__info">
-                  <div className="SelectAssetRows__row__info__header">
-                    {code}
-                    <ScamAssetIcon isScamAsset={isScamAsset} />
-                  </div>
-                  <div className="SelectAssetRows__domain">
-                    {formatDomain(domain)}
-                  </div>
+  return (
+    <SimpleBar
+      className="SelectAssetRows__scrollbar"
+      style={{
+        maxHeight: `${maxHeight}px`,
+      }}
+    >
+      <div className="SelectAssetRows__content">
+        {assetRows.map(({ code, domain, image, issuer }) => {
+          const isScamAsset = !!blockedDomains.domains[domain];
+
+          return (
+            <div
+              className="SelectAssetRows__row selectable"
+              key={getCanonicalFromAsset(code, issuer)}
+              onClick={() => {
+                if (assetSelect.isSource) {
+                  dispatch(saveAsset(getCanonicalFromAsset(code, issuer)));
+                  history.goBack();
+                } else {
+                  dispatch(
+                    saveDestinationAsset(getCanonicalFromAsset(code, issuer)),
+                  );
+                  history.goBack();
+                }
+              }}
+            >
+              <AssetIcon
+                assetIcons={
+                  code !== "XLM"
+                    ? { [getCanonicalFromAsset(code, issuer)]: image }
+                    : {}
+                }
+                code={code}
+                issuerKey={issuer}
+              />
+              <div className="SelectAssetRows__row__info">
+                <div className="SelectAssetRows__row__info__header">
+                  {code}
+                  <ScamAssetIcon isScamAsset={isScamAsset} />
                 </div>
-                {!hideBalances && (
-                  <div>
-                    {getAccountBalance(getCanonicalFromAsset(code, issuer))}{" "}
-                    {code}
-                  </div>
-                )}
+                <div className="SelectAssetRows__domain">
+                  {formatDomain(domain)}
+                </div>
               </div>
-            );
-          })}
-        </div>
-      </SimpleBar>
-    );
+              {!hideBalances && (
+                <div>
+                  {getAccountBalance(getCanonicalFromAsset(code, issuer))}{" "}
+                  {code}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </SimpleBar>
+  );
 };

--- a/extension/src/popup/components/sendPayment/SendAmount/AssetSelect/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/AssetSelect/index.tsx
@@ -12,7 +12,7 @@ import {
   AssetSelectType,
 } from "popup/ducks/transactionSubmission";
 import { useIsSwap } from "popup/helpers/useIsSwap";
-import { useIsScamAsset } from "popup/helpers/useIsScamAsset";
+import { useIsOwnedScamAsset } from "popup/helpers/useIsOwnedScamAsset";
 import { ScamAssetIcon } from "popup/components/account/ScamAssetIcon";
 
 import "./styles.scss";
@@ -26,7 +26,7 @@ export function AssetSelect({
 }) {
   const dispatch = useDispatch();
   const { assetIcons } = useSelector(transactionSubmissionSelector);
-  const isScamAsset = useIsScamAsset(assetCode, issuerKey);
+  const isOwnedScamAsset = useIsOwnedScamAsset(assetCode, issuerKey);
 
   const handleSelectAsset = () => {
     dispatch(saveAssetSelectType(AssetSelectType.REGULAR));
@@ -44,7 +44,7 @@ export function AssetSelect({
             issuerKey={issuerKey}
           />
           <span className="AssetSelect__medium-copy">{assetCode}</span>
-          <ScamAssetIcon isScamAsset={isScamAsset} />
+          <ScamAssetIcon isScamAsset={isOwnedScamAsset} />
         </div>
         <div className="AssetSelect__content__right">
           <Icon.ChevronDown />
@@ -68,7 +68,7 @@ export function PathPayAssetSelect({
   const dispatch = useDispatch();
   const { assetIcons } = useSelector(transactionSubmissionSelector);
   const isSwap = useIsSwap();
-  const isScamAsset = useIsScamAsset(assetCode, issuerKey);
+  const isOwnedScamAsset = useIsOwnedScamAsset(assetCode, issuerKey);
 
   const handleSelectAsset = () => {
     dispatch(
@@ -105,7 +105,7 @@ export function PathPayAssetSelect({
           <span className="AssetSelect__medium-copy">
             {truncateLongAssetCode(assetCode)}
           </span>{" "}
-          <ScamAssetIcon isScamAsset={isScamAsset} />
+          <ScamAssetIcon isScamAsset={isOwnedScamAsset} />
           <Icon.ChevronDown />
         </div>
         <div className="AssetSelect__content__right">

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
@@ -50,6 +50,8 @@ import {
   AssetIcon,
 } from "popup/components/account/AccountAssets";
 import { LedgerSign } from "popup/components/hardwareConnect/LedgerSign";
+import { useIsOwnedScamAsset } from "popup/helpers/useIsOwnedScamAsset";
+import { ScamAssetIcon } from "popup/components/account/ScamAssetIcon";
 
 import "./styles.scss";
 
@@ -71,6 +73,12 @@ const TwoAssetCard = ({
   const sourceAsset = getAssetFromCanonical(sourceCanon);
   const destAsset = getAssetFromCanonical(destCanon);
 
+  const isSourceAssetScam = useIsOwnedScamAsset(
+    sourceAsset.code,
+    sourceAsset.issuer,
+  );
+  const isDestAssetScam = useIsOwnedScamAsset(destAsset.code, destAsset.issuer);
+
   return (
     <div className="TwoAssetCard">
       <div className="TwoAssetCard__row">
@@ -81,6 +89,7 @@ const TwoAssetCard = ({
             issuerKey={sourceAsset.issuer}
           />
           {sourceAsset.code}
+          <ScamAssetIcon isScamAsset={isSourceAssetScam} />
         </div>
         <div className="TwoAssetCard__row__right">
           {sourceAmount} {sourceAsset.code}
@@ -97,6 +106,7 @@ const TwoAssetCard = ({
             issuerKey={destAsset.issuer}
           />
           {destAsset.code}
+          <ScamAssetIcon isScamAsset={isDestAssetScam} />
         </div>
         <div className="TwoAssetCard__row__right">
           {new BigNumber(destAmount).toFixed()} {destAsset.code}

--- a/extension/src/popup/helpers/useIsOwnedScamAsset.ts
+++ b/extension/src/popup/helpers/useIsOwnedScamAsset.ts
@@ -2,7 +2,7 @@ import { useSelector } from "react-redux";
 import { getCanonicalFromAsset } from "helpers/stellar";
 import { transactionSubmissionSelector } from "popup/ducks/transactionSubmission";
 
-export const useIsScamAsset = (code: string, issuer: string) => {
+export const useIsOwnedScamAsset = (code: string, issuer: string) => {
   const { assetDomains, blockedDomains } = useSelector(
     transactionSubmissionSelector,
   );


### PR DESCRIPTION
[ticket](https://stellarorg.atlassian.net/browse/WAL-495?atlOrigin=eyJpIjoiYmFiMTkwYWU5YjdhNDk4MjhjZjEwZWQ5ZjIzMzgzYWEiLCJwIjoiaiJ9)
show the warning icon in the search results screen for a scam asset domain

<img width="365" alt="Screen Shot 2022-10-17 at 1 11 50 PM" src="https://user-images.githubusercontent.com/30449853/196262658-7c8de355-d05f-4155-bd58-db470188cf75.png">


also adds these missing icons in the send confirmation screen
<img width="359" alt="Screen Shot 2022-10-17 at 1 21 04 PM" src="https://user-images.githubusercontent.com/30449853/196262696-b5ab73b9-b938-40c6-ba9b-038eadfee979.png">
