### PR TITLE
filter soroban txs from tx log as a default

### DIFF
--- a/extension/src/popup/views/AccountHistory/index.tsx
+++ b/extension/src/popup/views/AccountHistory/index.tsx
@@ -72,13 +72,19 @@ export const AccountHistory = () => {
 
   useEffect(() => {
     setIsLoading(true);
-    const createSegments = (operations: HorizonOperation[]) => {
+    const createSegments = (
+      operations: HorizonOperation[],
+      showSorobanTxs = false,
+    ) => {
+      const _operations = showSorobanTxs
+        ? operations
+        : operations.filter((op) => op.type_i !== 24);
       const segments = {
         [SELECTOR_OPTIONS.ALL]: [] as HistoryItemOperation[],
         [SELECTOR_OPTIONS.SENT]: [] as HistoryItemOperation[],
         [SELECTOR_OPTIONS.RECEIVED]: [] as HistoryItemOperation[],
       };
-      operations.forEach((operation) => {
+      _operations.forEach((operation) => {
         const isPayment = getIsPayment(operation.type);
         const isSwap = getIsSwap(operation);
         const isCreateExternalAccount =


### PR DESCRIPTION
Since most Soroban transactions how up as `InvokeHostFunction` right now, we filter these out as a default until product can decide how to display those in a more user friendly way.