### PR TITLE
skip UnlockAccount in history stack

### DIFF
--- a/extension/src/popup/views/UnlockAccount/index.tsx
+++ b/extension/src/popup/views/UnlockAccount/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import get from "lodash/get";
 import { useDispatch, useSelector } from "react-redux";
-import { useLocation } from "react-router-dom";
+import { useLocation, useHistory } from "react-router-dom";
 import { Field, Form, Formik, FieldProps } from "formik";
 import { Input, TextLink } from "@stellar/design-system";
 import { useTranslation } from "react-i18next";
@@ -22,6 +22,7 @@ import "./styles.scss";
 export const UnlockAccount = () => {
   const { t } = useTranslation();
   const location = useLocation();
+  const history = useHistory();
   const from = get(location, "state.from.pathname", "") as ROUTES;
   const queryParams = get(location, "search", "");
   const destination = from || ROUTES.account;
@@ -39,6 +40,8 @@ export const UnlockAccount = () => {
   const handleSubmit = async (values: FormValues) => {
     const { password } = values;
     await dispatch(confirmPassword(password));
+    // skip this location in history, we won't need to come back here after unlocking account
+    history.replace(destination);
     navigateTo(destination, queryParams);
   };
 


### PR DESCRIPTION
fixes: https://stellarorg.atlassian.net/browse/WAL-399
and also came up: https://stellarfoundation.slack.com/archives/C03SJU2D5H9/p1678121113589049

if the view after UnlockAccount calls `history.goBack()` , it goes back to unlock-account causing an annoying UX for user. So instead don't add UnlockAccount to the history stack, since after leaving we won't need to go back to it


