### PR TITLE
move avail balance check to native asset only

### DIFF
--- a/extension/src/popup/components/sendPayment/SendAmount/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/index.tsx
@@ -163,15 +163,15 @@ export const SendAmount = ({
           availBalance = currentBal
             .minus(minBalance)
             .minus(new BigNumber(Number(recommendedFee)));
+
+          if (availBalance.lt(minBalance)) {
+            return "0";
+          }
         } else {
           // needed for different wallet-sdk bignumber.js version
           availBalance = new BigNumber(
             accountBalances.balances[selectedAsset].total,
           );
-        }
-
-        if (availBalance.lt(minBalance)) {
-          return "0";
         }
       }
 


### PR DESCRIPTION
small bug fix from 3.0.0 QA


otherwise if an asset has a small value below the min balance it will say there's a balance of 0