### PR TITLE
use custom error infloblock component

### DIFF
--- a/extension/src/popup/basics/InfoBlock/index.tsx
+++ b/extension/src/popup/basics/InfoBlock/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { InfoBlock as SDSInfoBlock } from "@stellar/design-system";
+import IconWarning from "popup/assets/icon-warning-red.svg";
 
 import "./styles.scss";
 
@@ -16,9 +17,27 @@ interface InfoBlockProps extends React.InputHTMLAttributes<HTMLInputElement> {
   children: string | React.ReactNode;
 }
 
+// TODO - reconcile with SDS, for now using local triangle icon for error info blocks
+const ErrorInfoBlock = ({
+  children,
+}: {
+  children: string | React.ReactNode;
+}) => (
+  <div className="InfoBlock InfoBlock--error">
+    <div className="InfoBlock__icon">
+      <img src={IconWarning} alt="warning" />
+    </div>
+    {children}
+  </div>
+);
+
 export const InfoBlock = ({ children, className, variant }: InfoBlockProps) => (
   <div className={`BasicInfoBlock ${className}`}>
-    <SDSInfoBlock variant={variant}>{children}</SDSInfoBlock>
+    {variant === InfoBlockVariant.error ? (
+      <ErrorInfoBlock>{children}</ErrorInfoBlock>
+    ) : (
+      <SDSInfoBlock variant={variant}>{children}</SDSInfoBlock>
+    )}
   </div>
 );
 

--- a/extension/src/popup/components/WarningMessages/index.tsx
+++ b/extension/src/popup/components/WarningMessages/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { createPortal } from "react-dom";
-import { InfoBlock, Icon } from "@stellar/design-system";
+import { Icon } from "@stellar/design-system";
 import { useTranslation } from "react-i18next";
 import { POPUP_HEIGHT } from "constants/dimensions";
 import StellarSdk, { Account } from "stellar-sdk";
@@ -9,6 +9,7 @@ import StellarSdk, { Account } from "stellar-sdk";
 import { xlmToStroop, getCanonicalFromAsset } from "helpers/stellar";
 import { AppDispatch } from "popup/App";
 import { Button } from "popup/basics/buttons/Button";
+import { InfoBlock } from "popup/basics/InfoBlock";
 import {
   signFreighterTransaction,
   submitFreighterTransaction,
@@ -359,23 +360,25 @@ export const ScamAssetWarning = ({
               </InfoBlock>
             ) : (
               <InfoBlock variant={InfoBlock.variant.error}>
-                <p>
-                  {isValidatingSafeAssetsEnabled
-                    ? t(
-                        "Freighter automatically blocked this asset. Projects related to this asset may be fraudulent even if the creators say otherwise.",
-                      )
-                    : t(
-                        "Projects related to this asset may be fraudulent even if the creators say otherwise. ",
-                      )}
-                </p>
-                <p>
-                  {t("You can")}{" "}
-                  {`${
-                    isValidatingSafeAssetsEnabled ? t("disable") : t("enable")
-                  }`}{" "}
-                  {t("this alert by going to")}{" "}
-                  <strong>{t("Settings > Security")}</strong>
-                </p>
+                <div>
+                  <p>
+                    {isValidatingSafeAssetsEnabled
+                      ? t(
+                          "Freighter automatically blocked this asset. Projects related to this asset may be fraudulent even if the creators say otherwise.",
+                        )
+                      : t(
+                          "Projects related to this asset may be fraudulent even if the creators say otherwise. ",
+                        )}
+                  </p>
+                  <p>
+                    {t("You can")}{" "}
+                    {`${
+                      isValidatingSafeAssetsEnabled ? t("disable") : t("enable")
+                    }`}{" "}
+                    {t("this alert by going to")}{" "}
+                    <strong>{t("Settings > Security")}</strong>
+                  </p>
+                </div>
               </InfoBlock>
             )}
           </div>

--- a/extension/src/popup/components/account/AssetDetail/index.tsx
+++ b/extension/src/popup/components/account/AssetDetail/index.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 import { BigNumber } from "bignumber.js";
 import { useTranslation } from "react-i18next";
-import { IconButton, Icon, InfoBlock } from "@stellar/design-system";
+import { IconButton, Icon } from "@stellar/design-system";
 import SimpleBar from "simplebar-react";
 import "simplebar-react/dist/simplebar.min.css";
 
@@ -37,7 +37,7 @@ import { SubviewHeader } from "popup/components/SubviewHeader";
 import { saveAsset } from "popup/ducks/transactionSubmission";
 import { AppDispatch } from "popup/App";
 import { useIsOwnedScamAsset } from "popup/helpers/useIsOwnedScamAsset";
-
+import { InfoBlock } from "popup/basics/InfoBlock";
 import StellarLogo from "popup/assets/stellar-logo.png";
 
 import "./styles.scss";
@@ -174,15 +174,17 @@ export const AssetDetail = ({
           <div className="AssetDetail__scam-warning">
             {isOwnedScamAsset && (
               <InfoBlock variant={InfoBlock.variant.error}>
-                <p>
-                  This asset was tagged as fraudulent by stellar.expert, a
-                  reliable community-maintained directory.
-                </p>
-                <p>
-                  Trading or sending this asset is not recommended. Projects
-                  related to this asset may be fraudulent even if the creators
-                  say otherwise.
-                </p>
+                <div>
+                  <p>
+                    This asset was tagged as fraudulent by stellar.expert, a
+                    reliable community-maintained directory.
+                  </p>
+                  <p>
+                    Trading or sending this asset is not recommended. Projects
+                    related to this asset may be fraudulent even if the creators
+                    say otherwise.
+                  </p>
+                </div>
               </InfoBlock>
             )}
           </div>


### PR DESCRIPTION
[ticket](https://stellarorg.atlassian.net/browse/WAL-496?atlOrigin=eyJpIjoiNzAyNGQzYzkyZWI1NGZmNzhlY2ZhZGI1MjUxN2E5NmQiLCJwIjoiaiJ9)

[spoke with Charles](https://www.figma.com/file/BR8lyECrgUHybq7XuQSEED?node-id=4279:7754#287329950) about using the triangle icon for error info blocks throughout the app (right now they have a `!` icon). We don't want to make the change to SDS yet so doing a (slightly hacky) solution for freighter only for now

<img width="333" alt="Screen Shot 2022-10-18 at 3 52 11 PM" src="https://user-images.githubusercontent.com/30449853/196542409-a90231a3-1ea3-422a-bc08-f4979a5377a9.png">
