### PR TITLE
[BUG] Use tx source as fallback account to sign

### DIFF
--- a/extension/src/helpers/stellar.ts
+++ b/extension/src/helpers/stellar.ts
@@ -42,8 +42,10 @@ export const getTransactionInfo = (search: string) => {
     (operation: { type: string }) => operation.type,
   );
 
+  const _accountToSign = accountToSign && accountToSign.length > 0 ? accountToSign : transaction._source
+
   return {
-    accountToSign,
+    accountToSign: _accountToSign,
     transaction,
     transactionXdr,
     domain: hostname,


### PR DESCRIPTION
Ticket - https://stellarorg.atlassian.net/browse/WAL-635

`accountToSign` is an optional field, and when the "sign tx" workflow is triggered from an external API, we have no guarantee that it will be set. This adds a fallback to use the tx source account as the fallback.

