### PR TITLE
check for window.freighter before attempting new api method

### DIFF
--- a/@stellar/freighter-api/package.json
+++ b/@stellar/freighter-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/freighter-api",
-  "version": "1.3.1",
+  "version": "1.4.1",
   "license": "Apache-2.0",
   "author": "Stellar Development Foundation <hello@stellar.org>",
   "description": "Utility functions to interact with Freighter extension",

--- a/@stellar/freighter-api/src/isConnected.ts
+++ b/@stellar/freighter-api/src/isConnected.ts
@@ -1,3 +1,9 @@
 import { requestConnectionStatus } from "@shared/api/external";
 
-export const isConnected = () => requestConnectionStatus();
+export const isConnected = () => {
+  if (window?.freighter) {
+    return window.freighter;
+  }
+
+  return requestConnectionStatus();
+};


### PR DESCRIPTION
This will allow dapps to upgrade well ahead of the rollout of 3.0.0 and not lose any functionality