### PR TITLE
[WAL-233] Limit the number of chars in the amount field

### DIFF
--- a/extension/src/popup/components/sendPayment/SendAmount/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/index.tsx
@@ -42,12 +42,14 @@ import {
 } from "popup/components/sendPayment/SendTo";
 import { BottomNav } from "popup/components/BottomNav";
 import { ScamAssetWarning } from "popup/components/WarningMessages";
+import { TX_SEND_MAX } from "popup/constants/transaction";
 
 import "../styles.scss";
 
 enum AMOUNT_ERROR {
   TOO_HIGH = "amount too high",
   DEC_MAX = "too many decimal digits",
+  SEND_MAX = "amount higher than send max",
 }
 
 const ConversionRate = ({
@@ -202,6 +204,9 @@ export const SendAmount = ({
     if (val.indexOf(".") !== -1 && val.split(".")[1].length > 7) {
       return { amount: AMOUNT_ERROR.DEC_MAX };
     }
+    if (new BigNumber(val).gt(new BigNumber(TX_SEND_MAX))) {
+      return { amount: AMOUNT_ERROR.SEND_MAX };
+    }
     return {};
   };
 
@@ -303,7 +308,7 @@ export const SendAmount = ({
 
   const formatAmount = (val: string) => {
     const decimal = new Intl.NumberFormat("en-US", { style: "decimal" });
-    const maxDigits = 16;
+    const maxDigits = 12;
     const cleaned = cleanAmount(val);
     // add commas to pre decimal digits
     if (cleaned.indexOf(".") !== -1) {
@@ -340,6 +345,14 @@ export const SendAmount = ({
       return (
         <InfoBlock variant={InfoBlock.variant.error}>
           7 {t("digits after the decimal allowed")}
+        </InfoBlock>
+      );
+    }
+    if (formik.errors.amount === AMOUNT_ERROR.SEND_MAX) {
+      return (
+        <InfoBlock variant={InfoBlock.variant.error}>
+          {t("Entered amount is higher than the maximum send amount")} (
+          {formatAmount(TX_SEND_MAX)})
         </InfoBlock>
       );
     }

--- a/extension/src/popup/constants/transaction.ts
+++ b/extension/src/popup/constants/transaction.ts
@@ -1,0 +1,1 @@
+export const TX_SEND_MAX = "922337203685.4775807" as const;

--- a/extension/src/popup/locales/en/translation.json
+++ b/extension/src/popup/locales/en/translation.json
@@ -125,6 +125,7 @@
   "Enter your account password to authorize this transaction": "Enter your account password to authorize this transaction.",
   "Enter your account password to verify your account": "Enter your account password to verify your account.",
   "Enter your password": "Enter your password",
+  "Entered amount is higher than the maximum send amount": "Entered amount is higher than the maximum send amount",
   "Entered amount is higher than your balance": "Entered amount is higher than your balance",
   "Error": "Error",
   "Error code": "Error code",

--- a/extension/src/popup/locales/pt/translation.json
+++ b/extension/src/popup/locales/pt/translation.json
@@ -125,6 +125,7 @@
   "Enter your account password to authorize this transaction": "Enter your account password to authorize this transaction.",
   "Enter your account password to verify your account": "Enter your account password to verify your account.",
   "Enter your password": "Enter your password",
+  "Entered amount is higher than the maximum send amount": "Entered amount is higher than the maximum send amount",
   "Entered amount is higher than your balance": "Entered amount is higher than your balance",
   "Error": "Error",
   "Error code": "Error code",


### PR DESCRIPTION
Ticket: https://stellarorg.atlassian.net/browse/WAL-233

Adds `TX_SEND_MAX` constant and uses it to validate the max send amount and show the appropriate error message.
Lowers the `maxDigits` to 12, down from 16.