### PR TITLE
[BUG] uses current network details to set allowHttp in SorobanClient

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11915,9 +11915,9 @@ minimatch@^3.0.2, minimatch@^3.0.5:
     brace-expansion "^1.1.7"
 
 minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 mississippi@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Issue: https://github.com/stellar/freighter/issues/746

When building the SorobanClient, we previously used the wrong value(Futurenet network details) to set `allowHttp`. This fixes the bug by setting the flag from the current network details.