### PR TITLE
fix bottom padding of new asset warning modal

### DIFF
--- a/extension/src/popup/components/WarningMessages/styles.scss
+++ b/extension/src/popup/components/WarningMessages/styles.scss
@@ -186,8 +186,7 @@
     transition: bottom var(--dropdown-animation);
     border-top-right-radius: 1rem;
     border-top-left-radius: 1rem;
-    padding: var(--popup-vertical-padding) var(--account-view-padding-side) 1rem
-      var(--account-view-padding-side);
+    padding: var(--popup-vertical-padding) var(--account-view-padding-side);
   }
 
   &__header {


### PR DESCRIPTION
<img width="354" alt="Screen Shot 2022-10-26 at 2 20 59 PM" src="https://user-images.githubusercontent.com/6789586/198105549-87724395-1e52-424e-834a-1fc6631da674.png">
