### PR TITLE
More consistent loading on Accounts

### DIFF
--- a/extension/src/popup/ducks/transactionSubmission.ts
+++ b/extension/src/popup/ducks/transactionSubmission.ts
@@ -394,6 +394,9 @@ const transactionSubmissionSlice = createSlice({
   initialState,
   reducers: {
     resetSubmission: () => initialState,
+    resetAccountBalanceStatus: (state) => {
+      state.accountBalanceStatus = initialState.accountBalanceStatus;
+    },
     resetDestinationAmount: (state) => {
       state.transactionData.destinationAmount =
         initialState.transactionData.destinationAmount;
@@ -521,6 +524,7 @@ const transactionSubmissionSlice = createSlice({
 
 export const {
   resetSubmission,
+  resetAccountBalanceStatus,
   resetDestinationAmount,
   saveDestination,
   saveFederationAddress,

--- a/extension/src/popup/views/Account/index.tsx
+++ b/extension/src/popup/views/Account/index.tsx
@@ -23,6 +23,7 @@ import {
   getAssetDomains,
   transactionSubmissionSelector,
   resetSubmission,
+  resetAccountBalanceStatus,
   saveAssetSelectType,
   AssetSelectType,
   getBlockedDomains,
@@ -84,6 +85,10 @@ export const Account = () => {
       }),
     );
     dispatch(getBlockedDomains());
+
+    return () => {
+      dispatch(resetAccountBalanceStatus());
+    };
   }, [publicKey, networkDetails, isAccountFriendbotFunded, dispatch]);
 
   useEffect(() => {
@@ -112,10 +117,9 @@ export const Account = () => {
     fetchAccountHistory();
   }, [publicKey, networkDetails, sortedBalances]);
 
-  if (accountBalanceStatus === ActionStatus.PENDING) {
-    // waiting for account balances to load
-    return null;
-  }
+  const isLoading =
+    accountBalanceStatus === ActionStatus.PENDING ||
+    accountBalanceStatus === ActionStatus.IDLE;
 
   return selectedAsset ? (
     <AssetDetail
@@ -128,78 +132,80 @@ export const Account = () => {
     />
   ) : (
     <>
-      <div className="AccountView">
-        <AccountHeader
-          accountDropDownRef={accountDropDownRef}
-          allAccounts={allAccounts}
-          currentAccountName={currentAccountName}
-          publicKey={publicKey}
-        />
-        <div className="AccountView__account-actions">
-          <div className="AccountView__name-key-display">
-            <div className="AccountView__account-name">
-              {currentAccountName}
-            </div>
-            <CopyText
-              textToCopy={publicKey}
-              showTooltip
-              tooltipPosition={CopyText.tooltipPosition.RIGHT}
-            >
-              <div className="AccountView__account-num">
-                {truncatedPublicKey(publicKey)}
-                <Icon.Copy />
-              </div>
-            </CopyText>
-          </div>
-          <div className="AccountView__send-receive-display">
-            <div className="AccountView__send-receive-button">
-              <NavButton
-                showBorder
-                title={t("View public key")}
-                id="nav-btn-qr"
-                icon={<Icon.QrCode />}
-                onClick={() => navigateTo(ROUTES.viewPublicKey)}
-              />
-            </div>
-            <div className="AccountView__send-receive-button">
-              <NavButton
-                showBorder
-                title={t("Send Payment")}
-                id="nav-btn-send"
-                icon={<Icon.Send />}
-                onClick={() => navigateTo(ROUTES.sendPayment)}
-              />
-            </div>
-          </div>
-        </div>
-        {isFunded ? (
-          <SimpleBar className="AccountView__assets-wrapper">
-            <AccountAssets
-              sortedBalances={sortedBalances}
-              assetIcons={assetIcons}
-              setSelectedAsset={setSelectedAsset}
-            />
-          </SimpleBar>
-        ) : (
-          <NotFundedMessage
-            isTestnet={isTestnet(networkDetails)}
-            setIsAccountFriendbotFunded={setIsAccountFriendbotFunded}
+      {isLoading ? null : (
+        <div className="AccountView">
+          <AccountHeader
+            accountDropDownRef={accountDropDownRef}
+            allAccounts={allAccounts}
+            currentAccountName={currentAccountName}
             publicKey={publicKey}
           />
-        )}
-        {isFunded ? (
-          <Button
-            fullWidth
-            variant={Button.variant.tertiary}
-            onClick={() => {
-              dispatch(saveAssetSelectType(AssetSelectType.MANAGE));
-              navigateTo(ROUTES.manageAssets);
-            }}
-          >
-            {t("Manage Assets")}
-          </Button>
-        ) : null}
-      </div>
+          <div className="AccountView__account-actions">
+            <div className="AccountView__name-key-display">
+              <div className="AccountView__account-name">
+                {currentAccountName}
+              </div>
+              <CopyText
+                textToCopy={publicKey}
+                showTooltip
+                tooltipPosition={CopyText.tooltipPosition.RIGHT}
+              >
+                <div className="AccountView__account-num">
+                  {truncatedPublicKey(publicKey)}
+                  <Icon.Copy />
+                </div>
+              </CopyText>
+            </div>
+            <div className="AccountView__send-receive-display">
+              <div className="AccountView__send-receive-button">
+                <NavButton
+                  showBorder
+                  title={t("View public key")}
+                  id="nav-btn-qr"
+                  icon={<Icon.QrCode />}
+                  onClick={() => navigateTo(ROUTES.viewPublicKey)}
+                />
+              </div>
+              <div className="AccountView__send-receive-button">
+                <NavButton
+                  showBorder
+                  title={t("Send Payment")}
+                  id="nav-btn-send"
+                  icon={<Icon.Send />}
+                  onClick={() => navigateTo(ROUTES.sendPayment)}
+                />
+              </div>
+            </div>
+          </div>
+          {isFunded ? (
+            <SimpleBar className="AccountView__assets-wrapper">
+              <AccountAssets
+                sortedBalances={sortedBalances}
+                assetIcons={assetIcons}
+                setSelectedAsset={setSelectedAsset}
+              />
+            </SimpleBar>
+          ) : (
+            <NotFundedMessage
+              isTestnet={isTestnet(networkDetails)}
+              setIsAccountFriendbotFunded={setIsAccountFriendbotFunded}
+              publicKey={publicKey}
+            />
+          )}
+          {isFunded ? (
+            <Button
+              fullWidth
+              variant={Button.variant.tertiary}
+              onClick={() => {
+                dispatch(saveAssetSelectType(AssetSelectType.MANAGE));
+                navigateTo(ROUTES.manageAssets);
+              }}
+            >
+              {t("Manage Assets")}
+            </Button>
+          ) : null}
+        </div>
+      )}
       <BottomNav />
     </>
   );

--- a/extension/src/popup/views/AccountHistory/index.tsx
+++ b/extension/src/popup/views/AccountHistory/index.tsx
@@ -125,53 +125,56 @@ export const AccountHistory = () => {
     <TransactionDetail {...detailViewProps} />
   ) : (
     <div className="AccountHistory">
-      {isLoading && (
+      {isLoading ? (
         <div className="AccountHistory__loader">
           <Loader size="2rem" />
         </div>
+      ) : (
+        <div className="AccountHistory__wrapper">
+          <header className="AccountHistory__header">
+            {t("Transactions")}
+          </header>
+          <div className="AccountHistory__selector">
+            {Object.values(SELECTOR_OPTIONS).map((option) => (
+              <div
+                key={option}
+                className={`AccountHistory__selector__item ${
+                  option === selectedSegment
+                    ? "AccountHistory__selector__item--active"
+                    : ""
+                }`}
+                onClick={() => setSelectedSegment(option)}
+              >
+                {t(option)}
+              </div>
+            ))}
+          </div>
+          <div className="AccountHistory__list">
+            {historySegments?.[SELECTOR_OPTIONS[selectedSegment]].length ? (
+              <HistoryList>
+                <>
+                  {historySegments![SELECTOR_OPTIONS[selectedSegment]].map(
+                    (operation: HistoryItemOperation) => (
+                      <HistoryItem
+                        key={operation.id}
+                        operation={operation}
+                        publicKey={publicKey}
+                        url={stellarExpertUrl}
+                        setDetailViewProps={setDetailViewProps}
+                        setIsDetailViewShowing={setIsDetailViewShowing}
+                      />
+                    ),
+                  )}
+                </>
+              </HistoryList>
+            ) : (
+              <div>
+                {isAccountHistoryLoading ? null : t("No transactions to show")}
+              </div>
+            )}
+          </div>
+        </div>
       )}
-      <div className="AccountHistory__wrapper">
-        <header className="AccountHistory__header">{t("Transactions")}</header>
-        <div className="AccountHistory__selector">
-          {Object.values(SELECTOR_OPTIONS).map((option) => (
-            <div
-              key={option}
-              className={`AccountHistory__selector__item ${
-                option === selectedSegment
-                  ? "AccountHistory__selector__item--active"
-                  : ""
-              }`}
-              onClick={() => setSelectedSegment(option)}
-            >
-              {t(option)}
-            </div>
-          ))}
-        </div>
-        <div className="AccountHistory__list">
-          {historySegments?.[SELECTOR_OPTIONS[selectedSegment]].length ? (
-            <HistoryList>
-              <>
-                {historySegments[SELECTOR_OPTIONS[selectedSegment]].map(
-                  (operation: HistoryItemOperation) => (
-                    <HistoryItem
-                      key={operation.id}
-                      operation={operation}
-                      publicKey={publicKey}
-                      url={stellarExpertUrl}
-                      setDetailViewProps={setDetailViewProps}
-                      setIsDetailViewShowing={setIsDetailViewShowing}
-                    />
-                  ),
-                )}
-              </>
-            </HistoryList>
-          ) : (
-            <div>
-              {isAccountHistoryLoading ? null : t("No transactions to show")}
-            </div>
-          )}
-        </div>
-      </div>
       <BottomNav />
     </div>
   );

--- a/extension/src/popup/views/AccountHistory/styles.scss
+++ b/extension/src/popup/views/AccountHistory/styles.scss
@@ -4,7 +4,7 @@
   }
 
   &__loader {
-    height: var(--popup--height);
+    height: calc(var(--popup--height) - var(--bottom-nav--height));
     width: var(--popup--width);
     z-index: calc(var(--back--button-z-index) + 1);
     position: absolute;


### PR DESCRIPTION
Right now, If you navigate to the Account(Home) tab you might notice that there is a very quick "flash of screen".

This happens because we use the `accountBalanceStatus` to conditionally render the page body but nothing resets it after navigating away from this page so when you land on the page you are in `accountBalanceStatus.success` which does not skip the render and quickly flashes the bare screen before the effect kicks off the api call and resets the loading/data fetching cycle.

I added an action to `resetAccountBalanceStatus` and dispatch it on dismount of Account in order to avoid this.
I also tweaked the height on the loader div for SendAmount in order to expose the tabs underneath, before they were covered by the transparent bg of the loader div which prevented users from being able to nav while loading is taking place. This likely never happens but if the call took a long time for some reason or hung then the user could still nav away from the tab and do other stuff.
