### PR TITLE
[BUG] Don't lose cursor placement after sanitization/formatting

### DIFF
--- a/extension/src/popup/helpers/formatters.ts
+++ b/extension/src/popup/helpers/formatters.ts
@@ -1,0 +1,81 @@
+// remove non digits and decimal
+export const cleanAmount = (s: string) => s.replace(/[^0-9.]/g, "");
+
+// This assumes the specific formatting being done is Intl.NumberFormat of deciaml type,
+// other formats may not work out of the box
+export const preserveCursor = (
+  val: string, // raw value from input,
+  previousVal: string, // previous state for val
+  cleanedVal: string, // string after format/sanitize
+) => {
+  const decimal = new Intl.NumberFormat("en-US", { style: "decimal" });
+  const formatted = cleanedVal.includes(",")
+    ? cleanedVal
+    : decimal.format(Number(cleanedVal)).toString();
+  const previousCommas = (previousVal.match(/,/g) || []).length;
+  const newCommas = (formatted.match(/,/g) || []).length;
+  const commaDiff = Math.abs(newCommas - previousCommas);
+  const cleanedDiff = val.includes(",") // compare formatted vals if previous val had formatting
+    ? val.length - formatted.length
+    : val.length - cleanedVal.length;
+
+  return {
+    commaDiff,
+    cleanedDiff,
+  };
+};
+
+/*
+Logic for tracking where the cursor should be after updates/clean/sanitize.
+
+Determine wether we need to sanitize digits and/or decimals.
+For digits only, compare the previous value with the newly formatted value and move the cursor according to the difference in number of commas, and difference in number of characters in the raw value vs the cleaned/sanitized(even though we filter out anything but numbers, invalid chars still move the cursor).
+If digits & decimals, do previous step on chars before the dot and also account for characters after the dot that are cleaned out but have moved the cursor.
+*/
+export const formatAmount = (
+  val: string,
+  staleVal: string,
+  cursorPosition: number = 1,
+) => {
+  const decimal = new Intl.NumberFormat("en-US", { style: "decimal" });
+  const maxDigits = 12;
+  const cleaned = cleanAmount(val);
+  // add commas to pre decimal digits
+  if (cleaned.indexOf(".") !== -1) {
+    const parts = cleaned.split(".");
+    parts[0] = decimal.format(Number(parts[0].slice(0, maxDigits))).toString();
+    parts[1] = parts[1].slice(0, 7);
+
+    // To preserve cursor -
+    // need to account for commas and filtered chars before dot
+    // and need to account for filtered chars after dot
+    const uncleanedCurrentAmount = val.split(".");
+    const previousVal = staleVal.split(".");
+
+    const { commaDiff, cleanedDiff } = preserveCursor(
+      uncleanedCurrentAmount[0],
+      previousVal[0],
+      parts[0].slice(0, maxDigits),
+    );
+
+    // after dot, need to account for filtered chars moving the cursor
+    const afterDotCleanedDiff =
+      uncleanedCurrentAmount[1].length - parts[1].length;
+    return {
+      amount: `${parts[0]}.${parts[1]}`,
+      newCursor: cursorPosition + commaDiff - cleanedDiff - afterDotCleanedDiff,
+    };
+  }
+
+  // no decimals, need to account for newly added commas and for chars lost to cleanAmount which moved the cursor
+  const { commaDiff, cleanedDiff } = preserveCursor(
+    val,
+    staleVal,
+    cleaned.slice(0, maxDigits),
+  );
+
+  return {
+    amount: decimal.format(Number(cleaned.slice(0, maxDigits))).toString(),
+    newCursor: cursorPosition + commaDiff - cleanedDiff,
+  };
+};

--- a/extension/src/popup/helpers/useRunAfterUpdate.tsx
+++ b/extension/src/popup/helpers/useRunAfterUpdate.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+// https://egghead.io/lessons/react-preserve-cursor-position-when-filtering-out-characters-from-a-react-input
+// Schedule an arbitrary fn to run after update, the closure over afterPaintRef shared between useLayoutEffect
+// and runAfterUpdate keeps them synced
+export function useRunAfterUpdate() {
+  const afterPaintRef = React.useRef<any>(null);
+  React.useLayoutEffect(() => {
+    if (afterPaintRef.current) {
+      afterPaintRef.current();
+      afterPaintRef.current = null;
+    }
+  });
+  const runAfterUpdate = (fn: () => unknown) => {
+    afterPaintRef.current = fn;
+    return null;
+  };
+  return runAfterUpdate;
+}


### PR DESCRIPTION
This is likely pretty edge case but right now, in `SendAmount`, if you happen to need to change digits that are not the last character in the amount string, when `formatAmount` runs on change the user will experience a cursor reset. This is typically opaque because almost always when you are typing the amount your cursor is already on the last character where it gets reset after updating the amount value.

Example - 

https://user-images.githubusercontent.com/6886006/213299353-8b0ae370-7dc1-4698-b0ad-d5ddc3387c6f.mov

It might be hard to tell, but when I type the decimals in first and then go to type digits, my cursor is reset after every additional `,` added by the formatter in `formatAmount`.

To avoid this, we can track the cursor location by accounting for characters that have been removed by sanitization or added by formatting in order to move the cursor the correct place.