### PR TITLE
[BUG] Fix paths for native stops in path payments

### DIFF
--- a/extension/src/popup/ducks/transactionSubmission.ts
+++ b/extension/src/popup/ducks/transactionSubmission.ts
@@ -502,9 +502,13 @@ const transactionSubmissionSlice = createSlice({
 
       // store in canonical form for easier use
       const path: Array<string> = [];
-      action.payload.path.forEach((p) =>
-        path.push(getCanonicalFromAsset(p.asset_code, p.asset_issuer)),
-      );
+      action.payload.path.forEach((p) => {
+        if (!p.asset_code && !p.asset_issuer) {
+          path.push(p.asset_type);
+        } else {
+          path.push(getCanonicalFromAsset(p.asset_code, p.asset_issuer));
+        }
+      });
 
       state.transactionData.path = path;
       state.transactionData.destinationAmount =


### PR DESCRIPTION
I'm not sure how this worked before, I looked back through the previous states of `getCanonicalFromAsset` and of the `getBestPath` fulfilled builder step and I haven't made sense of how this used to work. It looks to me like this would have always failed for native steps in a path payment when using the `getCanonicalFromAsset` helper to build the paths. I'm wondering if maybe the Horizon response changed?