### PR TITLE
[BUG] Account Details can overflow DOM

### DIFF
--- a/extension/public/static/manifest.json
+++ b/extension/public/static/manifest.json
@@ -3,12 +3,6 @@
   "version": "4.0.0",
   "version_name": "4.0.0",
   "description": "Freighter is a non-custodial wallet extension that enables you to sign Stellar transactions via your browser.",
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "{3ee0dd4e-8c64-4b92-b539-25718a10f62f}",
-      "strict_min_version": "48.0"
-    }
-  },
   "background": {
     "service_worker": "background.min.js"
   },

--- a/extension/src/background/messageListener/popupMessageListener.ts
+++ b/extension/src/background/messageListener/popupMessageListener.ts
@@ -1089,7 +1089,7 @@ export const popupMessageListener = (request: Request) => {
     if (typeof assetDomainCache === "string") {
       assetDomainCache = JSON.parse(assetDomainCache);
     }
-
+    
     assetDomainCache[assetCanonical] = assetDomain;
     await dataStorageAccess.setItem(CACHED_ASSET_DOMAINS_ID, assetDomainCache);
   };

--- a/extension/src/popup/components/account/AccountAssets/index.tsx
+++ b/extension/src/popup/components/account/AccountAssets/index.tsx
@@ -235,7 +235,7 @@ export const AccountAssets = ({
                 retryAssetIconFetch={retryAssetIconFetch}
                 isLPShare={!!rb.liquidityPoolId}
               />
-              <span>{code}</span>
+              <span className="asset-code">{code}</span>
               <ScamAssetIcon isScamAsset={isScamAsset} />
             </div>
             <div className="AccountAssets__copy-right">

--- a/extension/src/popup/components/account/AccountAssets/styles.scss
+++ b/extension/src/popup/components/account/AccountAssets/styles.scss
@@ -4,7 +4,6 @@ $loader-light-color: #444961;
 .AccountAssets {
   &__asset {
     align-items: center;
-    justify-content: space-between;
     display: flex;
     color: var(--pal-text-primary);
     font-size: 1rem;
@@ -16,8 +15,8 @@ $loader-light-color: #444961;
 
     &--logo {
       margin-right: 1rem;
-      width: 2rem;
-      height: 2rem;
+      max-width: 2rem;
+      max-height: 2rem;
 
       img {
         width: 100%;
@@ -78,12 +77,31 @@ $loader-light-color: #444961;
   }
 
   &__copy-left {
+    flex: 5;
+    min-width: 0;
     align-items: center;
     display: flex;
     font-weight: var(--font-weight-medium);
+
+    .asset-code {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      min-width: 0;
+    }
   }
 
   &__copy-right {
+    flex: 4;
+    min-width: 0;
     font-weight: var(--font-weight-normal);
+
+    .asset-amount {
+      text-align: right;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      min-width: 0;
+    }
   }
 }


### PR DESCRIPTION
[Link to ticket](https://stellarorg.atlassian.net/jira/software/c/projects/WAL/boards/36?modal=detail&selectedIssue=WAL-700)
[Link to issue](https://github.com/stellar/freighter/issues/642)

This issue is most apparent outside of the typical classic asset flow, where asset codes can be longer strings and where asset decimal precision takes up more DOM space.
The Github issue highlights an instance of this when viewing an NFT asset on classic, NFT asset codes tend to be longer than your typical 3/4 letter classic asset code.
This also comes up more often in Soroban, where asset codes have no constraints, and where decimals are not set to 7 necessarily.

I changed the AssetDetail rows to now take up a defined horizontal space, while showing an ellipsis instead of overflowing when needed.

![Screenshot 2023-04-17 at 11 33 32 AM](https://user-images.githubusercontent.com/6886006/232567021-5a646381-0e05-4cb1-9d21-94d2b7e0b81c.png)
