### PR TITLE
connecting sep24 UI to test anchor

### DIFF
--- a/extension/src/popup/Router.tsx
+++ b/extension/src/popup/Router.tsx
@@ -328,9 +328,9 @@ export const Router = () => {
         <PublicKeyRoute exact path={ROUTES.buyAsset}>
           <BuyAsset />
         </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.buyMoneyGram}>
+        <VerifiedAccountRoute path={ROUTES.buyMoneyGram}>
           <MoneyGram />
-        </PublicKeyRoute>
+        </VerifiedAccountRoute>
 
         {DEV_SERVER && (
           <>

--- a/extension/src/popup/constants/sep24.ts
+++ b/extension/src/popup/constants/sep24.ts
@@ -1,0 +1,15 @@
+export enum Sep24Status {
+  COMPLETED = "completed",
+  ERROR = "error",
+  INCOMPLETE = "incomplete",
+  PENDING_ANCHOR = "pending_anchor",
+  PENDING_CUSTOMER_INFO_UPDATE = "pending_customer_info_update",
+  PENDING_EXTERNAL = "pending_external",
+  PENDING_RECEIVER = "pending_receiver",
+  PENDING_SENDER = "pending_sender",
+  PENDING_STELLAR = "pending_stellar",
+  PENDING_TRANSACTION_INFO_UPDATE = "pending_transaction_info_update",
+  PENDING_TRUST = "pending_trust",
+  PENDING_USER = "pending_user",
+  PENDING_USER_TRANSFER_START = "pending_user_transfer_start",
+}

--- a/extension/src/popup/ducks/transactionSubmission.ts
+++ b/extension/src/popup/ducks/transactionSubmission.ts
@@ -300,6 +300,7 @@ interface HardwareWalletData {
   status: ShowOverlayStatus;
   transactionXDR: string;
   shouldSubmit: boolean;
+  lastSignedXDR: string;
 }
 
 export enum AssetSelectType {
@@ -350,6 +351,7 @@ export const initialState: InitialState = {
     status: ShowOverlayStatus.IDLE,
     transactionXDR: "",
     shouldSubmit: true,
+    lastSignedXDR: "",
   },
   accountBalances: {
     balances: null,
@@ -502,6 +504,12 @@ const transactionSubmissionSlice = createSlice({
     });
     builder.addCase(getBlockedDomains.fulfilled, (state, action) => {
       state.blockedDomains.domains = action.payload;
+    });
+    builder.addCase(signWithLedger.pending, (state) => {
+      state.hardwareWalletData.lastSignedXDR = "";
+    });
+    builder.addCase(signWithLedger.fulfilled, (state, action) => {
+      state.hardwareWalletData.lastSignedXDR = action.payload;
     });
   },
 });

--- a/extension/src/popup/locales/en/translation.json
+++ b/extension/src/popup/locales/en/translation.json
@@ -96,6 +96,7 @@
   "CONNECTION ERROR": "CONNECTION ERROR",
   "Continue": "Continue",
   "CONTINUE": "CONTINUE",
+  "Continue to MoneyGram": "Continue to MoneyGram",
   "Conversion rate": "Conversion rate",
   "Conversion rate changed": "Conversion rate changed",
   "COPY": "COPY",

--- a/extension/src/popup/locales/pt/translation.json
+++ b/extension/src/popup/locales/pt/translation.json
@@ -96,6 +96,7 @@
   "CONNECTION ERROR": "CONNECTION ERROR",
   "Continue": "Continue",
   "CONTINUE": "CONTINUE",
+  "Continue to MoneyGram": "Continue to MoneyGram",
   "Conversion rate": "Conversion rate",
   "Conversion rate changed": "Conversion rate changed",
   "COPY": "COPY",

--- a/extension/src/popup/views/BuyAsset/MoneyGram/index.tsx
+++ b/extension/src/popup/views/BuyAsset/MoneyGram/index.tsx
@@ -1,70 +1,286 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { TextLink } from "@stellar/design-system";
+import StellarSdk, { Account, StellarTomlResolver } from "stellar-sdk";
 
+import { xlmToStroop } from "helpers/stellar";
+import { emitMetric } from "helpers/metrics";
+import {
+  signFreighterTransaction,
+  submitFreighterTransaction,
+  startHwSign,
+  ShowOverlayStatus,
+  transactionSubmissionSelector,
+} from "popup/ducks/transactionSubmission";
+import { LedgerSign } from "popup/components/hardwareConnect/LedgerSign";
+import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
+import {
+  publicKeySelector,
+  hardwareWalletTypeSelector,
+} from "popup/ducks/accountServices";
+import { AppDispatch } from "popup/App";
 import { Button } from "popup/basics/buttons/Button";
 import { SubviewHeader } from "popup/components/SubviewHeader";
 import IconGreenCheck from "popup/assets/icon-green-check.svg";
 import MoneyGramLogo from "popup/assets/moneygram-logo.svg";
+import { openTab, navigateTo } from "popup/helpers/navigate";
+import { ROUTES } from "popup/constants/routes";
+import { useNetworkFees } from "popup/helpers/useNetworkFees";
+import { Sep24Status } from "popup/constants/sep24";
+import { METRIC_NAMES } from "popup/constants/metricsNames";
 
 import "./styles.scss";
 
+// TODO - only can buy using test anchor for now
+const testAnchorDomain = "testanchor.stellar.org";
+const testAnchorCode = "SRT";
+const testAnchorIssuer =
+  "GCDNJUBQSX7AJWLJACMJ7I4BC3Z47BQUTMHEICZLE6MU4KQBRYG5JY6B";
+
 export const MoneyGram = () => {
   const { t } = useTranslation();
+  const dispatch: AppDispatch = useDispatch();
+  const networkDetails = useSelector(settingsNetworkDetailsSelector);
+  const publicKey = useSelector(publicKeySelector);
+  const [isLoading, setIsLoading] = useState(false);
+  const { recommendedFee } = useNetworkFees();
+  const {
+    hardwareWalletData: { status: hwStatus, lastSignedXDR: hwSignedXDR },
+  } = useSelector(transactionSubmissionSelector);
+  const [freighterSignedXDR, setFreighterSignedXDR] = useState("");
+  const isHardwareWallet = !!useSelector(hardwareWalletTypeSelector);
+  const [sep24Url, setSep24Url] = useState("");
+  const [authEndpoint, setAuthEndpoint] = useState("");
+
+  useEffect(() => {
+    (async () => {
+      const signedXdr = freighterSignedXDR || hwSignedXDR;
+      if (signedXdr) {
+        const token = await getAuthToken(signedXdr);
+        startSep24Deposit(token);
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hwSignedXDR, freighterSignedXDR]);
+
+  const getAuthToken = async (signedXdr: string) => {
+    const authRes = await fetch(authEndpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ transaction: signedXdr }),
+    });
+    const resJson = await authRes.json();
+    return resJson.token;
+  };
+
+  const handleContinue = async () => {
+    setIsLoading(true);
+    const tomlRes = await StellarTomlResolver.resolve(testAnchorDomain);
+    setAuthEndpoint(tomlRes.WEB_AUTH_ENDPOINT);
+    const anchorSigningKey = tomlRes.SIGNING_KEY;
+    setSep24Url(tomlRes.TRANSFER_SERVER_SEP0024);
+
+    const auth = await fetch(
+      `${tomlRes.WEB_AUTH_ENDPOINT}?account=${publicKey}`,
+    );
+    const authJson = await auth.json();
+    const challengeTx = authJson.transaction;
+
+    const { tx } = StellarSdk.Utils.readChallengeTx(
+      challengeTx,
+      anchorSigningKey,
+      authJson.network_passphrase,
+      testAnchorDomain,
+      testAnchorDomain,
+    );
+    const transactionXDR = tx.toXDR();
+
+    if (isHardwareWallet) {
+      await dispatch(startHwSign({ transactionXDR, shouldSubmit: false }));
+    } else {
+      const res = await dispatch(
+        signFreighterTransaction({
+          transactionXDR,
+          network: networkDetails.networkPassphrase,
+        }),
+      );
+      if (signFreighterTransaction.fulfilled.match(res)) {
+        setFreighterSignedXDR(res.payload.signedTransaction);
+      }
+    }
+  };
+
+  const startSep24Deposit = async (token: string) => {
+    const response = await fetch(
+      `${sep24Url}/transactions/deposit/interactive`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          asset_code: "SRT",
+          account: publicKey,
+          lang: "en",
+          claimable_balance_supported: false,
+        }),
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+    const j = await response.json();
+
+    // TODO - when polling starts will have to change,
+    // since the extension closes on new tab.
+    openTab(j.url);
+    startPolling(j.id, token);
+  };
+
+  const startPolling = async (transactionId: string, token: string) => {
+    let currentStatus = Sep24Status.INCOMPLETE;
+    const endStatuses = [
+      Sep24Status.PENDING_EXTERNAL,
+      Sep24Status.COMPLETED,
+      Sep24Status.ERROR,
+    ];
+    while (!endStatuses.includes(currentStatus)) {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await fetch(`${sep24Url}/transaction?id=${transactionId}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      // eslint-disable-next-line no-await-in-loop
+      const txJson = await res.json();
+
+      if (txJson.transaction.status !== currentStatus) {
+        currentStatus = txJson.transaction.status;
+        if (currentStatus === Sep24Status.PENDING_TRUST) {
+          // eslint-disable-next-line no-await-in-loop
+          await addTrustline();
+        }
+        if (currentStatus === Sep24Status.COMPLETED) {
+          navigateTo(ROUTES.account);
+          break;
+        }
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+    }
+  };
+
+  const addTrustline = async () => {
+    const server = new StellarSdk.Server(networkDetails.networkUrl);
+    const sourceAccount: Account = await server.loadAccount(publicKey);
+    const transactionXDR = new StellarSdk.TransactionBuilder(sourceAccount, {
+      fee: xlmToStroop(recommendedFee).toFixed(),
+      networkPassphrase: networkDetails.networkPassphrase,
+    })
+      .addOperation(
+        StellarSdk.Operation.changeTrust({
+          asset: new StellarSdk.Asset(testAnchorCode, testAnchorIssuer),
+        }),
+      )
+      .setTimeout(180)
+      .build()
+      .toXDR();
+
+    const trackAddTrustline = () => {
+      emitMetric(METRIC_NAMES.manageAssetAddAsset, {
+        testAnchorCode,
+        testAnchorIssuer,
+      });
+    };
+
+    if (isHardwareWallet) {
+      await dispatch(startHwSign({ transactionXDR, shouldSubmit: true }));
+      trackAddTrustline();
+    } else {
+      const res = await dispatch(
+        signFreighterTransaction({
+          transactionXDR,
+          network: networkDetails.networkPassphrase,
+        }),
+      );
+      if (signFreighterTransaction.fulfilled.match(res)) {
+        const submitResp = await dispatch(
+          submitFreighterTransaction({
+            signedXDR: res.payload.signedTransaction,
+            networkDetails,
+          }),
+        );
+        if (submitFreighterTransaction.fulfilled.match(submitResp)) {
+          trackAddTrustline();
+        }
+      }
+    }
+  };
+
   return (
-    <div className="MoneyGram">
-      <SubviewHeader title="" />
-      <div className="MoneyGram__logo__caption">{t("Powered by")}</div>
-      <div className="MoneyGram__logo">
-        <img src={MoneyGramLogo} alt="moneygram logo" />
+    <>
+      {hwStatus === ShowOverlayStatus.IN_PROGRESS && <LedgerSign />}
+      <div className="MoneyGram">
+        <SubviewHeader title="" />
+        <div className="MoneyGram__logo__caption">{t("Powered by")}</div>
+        <div className="MoneyGram__logo">
+          <img src={MoneyGramLogo} alt="moneygram logo" />
+        </div>
+        <div className="MoneyGram__title">
+          {t("Buy with cash using MoneyGram")}
+        </div>
+        <div className="MoneyGram__bullet">
+          <div className="MoneyGram__bullet__item">
+            <img src={IconGreenCheck} alt="check" />
+          </div>
+          <div className="MoneyGram__bullet__item">
+            {t("Create an order in Freighter")}
+          </div>
+        </div>
+        <div className="MoneyGram__bullet">
+          <div className="MoneyGram__bullet__item">
+            <img src={IconGreenCheck} alt="check" />
+          </div>
+          <div className="MoneyGram__bullet__item">
+            {t("Drop-off your cash at any participating Money Gram location")}
+          </div>
+        </div>
+        <div className="MoneyGram__bullet">
+          <div className="MoneyGram__bullet__item">
+            <img src={IconGreenCheck} alt="check" />
+          </div>
+          <div className="MoneyGram__bullet__item">
+            {t("USDC arrives instantly once drop-off is complete")}
+          </div>
+        </div>
+        <div className="MoneyGram__bottom">
+          <div className="MoneyGram__bottom__terms">
+            {t("By continuing, you agree to MoneyGram’s")}
+            <TextLink
+              underline
+              variant={TextLink.variant.secondary}
+              // TODO - moneygram url
+              href=""
+              rel="noreferrer"
+              target="_blank"
+            >
+              {t("Terms and Conditions.")}
+            </TextLink>
+          </div>
+          <div className="MoneyGram__bottom__btn">
+            <Button
+              fullWidth
+              variant={Button.variant.tertiary}
+              onClick={handleContinue}
+              isLoading={isLoading}
+            >
+              {t("Continue to MoneyGram")}
+            </Button>
+          </div>
+        </div>
       </div>
-      <div className="MoneyGram__title">
-        {t("Buy with cash using MoneyGram")}
-      </div>
-      <div className="MoneyGram__bullet">
-        <div className="MoneyGram__bullet__item">
-          <img src={IconGreenCheck} alt="check" />
-        </div>
-        <div className="MoneyGram__bullet__item">
-          {t("Create an order in Freighter")}
-        </div>
-      </div>
-      <div className="MoneyGram__bullet">
-        <div className="MoneyGram__bullet__item">
-          <img src={IconGreenCheck} alt="check" />
-        </div>
-        <div className="MoneyGram__bullet__item">
-          {t("Drop-off your cash at any participating Money Gram location")}
-        </div>
-      </div>
-      <div className="MoneyGram__bullet">
-        <div className="MoneyGram__bullet__item">
-          <img src={IconGreenCheck} alt="check" />
-        </div>
-        <div className="MoneyGram__bullet__item">
-          {t("USDC arrives instantly once drop-off is complete")}
-        </div>
-      </div>
-      <div className="MoneyGram__bottom">
-        <div className="MoneyGram__bottom__terms">
-          {t("By continuing, you agree to MoneyGram’s")}
-          <TextLink
-            underline
-            variant={TextLink.variant.secondary}
-            // TODO - moneygram url
-            href=""
-            rel="noreferrer"
-            target="_blank"
-          >
-            {t("Terms and Conditions.")}
-          </TextLink>
-        </div>
-        <div className="MoneyGram__bottom__btn">
-          <Button fullWidth variant={Button.variant.tertiary}>
-            Continue to MoneyGram
-          </Button>
-        </div>
-      </div>
-    </div>
+    </>
   );
 };


### PR DESCRIPTION
[ticket](https://stellarorg.atlassian.net/browse/WAL-578?atlOrigin=eyJpIjoiZTcyZWNjYjAwZWMxNDgwZTgxMzI1NjY0NDhjMzcyNGUiLCJwIjoiaiJ9)

limitation is that where the polling happens will have to change. Right now it starts polling from the MoneyGram component, but that view closes when a new tab opens. I was thinking it should start from the `/account` view, since that's where the ["sep-24 notification" is shown](https://www.figma.com/file/BR8lyECrgUHybq7XuQSEED?node-id=4800:12150#293081588)

https://user-images.githubusercontent.com/30449853/210432776-62755a38-6c7d-4685-a932-a49f5d7de969.mov



