### PR TITLE
return string from dataStorage always

### DIFF
--- a/extension/src/background/helpers/dataStorage.ts
+++ b/extension/src/background/helpers/dataStorage.ts
@@ -11,8 +11,12 @@ export const dataStorage = {
     // TODO: re-enable defaults by passing an object. The value of the key-value pair will be the default
 
     const storageResult = await browser.storage.local.get(key);
+    let val = storageResult[key];
+    if (val && typeof val !== "string") {
+      val = JSON.stringify(storageResult[key]);
+    }
 
-    return storageResult[key];
+    return val;
   },
   setItem: async (setItemParams: SetItemParams) => {
     await browser.storage.local.set(setItemParams);


### PR DESCRIPTION
popup is expecting strings from `localStorage` before