### PR TITLE
Soroban token transfers in account history

### DIFF
--- a/extension/src/popup/components/account/AssetDetail/index.tsx
+++ b/extension/src/popup/components/account/AssetDetail/index.tsx
@@ -11,6 +11,7 @@ import { NetworkDetails } from "@shared/constants/stellar";
 import {
   getAvailableBalance,
   getIsPayment,
+  getIsSorobanTransfer,
   getIsSwap,
   getStellarExpertUrl,
   getRawBalance,
@@ -225,10 +226,17 @@ export const AssetDetail = ({
                     isPayment: getIsPayment(operation.type),
                     isSwap: getIsSwap(operation),
                   };
+
+                  const tokenBalances =
+                    balance &&
+                    "contractId" in balance &&
+                    getIsSorobanTransfer(operation, networkDetails)
+                      ? [balance]
+                      : [];
                   return (
                     <HistoryItem
                       key={operation.id}
-                      tokenBalances={[]}
+                      tokenBalances={tokenBalances}
                       operation={historyItemOperation}
                       publicKey={publicKey}
                       url={stellarExpertUrl}

--- a/extension/src/popup/components/accountHistory/HistoryItem/index.tsx
+++ b/extension/src/popup/components/accountHistory/HistoryItem/index.tsx
@@ -92,6 +92,7 @@ export const HistoryItem = ({
   let dateText = date;
   let IconComponent = <Icon.Shuffle className="HistoryItem__icon--default" />;
   let PaymentComponent = null as React.ReactElement | null;
+  // TODO should be combined with isPayment
   const isSorobanTx = typeI === 24;
 
   let transactionDetailProps: TransactionDetailProps = {
@@ -172,10 +173,10 @@ export const HistoryItem = ({
     const { transaction_attr: transactionAttrs } = operation;
     const attrs = getAttrsFromSorobanOp(operation, networkDetails);
     const token = tokenBalances.find(
-      (balance) => balance.contractId === attrs.contractId,
+      (balance) => attrs && balance.contractId === attrs.contractId,
     );
 
-    if (!token || !attrs.amount) {
+    if (!token || !attrs) {
       rowText = operationString;
       transactionDetailProps = {
         ...transactionDetailProps,

--- a/extension/src/popup/views/Account/index.tsx
+++ b/extension/src/popup/views/Account/index.tsx
@@ -150,6 +150,8 @@ export const Account = () => {
           sortOperationsByAsset({
             operations: res.operations,
             balances: sortedBalances,
+            networkDetails,
+            publicKey,
           }),
         );
       } catch (e) {

--- a/extension/src/popup/views/AccountHistory/index.tsx
+++ b/extension/src/popup/views/AccountHistory/index.tsx
@@ -126,7 +126,7 @@ export const AccountHistory = () => {
           isCreateExternalAccount,
         };
 
-        if (isPayment || (isSorobanXfer && !isSwap)) {
+        if ((isPayment || isSorobanXfer) && !isSwap) {
           if (operation.source_account === publicKey) {
             segments[SELECTOR_OPTIONS.SENT].push(historyOperation);
           } else if (operation.to === publicKey) {


### PR DESCRIPTION
Adds support for Soroban token transfers in account history, both in Asset Detail and in the Tx History views.

Notes -
Because there is no history in Horizon for when a user receives a token (the tx is added to the sender's tx history only), I don't see a way to do the history of receiving a Soroban token.

This adds support for the `xfer` fn on the token interface, but leaves an easy path for adding other fns from the interface like `mint` for example.