### PR TITLE
Use decimals values to format/parse Soroban token values

### DIFF
--- a/extension/src/popup/components/account/AccountAssets/index.tsx
+++ b/extension/src/popup/components/account/AccountAssets/index.tsx
@@ -9,6 +9,7 @@ import { retryAssetIcon } from "@shared/api/internal";
 
 import { getCanonicalFromAsset } from "helpers/stellar";
 import { isSorobanIssuer } from "popup/helpers/account";
+import { formatTokenAmount } from "popup/helpers/soroban";
 import StellarLogo from "popup/assets/stellar-logo.png";
 import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
 import { transactionSubmissionSelector } from "popup/ducks/transactionSubmission";
@@ -211,6 +212,11 @@ export const AccountAssets = ({
         const assetDomain = assetDomains[canonicalAsset];
         const isScamAsset = !!blockedDomains.domains[assetDomain];
 
+        const bigTotal = new BigNumber(rb.total);
+        const amountVal = rb.contractId
+          ? formatTokenAmount(bigTotal, rb.decimals)
+          : bigTotal.toFixed();
+
         return (
           <div
             className={`AccountAssets__asset ${
@@ -234,7 +240,7 @@ export const AccountAssets = ({
             </div>
             <div className="AccountAssets__copy-right">
               <div>
-                {new BigNumber(rb.total).toFixed()} <span>{amountUnit}</span>
+                {amountVal} <span>{amountUnit}</span>
               </div>
             </div>
           </div>

--- a/extension/src/popup/components/account/AccountAssets/index.tsx
+++ b/extension/src/popup/components/account/AccountAssets/index.tsx
@@ -70,7 +70,7 @@ export const AssetIcon = ({
   // Placeholder for Soroban tokens
   if (_isSorobanToken) {
     return (
-      <div className="AccountAssets__asset--logo AccountAssets__asset--lp-share">
+      <div className="AccountAssets__asset--logo AccountAssets__asset--soroban-token">
         S
       </div>
     );

--- a/extension/src/popup/components/account/AccountAssets/styles.scss
+++ b/extension/src/popup/components/account/AccountAssets/styles.scss
@@ -25,7 +25,8 @@ $loader-light-color: #444961;
       }
     }
 
-    &--lp-share {
+    &--lp-share,
+    &--soroban-token {
       background: var(--pal-background-secondary);
       border-radius: 2rem;
       display: flex;

--- a/extension/src/popup/components/account/AssetDetail/index.tsx
+++ b/extension/src/popup/components/account/AssetDetail/index.tsx
@@ -18,6 +18,7 @@ import {
 } from "popup/helpers/account";
 import { useAssetDomain } from "popup/helpers/useAssetDomain";
 import { navigateTo } from "popup/helpers/navigate";
+import { formatTokenAmount } from "popup/helpers/soroban";
 import { getAssetFromCanonical } from "helpers/stellar";
 import { SimpleBarWrapper } from "popup/basics/SimpleBarWrapper";
 import { ROUTES } from "popup/constants/routes";
@@ -78,10 +79,14 @@ export const AssetDetail = ({
 
   const balance = getRawBalance(accountBalances, selectedAsset) || null;
   const assetIssuer = balance ? getIssuerFromBalance(balance) : "";
-  const balanceTotal =
-    balance && balance?.total
-      ? `${new BigNumber(balance?.total).toString()} ${canonical.code}`
-      : `0 ${canonical.code}`;
+  const total =
+    balance && "contractId" in balance
+      ? formatTokenAmount(
+          new BigNumber(balance.total || "0"),
+          Number(balance.decimals),
+        )
+      : (balance && new BigNumber(balance?.total).toString()) || "0";
+  const balanceTotal = `${total} ${canonical.code}`;
 
   const balanceAvailable = getAvailableBalance({
     accountBalances,

--- a/extension/src/popup/components/accountHistory/HistoryItem/index.tsx
+++ b/extension/src/popup/components/accountHistory/HistoryItem/index.tsx
@@ -8,7 +8,10 @@ import { OPERATION_TYPES } from "constants/transaction";
 import { METRIC_NAMES } from "popup/constants/metricsNames";
 
 import { emitMetric } from "helpers/metrics";
-import { getAttrsFromSorobanOp } from "popup/helpers/soroban";
+import {
+  formatTokenAmount,
+  getAttrsFromSorobanOp,
+} from "popup/helpers/soroban";
 
 import { HorizonOperation, TokenBalances } from "@shared/api/types";
 import { NetworkDetails } from "@shared/constants/stellar";
@@ -184,12 +187,16 @@ export const HistoryItem = ({
         operationText: operationString,
       };
     } else {
+      const formattedTokenAmount = formatTokenAmount(
+        new BigNumber(attrs.amount),
+        Number(token.decimals),
+      );
       isRecipient = transactionAttrs.source_account !== publicKey;
       paymentDifference = isRecipient ? "+" : "-";
       PaymentComponent = (
         <>
           {paymentDifference}
-          {new BigNumber(attrs.amount).toFixed(2, 1)} {token.symbol}
+          {formattedTokenAmount} {token.symbol}
         </>
       );
       IconComponent = isRecipient ? (
@@ -205,9 +212,7 @@ export const HistoryItem = ({
         headerTitle: `${isRecipient ? t("Received") : t("Sent")} ${
           token.symbol
         }`,
-        operationText: `${paymentDifference}${new BigNumber(attrs.amount)} ${
-          token.symbol
-        }`,
+        operationText: `${paymentDifference}${formattedTokenAmount} ${token.symbol}`,
       };
     }
   } else {

--- a/extension/src/popup/components/sendPayment/SendAmount/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/index.tsx
@@ -48,12 +48,30 @@ import { ScamAssetWarning } from "popup/components/WarningMessages";
 import { TX_SEND_MAX } from "popup/constants/transaction";
 
 import "../styles.scss";
+import { TokenBalances } from "@shared/api/types";
 
 enum AMOUNT_ERROR {
   TOO_HIGH = "amount too high",
   DEC_MAX = "too many decimal digits",
   SEND_MAX = "amount higher than send max",
 }
+
+const getAssetDecimals = (
+  asset: string,
+  balances: TokenBalances,
+  isToken: boolean,
+) => {
+  if (isToken) {
+    const contractId = asset.split(":")[1];
+    const balance = balances.find(({ contractId: id }) => id === contractId);
+
+    if (balance) {
+      return Number(balance.decimals);
+    }
+  }
+
+  return 7;
+};
 
 const ConversionRate = ({
   source,
@@ -350,7 +368,12 @@ export const SendAmount = ({
       return (
         <InfoBlock variant={InfoBlock.variant.error}>
           {t("Entered amount is higher than the maximum send amount")} (
-          {formatAmount(TX_SEND_MAX, formik.values.amount)})
+          {formatAmount(
+            TX_SEND_MAX,
+            formik.values.amount,
+            getAssetDecimals(asset, tokenBalances, isToken),
+          )}
+          )
         </InfoBlock>
       );
     }
@@ -433,6 +456,7 @@ export const SendAmount = ({
                     const { amount: newAmount, newCursor } = formatAmount(
                       e.target.value,
                       formik.values.amount,
+                      getAssetDecimals(asset, tokenBalances, isToken),
                       e.target.selectionStart || 1,
                     );
                     formik.setFieldValue("amount", newAmount);

--- a/extension/src/popup/ducks/soroban.ts
+++ b/extension/src/popup/ducks/soroban.ts
@@ -43,6 +43,7 @@ export const getTokenBalances = createAsyncThunk<
           },
           params,
         );
+
         const total = new BigNumber(balance) as any; // ?? why can't the BigNumber type work here
 
         results.push({

--- a/extension/src/popup/helpers/formatters.ts
+++ b/extension/src/popup/helpers/formatters.ts
@@ -1,7 +1,7 @@
 // remove non digits and decimal
 export const cleanAmount = (s: string) => s.replace(/[^0-9.]/g, "");
 
-// This assumes the specific formatting being done is Intl.NumberFormat of deciaml type,
+// This assumes the specific formatting being done is Intl.NumberFormat of decimal type,
 // other formats may not work out of the box
 export const preserveCursor = (
   val: string, // raw value from input,
@@ -35,6 +35,7 @@ If digits & decimals, do previous step on chars before the dot and also account 
 export const formatAmount = (
   val: string,
   staleVal: string,
+  decimals: number = 7,
   cursorPosition: number = 1,
 ) => {
   const decimal = new Intl.NumberFormat("en-US", { style: "decimal" });
@@ -44,7 +45,7 @@ export const formatAmount = (
   if (cleaned.indexOf(".") !== -1) {
     const parts = cleaned.split(".");
     parts[0] = decimal.format(Number(parts[0].slice(0, maxDigits))).toString();
-    parts[1] = parts[1].slice(0, 7);
+    parts[1] = parts[1].slice(0, decimals);
 
     // To preserve cursor -
     // need to account for commas and filtered chars before dot

--- a/extension/src/popup/helpers/soroban.ts
+++ b/extension/src/popup/helpers/soroban.ts
@@ -17,6 +17,7 @@ export enum SorobanTokenInterface {
   xfer = "xfer",
 }
 
+// Adopted from https://github.com/ethers-io/ethers.js/blob/master/packages/bignumber/src.ts/fixednumber.ts#L27
 // Constant to pull zeros from for multipliers
 let ZEROS = "0";
 while (ZEROS.length < 256) {
@@ -28,7 +29,13 @@ const getAmountMultiplier = (decimals: number) =>
 
 export const formatTokenAmount = (amount: BigNumber, decimals: number) => {
   const multiplier = getAmountMultiplier(decimals);
-  return amount.div(multiplier).toString();
+  let formatted = amount.div(multiplier).toFixed(decimals).toString();
+
+  // Trim trailing zeros
+  while (formatted[formatted.length - 1] === "0") {
+    formatted = formatted.substring(0, formatted.length - 1);
+  }
+  return formatted;
 };
 
 export const parseTokenAmount = (value: string, decimals: number) => {
@@ -75,7 +82,10 @@ export const getTokenBalance = (
     throw new Error("Balance not found");
   }
 
-  return balance.total.toString();
+  return formatTokenAmount(
+    new BigNumber(balance.total),
+    Number(balance.decimals),
+  );
 };
 
 export const contractIdAttrToHex = (byteArray: Buffer) =>

--- a/extension/src/popup/helpers/soroban.ts
+++ b/extension/src/popup/helpers/soroban.ts
@@ -1,11 +1,64 @@
+import BigNumber from "bignumber.js";
 import * as SorobanClient from "soroban-client";
 
 import { HorizonOperation, TokenBalances } from "@shared/api/types";
 import { NetworkDetails } from "@shared/constants/stellar";
 
+interface RootInvocation {
+  _attributes: {
+    contractId: Buffer;
+    functionName: Buffer;
+    args: SorobanClient.xdr.ScVal[];
+    subInvocations: SorobanClient.xdr.AuthorizedInvocation[];
+  };
+}
+
 export enum SorobanTokenInterface {
   xfer = "xfer",
 }
+
+// Constant to pull zeros from for multipliers
+let ZEROS = "0";
+while (ZEROS.length < 256) {
+  ZEROS += ZEROS;
+}
+
+const getAmountMultiplier = (decimals: number) => {
+  return "1" + ZEROS.substring(0, decimals);
+};
+
+export const formatTokenAmount = (amount: BigNumber, decimals: number) => {
+  const multiplier = getAmountMultiplier(decimals);
+
+  const negative = amount.lt(new BigNumber(0));
+  if (negative) {
+    amount = amount.multipliedBy(new BigNumber(-1));
+  }
+
+  let fraction = amount.mod(multiplier).toString();
+  while (fraction.length < multiplier.length - 1) {
+    fraction = "0" + fraction;
+  }
+
+  // Strip trailing 0
+  fraction = fraction.match(/^([0-9]*[1-9]|0)(0*)/)![1];
+
+  const whole = amount.div(multiplier).toString();
+
+  let value = "";
+
+  if (multiplier.length === 1) {
+    value = whole;
+  } else {
+    value = whole + "." + fraction;
+  }
+
+  if (negative) {
+    value = "-" + value;
+  }
+
+  return value;
+};
 
 export const getTokenBalance = (
   tokenBalances: TokenBalances,
@@ -38,15 +91,6 @@ export const getXferArgs = (
     amount: value,
   };
 };
-
-interface RootInvocation {
-  _attributes: {
-    contractId: Buffer;
-    functionName: Buffer;
-    args: SorobanClient.xdr.ScVal[];
-    subInvocations: SorobanClient.xdr.AuthorizedInvocation[];
-  };
-}
 
 export const getAttrsFromSorobanOp = (
   operation: HorizonOperation,


### PR DESCRIPTION
Ticket - https://stellarorg.atlassian.net/jira/software/c/projects/WAL/boards/36?modal=detail&selectedIssue=WAL-737

Before this, we assume all assets follow the classic asset path of using 7 decimals for their amount precisions.
While this will be true for all wrapped assets and may become the canonical pattern for non wrapped assets, token deployments can choose a different decimal precision for whatever reason.

This change takes into the account the token decimal interface and uses that throughout the app to format/parse values to/from human readable values.

Example - 

We have deployed Freighter Test Token with `7` decimals, which mimics the relationship between a lumen and a stroop. Without floating point representations, we can pad the values with zeros in order to represent fractional values using an i128.

So to send `1.5 FTT`, you interact with the contract using the value `150000000` for an `xfer`. When you account for the number of decimals set in the contract, you can display this value as `1.5`.

The parser does the opposite of the formatter, it takes a human readable value from the input and pads it with the appropriate amount of zeros when necessary.