### PR TITLE
Add "Has FriendBot" toggle when creating a custom network

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -585,7 +585,7 @@ export const submitFreighterSorobanTransaction = async ({
     console.error(e);
   }
 
-  const server = new SorobanClient.Server(SOROBAN_RPC_URLS.futureNet, {
+  const server = new SorobanClient.Server(SOROBAN_RPC_URLS.FUTURENET, {
     allowHttp: true,
   });
 

--- a/@shared/constants/stellar.ts
+++ b/@shared/constants/stellar.ts
@@ -3,23 +3,36 @@ import StellarSdk from "stellar-sdk";
 export enum NETWORK_NAMES {
   TESTNET = "Test Net",
   PUBNET = "Main Net",
+  FUTURENET = "Future Net",
 }
 
 export enum NETWORKS {
   PUBLIC = "PUBLIC",
   TESTNET = "TESTNET",
+  FUTURENET = "FUTURENET",
 }
 
 export enum NETWORK_URLS {
   PUBLIC = "https://horizon.stellar.org",
   TESTNET = "https://horizon-testnet.stellar.org",
+  FUTURENET = "https://horizon-futurenet.stellar.org",
 }
+
+export enum FRIENDBOT_URLS {
+  TESTNET = "https://friendbot.stellar.org",
+  FUTURENET = "https://friendbot-futurenet.stellar.org",
+}
+
+export const SOROBAN_RPC_URLS = {
+  FUTURENET: "https://rpc-futurenet.stellar.org/",
+};
 
 export interface NetworkDetails {
   network: string;
   networkName: string;
   networkUrl: string;
   networkPassphrase: string;
+  friendbotUrl?: string;
 }
 
 export const MAINNET_NETWORK_DETAILS: NetworkDetails = {
@@ -34,20 +47,18 @@ export const TESTNET_NETWORK_DETAILS: NetworkDetails = {
   networkName: NETWORK_NAMES.TESTNET,
   networkUrl: NETWORK_URLS.TESTNET,
   networkPassphrase: StellarSdk.Networks.TESTNET,
+  friendbotUrl: FRIENDBOT_URLS.TESTNET,
 };
 
 export const FUTURENET_NETWORK_DETAILS: NetworkDetails = {
-  network: "Futurenet",
-  networkName: "Future Net",
-  networkUrl: "https://horizon-futurenet.stellar.org/",
+  network: NETWORKS.FUTURENET,
+  networkName: NETWORK_NAMES.FUTURENET,
+  networkUrl: NETWORK_URLS.FUTURENET,
   networkPassphrase: "Test SDF Future Network ; October 2022",
+  friendbotUrl: FRIENDBOT_URLS.FUTURENET,
 };
 
 export const DEFAULT_NETWORKS: Array<NetworkDetails> = [
   MAINNET_NETWORK_DETAILS,
   TESTNET_NETWORK_DETAILS,
 ];
-
-export const SOROBAN_RPC_URLS = {
-  futureNet: "https://rpc-futurenet.stellar.org/",
-};

--- a/extension/src/background/helpers/account.ts
+++ b/extension/src/background/helpers/account.ts
@@ -11,7 +11,7 @@ import {
 } from "constants/localStorageTypes";
 import { DEFAULT_NETWORKS, NetworkDetails } from "@shared/constants/stellar";
 import { decodeString, encodeObject } from "helpers/urls";
-import { isMainnet, isTestnet } from "helpers/stellar";
+import { isMainnet, isTestnet, isFuturenet } from "helpers/stellar";
 import { dataStorageAccess } from "background/helpers/dataStorage";
 
 export const getKeyIdList = async () =>
@@ -50,6 +50,12 @@ export const getIsTestnet = async () => {
   const networkDetails = await getNetworkDetails();
 
   return isTestnet(networkDetails);
+};
+
+export const getIsFuturenet = async () => {
+  const networkDetails = await getNetworkDetails();
+
+  return isFuturenet(networkDetails);
 };
 
 export const getIsMemoValidationEnabled = async () =>

--- a/extension/src/background/helpers/dataStorage.ts
+++ b/extension/src/background/helpers/dataStorage.ts
@@ -1,5 +1,14 @@
 import browser from "webextension-polyfill";
 
+import { NETWORKS_LIST_ID } from "constants/localStorageTypes";
+import {
+  DEFAULT_NETWORKS,
+  NetworkDetails,
+  NETWORKS,
+  TESTNET_NETWORK_DETAILS,
+  FUTURENET_NETWORK_DETAILS,
+} from "@shared/constants/stellar";
+
 interface SetItemParams {
   [key: string]: any;
 }
@@ -29,4 +38,24 @@ export const dataStorageAccess = {
     await dataStorage.setItem({ [keyId]: value });
   },
   clear: () => dataStorage.clear(),
+};
+
+// This migration adds a friendbotUrl to testnet and futurenet network details
+export const migrateFriendBotUrlNetworkDetails = async () => {
+  const networksList: NetworkDetails[] =
+    (await dataStorageAccess.getItem(NETWORKS_LIST_ID)) || DEFAULT_NETWORKS;
+
+  const migratedNetworkList = networksList.map((network) => {
+    if (network.network === NETWORKS.TESTNET) {
+      return TESTNET_NETWORK_DETAILS;
+    }
+
+    if (network.network === FUTURENET_NETWORK_DETAILS.network) {
+      return FUTURENET_NETWORK_DETAILS;
+    }
+
+    return network;
+  });
+
+  await dataStorageAccess.setItem(NETWORKS_LIST_ID, migratedNetworkList);
 };

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -7,6 +7,7 @@ import {
 
 import { popupMessageListener } from "./messageListener/popupMessageListener";
 import { freighterApiMessageListener } from "./messageListener/freighterApiMessageListener";
+import { migrateFriendBotUrlNetworkDetails } from "./helpers/dataStorage";
 
 export const initContentScriptMessageListener = () => {
   browser?.runtime?.onMessage?.addListener((message) => {
@@ -47,4 +48,5 @@ export const initInstalledListener = () => {
       default:
     }
   });
+  browser?.runtime?.onInstalled.addListener(migrateFriendBotUrlNetworkDetails);
 };

--- a/extension/src/background/messageListener/popupMessageListener.ts
+++ b/extension/src/background/messageListener/popupMessageListener.ts
@@ -48,7 +48,6 @@ import {
   addAccountName,
   getAccountNameList,
   getKeyIdList,
-  getIsMainnet,
   getIsMemoValidationEnabled,
   getIsSafetyValidationEnabled,
   getIsValidatingSafeAssetsEnabled,
@@ -269,13 +268,11 @@ export const popupMessageListener = (request: Request) => {
   const fundAccount = async () => {
     const { publicKey } = request;
 
-    const isMainnet = await getIsMainnet();
+    const { friendbotUrl } = await getNetworkDetails();
 
-    if (!isMainnet) {
+    if (friendbotUrl) {
       try {
-        await fetch(
-          `https://friendbot.stellar.org?addr=${encodeURIComponent(publicKey)}`,
-        );
+        await fetch(`${friendbotUrl}?addr=${encodeURIComponent(publicKey)}`);
       } catch (e) {
         console.error(e);
         throw new Error("Error creating account");

--- a/extension/src/helpers/stellar.ts
+++ b/extension/src/helpers/stellar.ts
@@ -2,8 +2,12 @@ import BigNumber from "bignumber.js";
 import StellarSdk from "stellar-sdk";
 import isEqual from "lodash/isEqual";
 
-import { NETWORK_URLS, NetworkDetails } from "@shared/constants/stellar";
 import { isSorobanIssuer } from "popup/helpers/account";
+import {
+  FUTURENET_NETWORK_DETAILS,
+  NETWORK_URLS,
+  NetworkDetails,
+} from "@shared/constants/stellar";
 
 import { parsedSearchParam, getUrlHostname } from "./urls";
 
@@ -134,6 +138,15 @@ export const isTestnet = (networkDetails: NetworkDetails) => {
   return (
     networkPassphrase === StellarSdk.Networks.TESTNET &&
     networkUrl === NETWORK_URLS.TESTNET
+  );
+};
+
+export const isFuturenet = (networkDetails: NetworkDetails) => {
+  const { networkPassphrase, networkUrl } = networkDetails;
+
+  return (
+    networkPassphrase === FUTURENET_NETWORK_DETAILS.networkPassphrase &&
+    networkUrl === NETWORK_URLS.FUTURENET
   );
 };
 

--- a/extension/src/popup/SorobanContext.tsx
+++ b/extension/src/popup/SorobanContext.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { useSelector } from "react-redux";
 import * as SorobanClient from "soroban-client";
 
-import { SOROBAN_RPC_URLS } from "@shared/constants/stellar";
+import {
+  SOROBAN_RPC_URLS,
+  FUTURENET_NETWORK_DETAILS,
+} from "@shared/constants/stellar";
 
 import { settingsNetworkDetailsSelector } from "./ducks/settings";
 
@@ -29,8 +32,8 @@ export const SorobanProvider = ({
   const serverUrl =
     networkDetails.networkPassphrase ===
       "Test SDF Future Network ; October 2022" &&
-    networkDetails.networkUrl === "https://horizon-futurenet.stellar.org/"
-      ? SOROBAN_RPC_URLS.futureNet
+    networkDetails.networkUrl === FUTURENET_NETWORK_DETAILS.networkUrl
+      ? SOROBAN_RPC_URLS.FUTURENET
       : networkDetails.networkUrl;
 
   const server = new SorobanClient.Server(serverUrl, {

--- a/extension/src/popup/components/account/NotFundedMessage/index.tsx
+++ b/extension/src/popup/components/account/NotFundedMessage/index.tsx
@@ -10,11 +10,11 @@ import { fundAccount } from "popup/ducks/accountServices";
 import "./styles.scss";
 
 export const NotFundedMessage = ({
-  isTestnet,
+  canUseFriendbot,
   publicKey,
   setIsAccountFriendbotFunded,
 }: {
-  isTestnet: boolean;
+  canUseFriendbot: boolean;
   publicKey: string;
   setIsAccountFriendbotFunded: (isAccountFriendbotFunded: boolean) => void;
 }) => {
@@ -35,10 +35,10 @@ export const NotFundedMessage = ({
         </div>
         <div className="NotFunded__copy">
           {t("To create this account, fund it with a minimum of 1 XLM.")}
-          {isTestnet ? (
+          {canUseFriendbot ? (
             <span>
               {t(
-                "You can fund this account on the test network using the friendbot tool. The friendbot is a horizon API endpoint that will fund an account with 10,000 lumens on the test network.",
+                "You can fund this account using the friendbot tool. The friendbot is a horizon API endpoint that will fund an account with 10,000 lumens.",
               )}
             </span>
           ) : null}{" "}
@@ -51,7 +51,7 @@ export const NotFundedMessage = ({
           </a>
         </div>
       </div>
-      {isTestnet ? (
+      {canUseFriendbot ? (
         <Formik initialValues={{}} onSubmit={handleFundAccount}>
           {({ isSubmitting }) => (
             <Form className="NotFunded__form">

--- a/extension/src/popup/components/manageNetwork/NetworkForm/index.tsx
+++ b/extension/src/popup/components/manageNetwork/NetworkForm/index.tsx
@@ -39,6 +39,7 @@ interface FormValues {
   networkUrl: string;
   isSwitchSelected?: boolean;
   isAllowHttpSelected: boolean;
+  friendbotUrl?: string;
 }
 
 interface NetworkFormProps {
@@ -76,12 +77,15 @@ export const NetworkForm = ({ isEditing }: NetworkFormProps) => {
     ? {
         ...networkDetailsToEdit,
         isSwitchSelected: false,
-        isAllowHttpSelected: !networkDetailsToEdit.networkUrl.includes("https"),
+        isAllowHttpSelected: !networkDetailsToEdit?.networkUrl.includes(
+          "https",
+        ),
       }
     : {
         networkName: "",
         networkPassphrase: "",
         networkUrl: "",
+        friendbotUrl: "",
         isSwitchSelected: false,
         isAllowHttpSelected: false,
       };
@@ -110,9 +114,10 @@ export const NetworkForm = ({ isEditing }: NetworkFormProps) => {
   };
 
   const getCustomNetworkDetailsFromFormValues = (values: FormValues) => {
-    const { networkName, networkUrl, networkPassphrase } = values;
+    const { friendbotUrl, networkName, networkUrl, networkPassphrase } = values;
 
     return {
+      friendbotUrl,
       network: CUSTOM_NETWORK,
       networkName,
       networkUrl,
@@ -349,6 +354,20 @@ export const NetworkForm = ({ isEditing }: NetworkFormProps) => {
                 label={t("Passphrase")}
                 name="networkPassphrase"
                 placeholder={t("Enter passphrase")}
+              />
+              <Input
+                disabled={isEditingDefaultNetworks}
+                id="friendbotUrl"
+                autoComplete="off"
+                error={
+                  errors.friendbotUrl && touched.friendbotUrl
+                    ? errors.friendbotUrl
+                    : ""
+                }
+                customInput={<Field />}
+                label={t("Friendbot URL")}
+                name="friendbotUrl"
+                placeholder={t("Enter Friendbot URL")}
               />
               {!isEditingDefaultNetworks ? (
                 <Field name="isAllowHttpSelected">

--- a/extension/src/popup/locales/en/translation.json
+++ b/extension/src/popup/locales/en/translation.json
@@ -120,6 +120,7 @@
   },
   "enable": "enable",
   "Enable experimental mode": "Enable experimental mode",
+  "Enter Friendbot URL": "Enter Friendbot URL",
   "Enter network name": "Enter network name",
   "Enter network URL": "Enter network URL",
   "Enter passphrase": "Enter passphrase",
@@ -161,6 +162,7 @@
   "Freighter will use experimental API‘s and connect to the Futurenet, a test network": {
     " Please proceed at your own risk as you may be interacting with schemas that are untested and still changing": "Freighter will use experimental API‘s and connect to the Futurenet, a test network. Please proceed at your own risk as you may be interacting with schemas that are untested and still changing."
   },
+  "Friendbot URL": "Friendbot URL",
   "From": "From",
   "Function": "Function",
   "Fund with Friendbot": "Fund with Friendbot",
@@ -408,8 +410,8 @@
     " Proceed at your own risk": "You are interacting with a transaction that may be using untested and changing schemas. Proceed at your own risk."
   },
   "You can": "You can",
-  "You can fund this account on the test network using the friendbot tool": {
-    " The friendbot is a horizon API endpoint that will fund an account with 10,000 lumens on the test network": "You can fund this account on the test network using the friendbot tool. The friendbot is a horizon API endpoint that will fund an account with 10,000 lumens on the test network."
+  "You can fund this account using the friendbot tool": {
+    " The friendbot is a horizon API endpoint that will fund an account with 10,000 lumens": "You can fund this account using the friendbot tool. The friendbot is a horizon API endpoint that will fund an account with 10,000 lumens."
   },
   "You must have a balance of": "You must have a balance of",
   "You successfully imported your account": {

--- a/extension/src/popup/locales/pt/translation.json
+++ b/extension/src/popup/locales/pt/translation.json
@@ -120,6 +120,7 @@
   },
   "enable": "enable",
   "Enable experimental mode": "Enable experimental mode",
+  "Enter Friendbot URL": "Enter Friendbot URL",
   "Enter network name": "Enter network name",
   "Enter network URL": "Enter network URL",
   "Enter passphrase": "Enter passphrase",
@@ -161,6 +162,7 @@
   "Freighter will use experimental API‘s and connect to the Futurenet, a test network": {
     " Please proceed at your own risk as you may be interacting with schemas that are untested and still changing": "Freighter will use experimental API‘s and connect to the Futurenet, a test network. Please proceed at your own risk as you may be interacting with schemas that are untested and still changing."
   },
+  "Friendbot URL": "Friendbot URL",
   "From": "From",
   "Function": "Function",
   "Fund with Friendbot": "Fund with Friendbot",
@@ -408,8 +410,8 @@
     " Proceed at your own risk": "You are interacting with a transaction that may be using untested and changing schemas. Proceed at your own risk."
   },
   "You can": "You can",
-  "You can fund this account on the test network using the friendbot tool": {
-    " The friendbot is a horizon API endpoint that will fund an account with 10,000 lumens on the test network": "You can fund this account on the test network using the friendbot tool. The friendbot is a horizon API endpoint that will fund an account with 10,000 lumens on the test network."
+  "You can fund this account using the friendbot tool": {
+    " The friendbot is a horizon API endpoint that will fund an account with 10,000 lumens": "You can fund this account using the friendbot tool. The friendbot is a horizon API endpoint that will fund an account with 10,000 lumens."
   },
   "You must have a balance of": "You must have a balance of",
   "You successfully imported your account": {

--- a/extension/src/popup/views/Account/index.tsx
+++ b/extension/src/popup/views/Account/index.tsx
@@ -43,7 +43,7 @@ import {
   sortBalances,
   sortOperationsByAsset,
 } from "popup/helpers/account";
-import { isTestnet, truncatedPublicKey } from "helpers/stellar";
+import { truncatedPublicKey } from "helpers/stellar";
 import { navigateTo } from "popup/helpers/navigate";
 import { AccountAssets } from "popup/components/account/AccountAssets";
 import { AccountHeader } from "popup/components/account/AccountHeader";
@@ -230,7 +230,7 @@ export const Account = () => {
             </SimpleBarWrapper>
           ) : (
             <NotFundedMessage
-              isTestnet={isTestnet(networkDetails)}
+              canUseFriendbot={!!networkDetails.friendbotUrl}
               setIsAccountFriendbotFunded={setIsAccountFriendbotFunded}
               publicKey={publicKey}
             />


### PR DESCRIPTION
[Link to ticket.](https://stellarorg.atlassian.net/jira/software/c/projects/WAL/boards/36?modal=detail&selectedIssue=WAL-484)

Right now, only testnet is enabled to use the "Fund with Friendbot" button even though there is also a Futurenet friendbot instance and custom networks can also set up a Friendbot endpoint.

This adds a `friendbotUrl` input field on the "Add a custom network" form and updates network details to have an optional `friendbotUrl` field.
It then allows any network with a `friendbotUrl` to use the "Fund with Friendbot" flow.
It migrates the storage values for testnet/futurenet to include their `friendbotUrl` to support these changes on existing accounts.