### PR TITLE
[BUG] clears auth error on unmount of add account, fixes typo

### DIFF
--- a/extension/src/popup/components/mnemonicPhrase/ConfirmMnemonicPhrase/index.tsx
+++ b/extension/src/popup/components/mnemonicPhrase/ConfirmMnemonicPhrase/index.tsx
@@ -83,7 +83,7 @@ export const ConfirmMnemonicPhrase = ({
         </OnboardingHeader>
         <div className="ConfirmMnemonicPhrase__content">
           <p>{t("Please select each word in the same order you have")}</p>
-          <p>{t("them noted to confirm you go them right")}</p>
+          <p>{t("them noted to confirm you got them right")}</p>
         </div>
         <Formik initialValues={initialWordState} onSubmit={handleSubmit}>
           {({ dirty, isSubmitting, handleChange }) => (

--- a/extension/src/popup/locales/en/translation.json
+++ b/extension/src/popup/locales/en/translation.json
@@ -351,7 +351,7 @@
   "The website <1>{{domain}}</1> does not use an SSL certificate": {
     " For additional safety Freighter only works with websites that provide an SSL certificate": "The website <1>{{domain}}</1> does not use an SSL certificate. For additional safety Freighter only works with websites that provide an SSL certificate."
   },
-  "them noted to confirm you go them right": "them noted to confirm you go them right",
+  "them noted to confirm you got them right": "them noted to confirm you got them right",
   "this alert by going to": "this alert by going to",
   "This asset has a balance": "This asset has a balance",
   "This asset has a balance of": "This asset has a balance of",

--- a/extension/src/popup/locales/pt/translation.json
+++ b/extension/src/popup/locales/pt/translation.json
@@ -351,7 +351,7 @@
   "The website <1>{{domain}}</1> does not use an SSL certificate": {
     " For additional safety Freighter only works with websites that provide an SSL certificate": "The website <1>{{domain}}</1> does not use an SSL certificate. For additional safety Freighter only works with websites that provide an SSL certificate."
   },
-  "them noted to confirm you go them right": "them noted to confirm you go them right",
+  "them noted to confirm you got them right": "them noted to confirm you got them right",
   "this alert by going to": "this alert by going to",
   "This asset has a balance": "This asset has a balance",
   "This asset has a balance of": "This asset has a balance of",

--- a/extension/src/popup/views/AddAccount/AddAccount/index.tsx
+++ b/extension/src/popup/views/AddAccount/AddAccount/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Input } from "@stellar/design-system";
 import { Field, Form, Formik, FieldProps } from "formik";
@@ -16,7 +16,11 @@ import { PopupWrapper } from "popup/basics/PopupWrapper";
 
 import { SubviewHeader } from "popup/components/SubviewHeader";
 
-import { addAccount, authErrorSelector } from "popup/ducks/accountServices";
+import {
+  addAccount,
+  authErrorSelector,
+  clearApiError,
+} from "popup/ducks/accountServices";
 
 import "./styles.scss";
 
@@ -45,6 +49,10 @@ export const AddAccount = () => {
       navigateTo(ROUTES.account);
     }
   };
+
+  useEffect(() => () => (dispatch(clearApiError()) as unknown) as void, [
+    dispatch,
+  ]);
 
   return (
     <>


### PR DESCRIPTION
Fixes two minor things:

1. Adds an action on `accountServices` to clear the error state, then uses it on dismount of AddAccount to clear the error in the reducer.
2.  Fixes typo on mnemonic phrase confirmation.