### PR TITLE
Session storage for background redux store with feature flag

### DIFF
--- a/extension/public/background.ts
+++ b/extension/public/background.ts
@@ -2,9 +2,17 @@ import {
   initContentScriptMessageListener,
   initExtensionMessageListener,
   initInstalledListener,
+  initAlarmListener,
 } from "background";
 
-initContentScriptMessageListener();
-initExtensionMessageListener();
+import { buildStore } from "background/store";
 
-initInstalledListener();
+async function main() {
+  const store = await buildStore();
+  initContentScriptMessageListener();
+  initExtensionMessageListener(store);
+  initInstalledListener();
+  initAlarmListener(store);
+}
+
+main();

--- a/extension/public/static/manifest/v2.json
+++ b/extension/public/static/manifest/v2.json
@@ -1,0 +1,40 @@
+{
+  "name": "Freighter",
+  "version": "4.0.0",
+  "version_name": "4.0.0",
+  "description": "Freighter is a non-custodial wallet extension that enables you to sign Stellar transactions via your browser.",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{3ee0dd4e-8c64-4b92-b539-25718a10f62f}",
+      "strict_min_version": "48.0"
+    }
+  },
+  "background": {
+    "scripts": ["background.min.js"],
+    "persistent": true
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["contentScript.min.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "browser_action": {
+    "default_popup": "index.html",
+    "default_icon": {
+      "16": "images/icon16.png",
+      "32": "images/icon32.png",
+      "48": "images/icon48.png",
+      "128": "images/icon128.png"
+    }
+  },
+  "icons": {
+    "16": "images/icon16.png",
+    "32": "images/icon32.png",
+    "48": "images/icon48.png",
+    "128": "images/icon128.png"
+  },
+  "permissions": ["storage", "alarms"],
+  "manifest_version": 2
+}

--- a/extension/public/static/manifest/v3.json
+++ b/extension/public/static/manifest/v3.json
@@ -28,6 +28,6 @@
     "48": "images/icon48.png",
     "128": "images/icon128.png"
   },
-  "permissions": ["storage"],
+  "permissions": ["storage", "alarms"],
   "manifest_version": 3
 }

--- a/extension/src/background/helpers/account.ts
+++ b/extension/src/background/helpers/account.ts
@@ -12,14 +12,19 @@ import {
 import { DEFAULT_NETWORKS, NetworkDetails } from "@shared/constants/stellar";
 import { decodeString, encodeObject } from "helpers/urls";
 import { isMainnet, isTestnet, isFuturenet } from "helpers/stellar";
-import { dataStorageAccess } from "background/helpers/dataStorage";
+import {
+  dataStorageAccess,
+  localStorage,
+} from "background/helpers/dataStorage";
+
+const localStore = dataStorageAccess(localStorage);
 
 export const getKeyIdList = async () =>
-  (await dataStorageAccess.getItem(KEY_ID_LIST)) || [];
+  (await localStore.getItem(KEY_ID_LIST)) || [];
 
 export const getAccountNameList = async () => {
   const encodedaccountNameList =
-    (await dataStorageAccess.getItem(ACCOUNT_NAME_LIST_ID)) || encodeObject({});
+    (await localStore.getItem(ACCOUNT_NAME_LIST_ID)) || encodeObject({});
 
   return JSON.parse(decodeString(encodedaccountNameList));
 };
@@ -37,7 +42,7 @@ export const addAccountName = async ({
 
   const encodedaccountNameList = encodeObject(accountNameList);
 
-  await dataStorageAccess.setItem(ACCOUNT_NAME_LIST_ID, encodedaccountNameList);
+  await localStore.setItem(ACCOUNT_NAME_LIST_ID, encodedaccountNameList);
 };
 
 export const getIsMainnet = async () => {
@@ -59,50 +64,50 @@ export const getIsFuturenet = async () => {
 };
 
 export const getIsMemoValidationEnabled = async () =>
-  (await dataStorageAccess.getItem(IS_VALIDATING_MEMO_ID)) || true;
+  (await localStore.getItem(IS_VALIDATING_MEMO_ID)) || true;
 
 export const getIsSafetyValidationEnabled = async () =>
-  (await dataStorageAccess.getItem(IS_VALIDATING_SAFETY_ID)) || true;
+  (await localStore.getItem(IS_VALIDATING_SAFETY_ID)) || true;
 
 export const getIsValidatingSafeAssetsEnabled = async () =>
-  (await dataStorageAccess.getItem(IS_VALIDATING_SAFE_ASSETS_ID)) || true;
+  (await localStore.getItem(IS_VALIDATING_SAFE_ASSETS_ID)) || true;
 
 export const getIsExperimentalModeEnabled = async () =>
-  (await dataStorageAccess.getItem(IS_EXPERIMENTAL_MODE_ID)) || false;
+  (await localStore.getItem(IS_EXPERIMENTAL_MODE_ID)) || false;
 
 // hardware wallet helpers
 export const HW_PREFIX = "hw:";
 
 export const getIsHardwareWalletActive = async () =>
-  ((await dataStorageAccess.getItem(KEY_ID)) || "").indexOf(HW_PREFIX) > -1;
+  ((await localStore.getItem(KEY_ID)) || "").indexOf(HW_PREFIX) > -1;
 
 export const getBipPath = async () => {
-  const keyId = (await dataStorageAccess.getItem(KEY_ID)) || "";
-  const hwData = (await dataStorageAccess.getItem(keyId)) || {};
+  const keyId = (await localStore.getItem(KEY_ID)) || "";
+  const hwData = (await localStore.getItem(keyId)) || {};
   return hwData.bipPath || "";
 };
 
 export const getSavedNetworks = async (): Promise<NetworkDetails[]> =>
-  (await dataStorageAccess.getItem(NETWORKS_LIST_ID)) || DEFAULT_NETWORKS;
+  (await localStore.getItem(NETWORKS_LIST_ID)) || DEFAULT_NETWORKS;
 
 export const getNetworkDetails = async () => {
-  if (!(await dataStorageAccess.getItem(NETWORK_ID))) {
-    await dataStorageAccess.setItem(NETWORK_ID, DEFAULT_NETWORKS[0]);
+  if (!(await localStore.getItem(NETWORK_ID))) {
+    await localStore.setItem(NETWORK_ID, DEFAULT_NETWORKS[0]);
   }
 
   const networkDetails =
-    (await dataStorageAccess.getItem(NETWORK_ID)) || DEFAULT_NETWORKS[0];
+    (await localStore.getItem(NETWORK_ID)) || DEFAULT_NETWORKS[0];
 
   return networkDetails;
 };
 
 export const getNetworksList = async () => {
-  if (!(await dataStorageAccess.getItem(NETWORKS_LIST_ID))) {
-    await dataStorageAccess.setItem(NETWORKS_LIST_ID, DEFAULT_NETWORKS);
+  if (!(await localStore.getItem(NETWORKS_LIST_ID))) {
+    await localStore.setItem(NETWORKS_LIST_ID, DEFAULT_NETWORKS);
   }
 
   const networksList =
-    (await dataStorageAccess.getItem(NETWORKS_LIST_ID)) || DEFAULT_NETWORKS;
+    (await localStore.getItem(NETWORKS_LIST_ID)) || DEFAULT_NETWORKS;
 
   return networksList;
 };

--- a/extension/src/background/helpers/allowListAuthorization.ts
+++ b/extension/src/background/helpers/allowListAuthorization.ts
@@ -2,14 +2,18 @@ import browser from "webextension-polyfill";
 
 import { ALLOWLIST_ID } from "constants/localStorageTypes";
 import { getUrlHostname, getPunycodedDomain } from "helpers/urls";
-import { dataStorageAccess } from "background/helpers/dataStorage";
+import {
+  dataStorageAccess,
+  localStorage,
+} from "background/helpers/dataStorage";
 
 export const isSenderAllowed = async ({
   sender,
 }: {
   sender: browser.Runtime.MessageSender;
 }) => {
-  const allowListStr = (await dataStorageAccess.getItem(ALLOWLIST_ID)) || "";
+  const localStore = dataStorageAccess(localStorage);
+  const allowListStr = (await localStore.getItem(ALLOWLIST_ID)) || "";
   const allowList = allowListStr.split(",");
 
   const { url: tabUrl = "" } = sender;

--- a/extension/src/background/helpers/cachedFetch.ts
+++ b/extension/src/background/helpers/cachedFetch.ts
@@ -1,16 +1,19 @@
-import { dataStorageAccess } from "background/helpers/dataStorage";
+import {
+  dataStorageAccess,
+  localStorage,
+} from "background/helpers/dataStorage";
+
+const localStore = dataStorageAccess(localStorage);
 
 export const cachedFetch = async (url: string, storageKey: string) => {
   const cachedDateId = `${storageKey}_date`;
 
-  const cachedDate = Number(
-    (await dataStorageAccess.getItem(cachedDateId)) || "",
-  );
+  const cachedDate = Number((await localStore.getItem(cachedDateId)) || "");
   const date = new Date();
   const time = date.getTime();
   const sevenDaysAgo = time - 7 * 24 * 60 * 60 * 1000;
 
-  let directoryLookup = (await dataStorageAccess.getItem(storageKey)) || "{}";
+  let directoryLookup = (await localStore.getItem(storageKey)) || "{}";
 
   if (typeof directoryLookup === "string") {
     try {
@@ -26,8 +29,8 @@ export const cachedFetch = async (url: string, storageKey: string) => {
       const res = await fetch(url);
       directoryLookup = await res.json();
 
-      await dataStorageAccess.setItem(storageKey, directoryLookup);
-      await dataStorageAccess.setItem(cachedDateId, time.toString());
+      await localStore.setItem(storageKey, directoryLookup);
+      await localStore.setItem(cachedDateId, time.toString());
     } catch (e) {
       console.error(e);
     }

--- a/extension/src/background/helpers/dataStorage.ts
+++ b/extension/src/background/helpers/dataStorage.ts
@@ -14,39 +14,58 @@ interface SetItemParams {
   [key: string]: any;
 }
 
-export const browserStorage = browser.storage?.local;
+// https://github.com/mozilla/webextension-polyfill/issues/424
+interface BrowserStorage extends browser.Storage.Static {
+  session: browser.Storage.LocalStorageArea;
+}
 
-export const dataStorage = {
+const storage = browser.storage as BrowserStorage;
+
+// browser storage uses local storage which stores values on disk and persists data across sessions
+// session storage uses session storage which stores data in memory and clears data after every "session"
+// only use session storage for secrets or sensitive values
+export const localStorage = storage?.local;
+export const sessionStorage = storage?.session;
+
+// Session Storage Feature Flag - turn on when storage.session is supported
+export const SESSION_STORAGE_ENABLED = false;
+
+export type StorageOption = typeof localStorage | typeof sessionStorage;
+
+export const dataStorage = (storageApi: StorageOption = localStorage) => ({
   getItem: async (key: string) => {
     // TODO: re-enable defaults by passing an object. The value of the key-value pair will be the default
 
-    const storageResult = await browser.storage.local.get(key);
+    const storageResult = await storageApi.get(key);
 
     return storageResult[key];
   },
   setItem: async (setItemParams: SetItemParams) => {
-    await browser.storage.local.set(setItemParams);
+    await storageApi.set(setItemParams);
   },
 
   clear: async () => {
-    await browser.storage.local.clear();
+    await storageApi.clear();
   },
-};
+});
 
-export const dataStorageAccess = {
-  getItem: (keyId: string) => dataStorage.getItem(keyId),
-  setItem: async (keyId: string, value: any) => {
-    await dataStorage.setItem({ [keyId]: value });
-  },
-  clear: () => dataStorage.clear(),
+export const dataStorageAccess = (storageApi: StorageOption = localStorage) => {
+  const store = dataStorage(storageApi);
+  return {
+    getItem: store.getItem,
+    setItem: async (keyId: string, value: any) => {
+      await store.setItem({ [keyId]: value });
+    },
+    clear: () => store.clear(),
+  };
 };
 
 // This migration adds a friendbotUrl to testnet and futurenet network details
 export const migrateFriendBotUrlNetworkDetails = async () => {
-  const networkList = await dataStorageAccess.getItem(NETWORKS_LIST_ID);
-  const networksList: NetworkDetails[] = networkList
-    ? JSON.parse(networkList)
-    : DEFAULT_NETWORKS;
+  const localStore = dataStorageAccess(localStorage);
+
+  const networksList: NetworkDetails[] =
+    (await localStore.getItem(NETWORKS_LIST_ID)) || DEFAULT_NETWORKS;
 
   const migratedNetworkList = networksList.map((network) => {
     if (network.network === NETWORKS.TESTNET) {
@@ -60,8 +79,5 @@ export const migrateFriendBotUrlNetworkDetails = async () => {
     return network;
   });
 
-  await dataStorageAccess.setItem(
-    NETWORKS_LIST_ID,
-    JSON.stringify(migratedNetworkList),
-  );
+  await localStore.setItem(NETWORKS_LIST_ID, migratedNetworkList);
 };

--- a/extension/src/background/helpers/session.ts
+++ b/extension/src/background/helpers/session.ts
@@ -1,8 +1,8 @@
-import { store } from "background/store";
-import { timeoutAccountAccess } from "background/ducks/session";
+import browser from "webextension-polyfill";
 
 // 24 hours
 const SESSION_LENGTH = 60 * 24;
+export const SESSION_ALARM_NAME = "session-timer";
 
 export class SessionTimer {
   DURATION = 1000 * 60 * SESSION_LENGTH;
@@ -12,11 +12,8 @@ export class SessionTimer {
   }
 
   startSession() {
-    if (this.runningTimeout) {
-      clearTimeout(this.runningTimeout);
-    }
-    this.runningTimeout = setTimeout(() => {
-      store.dispatch(timeoutAccountAccess());
-    }, this.DURATION);
+    browser?.alarms.create(SESSION_ALARM_NAME, {
+      delayInMinutes: SESSION_LENGTH,
+    });
   }
 }

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -1,4 +1,5 @@
 import browser from "webextension-polyfill";
+import { Store } from "redux";
 import { ROUTES } from "popup/constants/routes";
 import {
   EXTERNAL_SERVICE_TYPES,
@@ -7,6 +8,8 @@ import {
 
 import { popupMessageListener } from "./messageListener/popupMessageListener";
 import { freighterApiMessageListener } from "./messageListener/freighterApiMessageListener";
+import { SESSION_ALARM_NAME } from "./helpers/session";
+import { timeoutAccountAccess } from "./ducks/session";
 import { migrateFriendBotUrlNetworkDetails } from "./helpers/dataStorage";
 
 export const initContentScriptMessageListener = () => {
@@ -19,15 +22,15 @@ export const initContentScriptMessageListener = () => {
   });
 };
 
-export const initExtensionMessageListener = () => {
+export const initExtensionMessageListener = (sessionStore: Store) => {
   browser?.runtime?.onMessage?.addListener(async (request, sender) => {
     // todo this is kinda ugly
     let res;
     if (Object.values(SERVICE_TYPES).includes(request.type)) {
-      res = await popupMessageListener(request);
+      res = await popupMessageListener(request, sessionStore);
     }
     if (Object.values(EXTERNAL_SERVICE_TYPES).includes(request.type)) {
-      res = await freighterApiMessageListener(request, sender);
+      res = await freighterApiMessageListener(request, sender, sessionStore);
     }
 
     return res;
@@ -49,4 +52,12 @@ export const initInstalledListener = () => {
     }
   });
   browser?.runtime?.onInstalled.addListener(migrateFriendBotUrlNetworkDetails);
+};
+
+export const initAlarmListener = (sessionStore: Store) => {
+  browser?.alarms?.onAlarm.addListener(({ name }: { name: string }) => {
+    if (name === SESSION_ALARM_NAME) {
+      sessionStore.dispatch(timeoutAccountAccess());
+    }
+  });
 };

--- a/extension/src/background/messageListener/__tests__/popupMessageListener.test.js
+++ b/extension/src/background/messageListener/__tests__/popupMessageListener.test.js
@@ -1,6 +1,6 @@
 import { SERVICE_TYPES } from "@shared/constants/services";
 import { popupMessageListener } from "background/messageListener/popupMessageListener";
-import { store } from "background/store";
+import { buildStore } from "background/store";
 import {
   publicKeySelector,
   privateKeySelector,
@@ -11,8 +11,11 @@ import { decodeString } from "helpers/urls";
 
 console.error = jest.fn((e) => console.log(e));
 
+let store = {};
+
 describe("regular account flow", () => {
-  beforeAll(() => {
+  beforeAll(async () => {
+    store = await buildStore();
     localStorage.clear();
     store.dispatch(sessionSlice.actions.reset());
   });
@@ -21,7 +24,7 @@ describe("regular account flow", () => {
       const r = {};
       r.type = SERVICE_TYPES.CREATE_ACCOUNT;
       r.password = "test";
-      await popupMessageListener(r);
+      await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
 
       // check store
@@ -38,7 +41,7 @@ describe("regular account flow", () => {
       r.type = SERVICE_TYPES.CONFIRM_PASSWORD;
       r.password = "test";
 
-      await popupMessageListener(r);
+      await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
     });
   });
@@ -47,7 +50,7 @@ describe("regular account flow", () => {
       const r = {};
       r.type = SERVICE_TYPES.LOAD_ACCOUNT;
 
-      await popupMessageListener(r);
+      await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
     });
   });
@@ -55,7 +58,7 @@ describe("regular account flow", () => {
     it("works", async () => {
       const r = {};
       r.type = SERVICE_TYPES.SIGN_OUT;
-      await popupMessageListener(r);
+      await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
     });
   });
@@ -65,7 +68,7 @@ describe("regular account flow", () => {
       r.type = SERVICE_TYPES.CONFIRM_PASSWORD;
       r.password = "test";
 
-      await popupMessageListener(r);
+      await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
     });
   });
@@ -75,7 +78,7 @@ describe("regular account flow", () => {
       r.type = SERVICE_TYPES.ADD_ACCOUNT;
       r.password = "test";
 
-      await popupMessageListener(r);
+      await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
 
       expect(allAccountsSelector(store.getState()).length).toBe(2);
@@ -88,7 +91,7 @@ describe("regular account flow", () => {
       r.type = SERVICE_TYPES.MAKE_ACCOUNT_ACTIVE;
       r.publicKey = "GBOORGNN6F35F3BFI4SF5ZR4Q7VHALNPGRG3MGA6WMOW4BKFOFMNI45O";
 
-      await popupMessageListener(r);
+      await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
     });
   });
@@ -104,7 +107,7 @@ describe("adding hardware wallets", () => {
       const r = {};
       r.type = SERVICE_TYPES.CREATE_ACCOUNT;
       r.password = "test";
-      await popupMessageListener(r);
+      await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
 
       // check store
@@ -122,7 +125,7 @@ describe("adding hardware wallets", () => {
       r.publicKey = "GBOORGNN6F35F3BFI4SF5ZR4Q7VHALNPGRG3MGA6WMOW4BKFOFMNI45O";
       r.hardwareWalletType = "Ledger";
       r.bipPath = "44'/148'/1'";
-      await popupMessageListener(r);
+      await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
 
       // check store
@@ -154,7 +157,7 @@ describe("adding hardware wallets", () => {
     it("works", async () => {
       const r = {};
       r.type = SERVICE_TYPES.SIGN_OUT;
-      await popupMessageListener(r);
+      await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
     });
   });
@@ -164,7 +167,7 @@ describe("adding hardware wallets", () => {
       r.type = SERVICE_TYPES.CONFIRM_PASSWORD;
       r.password = "test";
 
-      const resp = await popupMessageListener(r);
+      const resp = await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
 
       expect(resp.bipPath).toBe("44'/148'/1'");
@@ -175,7 +178,7 @@ describe("adding hardware wallets", () => {
       const r = {};
       r.type = SERVICE_TYPES.LOAD_ACCOUNT;
 
-      const resp = await popupMessageListener(r);
+      const resp = await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
 
       expect(resp.bipPath).toBe("44'/148'/1'");
@@ -188,7 +191,7 @@ describe("adding hardware wallets", () => {
       r.publicKey = "GBOORGNN6F35F3BFI4SF5ZR4Q7VHALNPGRG3MGA6WMOW4BKFOFMNI45O";
       r.hardwareWalletType = "Ledger";
       r.bipPath = "44'/148'/1'";
-      await popupMessageListener(r);
+      await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
 
       // check store
@@ -208,7 +211,7 @@ describe("adding hardware wallets", () => {
       r.type = SERVICE_TYPES.CONFIRM_PASSWORD;
       r.password = "test";
 
-      await popupMessageListener(r);
+      await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
     });
   });
@@ -219,7 +222,7 @@ describe("adding hardware wallets", () => {
       r.password = "test";
       r.privateKey = "SAUIIOB4EB6MZ25RKTKQ6DBXBDKKFQVMPLS2Q5LDH4GAMT7SAQPQMNCB";
 
-      await popupMessageListener(r);
+      await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
 
       // check store
@@ -240,7 +243,7 @@ describe("adding hardware wallets", () => {
       const r = {};
       r.type = SERVICE_TYPES.LOAD_ACCOUNT;
 
-      const resp = await popupMessageListener(r);
+      const resp = await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
 
       expect(resp.bipPath).toBe("");
@@ -252,7 +255,7 @@ describe("adding hardware wallets", () => {
       r.type = SERVICE_TYPES.MAKE_ACCOUNT_ACTIVE;
       r.publicKey = "GBOORGNN6F35F3BFI4SF5ZR4Q7VHALNPGRG3MGA6WMOW4BKFOFMNI45O";
 
-      await popupMessageListener(r);
+      await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
       expect(localStorage.getItem("keyId").indexOf("hw:")).toBe(0);
     });
@@ -263,7 +266,7 @@ describe("adding hardware wallets", () => {
       r.type = SERVICE_TYPES.ADD_ACCOUNT;
       r.password = "test";
 
-      await popupMessageListener(r);
+      await popupMessageListener(r, store);
       expect(console.error).not.toHaveBeenCalled();
 
       // check store

--- a/extension/src/background/messageListener/freighterApiMessageListener.ts
+++ b/extension/src/background/messageListener/freighterApiMessageListener.ts
@@ -1,6 +1,7 @@
 import StellarSdk from "stellar-sdk";
 import SorobanSdk from "soroban-client";
 import browser from "webextension-polyfill";
+import { Store } from "redux";
 
 import { ExternalRequest as Request } from "@shared/api/types";
 import { stellarSdkServer } from "@shared/api/helpers/stellarSdkServer";
@@ -27,11 +28,15 @@ import {
 import { isSenderAllowed } from "background/helpers/allowListAuthorization";
 import { cachedFetch } from "background/helpers/cachedFetch";
 import { encodeObject, getUrlHostname, getPunycodedDomain } from "helpers/urls";
-import { dataStorageAccess } from "background/helpers/dataStorage";
-import { store } from "background/store";
+import {
+  dataStorageAccess,
+  localStorage,
+} from "background/helpers/dataStorage";
 import { publicKeySelector } from "background/ducks/session";
 
 import { responseQueue, transactionQueue } from "./popupMessageListener";
+
+const localStore = dataStorageAccess(localStorage);
 
 interface WINDOW_PARAMS {
   height: number;
@@ -48,9 +53,10 @@ const WINDOW_SETTINGS: WINDOW_PARAMS = {
 export const freighterApiMessageListener = (
   request: Request,
   sender: browser.Runtime.MessageSender,
+  sessionStore: Store,
 ) => {
   const requestAccess = async () => {
-    const publicKey = publicKeySelector(store.getState());
+    const publicKey = publicKeySelector(sessionStore.getState());
 
     const { tab, url: tabUrl = "" } = sender;
 
@@ -72,7 +78,7 @@ export const freighterApiMessageListener = (
         // queue it up, we'll let user confirm the url looks okay and then we'll send publicKey
         // if we're good, of course
         if (url === tabUrl) {
-          resolve({ publicKey: publicKeySelector(store.getState()) });
+          resolve({ publicKey: publicKeySelector(sessionStore.getState()) });
         }
 
         resolve({ error: "User declined access" });
@@ -108,7 +114,7 @@ export const freighterApiMessageListener = (
     const domain = getUrlHostname(tabUrl);
     const punycodedDomain = getPunycodedDomain(domain);
 
-    const allowListStr = (await dataStorageAccess.getItem(ALLOWLIST_ID)) || "";
+    const allowListStr = (await localStore.getItem(ALLOWLIST_ID)) || "";
     const allowList = allowListStr.split(",");
 
     const isDomainListedAllowed = await isSenderAllowed({ sender });
@@ -205,7 +211,7 @@ export const freighterApiMessageListener = (
         if (signedTransaction) {
           if (!isDomainListedAllowed) {
             allowList.push(punycodedDomain);
-            dataStorageAccess.setItem(ALLOWLIST_ID, allowList.join());
+            localStore.setItem(ALLOWLIST_ID, allowList.join());
           }
           resolve({ signedTransaction });
         }

--- a/extension/src/background/messageListener/popupMessageListener.ts
+++ b/extension/src/background/messageListener/popupMessageListener.ts
@@ -62,12 +62,10 @@ import {
 import { SessionTimer } from "background/helpers/session";
 import { cachedFetch } from "background/helpers/cachedFetch";
 import {
-  browserStorage,
-  dataStorage,
   dataStorageAccess,
+  localStorage,
 } from "background/helpers/dataStorage";
 
-import { store } from "background/store";
 import {
   allAccountsSelector,
   hasPrivateKeySelector,
@@ -86,6 +84,7 @@ import {
   STELLAR_EXPERT_BLOCKED_DOMAINS_URL,
   STELLAR_EXPERT_BLOCKED_ACCOUNTS_URL,
 } from "background/constants/apiUrls";
+import { Store } from "redux";
 
 const sessionTimer = new SessionTimer();
 
@@ -100,9 +99,10 @@ interface KeyPair {
   privateKey: string;
 }
 
-export const popupMessageListener = (request: Request) => {
+export const popupMessageListener = (request: Request, sessionStore: Store) => {
+  const localStore = dataStorageAccess(localStorage);
   const localKeyStore = new KeyManagerPlugins.BrowserStorageKeyStore();
-  localKeyStore.configure({ storage: browserStorage });
+  localKeyStore.configure({ storage: localStorage });
   const keyManager = new KeyManager({
     keyStore: localKeyStore,
   });
@@ -141,8 +141,8 @@ export const popupMessageListener = (request: Request) => {
     hardwareWalletType: WalletType;
     bipPath: string;
   }) => {
-    const mnemonicPhrase = mnemonicPhraseSelector(store.getState());
-    let allAccounts = allAccountsSelector(store.getState());
+    const mnemonicPhrase = mnemonicPhraseSelector(sessionStore.getState());
+    let allAccounts = allAccountsSelector(sessionStore.getState());
 
     const keyId = `${HW_PREFIX}${publicKey}`;
     const keyIdListArr = await getKeyIdList();
@@ -152,12 +152,12 @@ export const popupMessageListener = (request: Request) => {
 
     if (keyIdListArr.indexOf(keyId) === -1) {
       keyIdListArr.push(keyId);
-      await dataStorageAccess.setItem(KEY_ID_LIST, keyIdListArr);
+      await localStore.setItem(KEY_ID_LIST, keyIdListArr);
       const hwData = {
         bipPath,
         publicKey,
       };
-      await dataStorageAccess.setItem(keyId, hwData);
+      await localStore.setItem(keyId, hwData);
       await addAccountName({
         keyId,
         accountName,
@@ -173,9 +173,9 @@ export const popupMessageListener = (request: Request) => {
       ];
     }
 
-    await dataStorageAccess.setItem(KEY_ID, keyId);
+    await localStore.setItem(KEY_ID, keyId);
 
-    store.dispatch(
+    sessionStore.dispatch(
       logIn({
         publicKey,
         mnemonicPhrase,
@@ -184,7 +184,7 @@ export const popupMessageListener = (request: Request) => {
     );
 
     // an active hw account should not have an active private key
-    store.dispatch(setActivePrivateKey({ privateKey: "" }));
+    sessionStore.dispatch(setActivePrivateKey({ privateKey: "" }));
   };
 
   const _storeAccount = async ({
@@ -200,10 +200,10 @@ export const popupMessageListener = (request: Request) => {
   }) => {
     const { publicKey, privateKey } = keyPair;
 
-    const allAccounts = allAccountsSelector(store.getState());
+    const allAccounts = allAccountsSelector(sessionStore.getState());
     const accountName = `Account ${allAccounts.length + 1}`;
 
-    store.dispatch(
+    sessionStore.dispatch(
       logIn({
         publicKey,
         mnemonicPhrase,
@@ -241,8 +241,8 @@ export const popupMessageListener = (request: Request) => {
     const keyIdListArr = await getKeyIdList();
     keyIdListArr.push(keyStore.id);
 
-    await dataStorageAccess.setItem(KEY_ID_LIST, keyIdListArr);
-    await dataStorageAccess.setItem(KEY_ID, keyStore.id);
+    await localStore.setItem(KEY_ID_LIST, keyIdListArr);
+    await localStore.setItem(KEY_ID, keyStore.id);
     await addAccountName({
       keyId: keyStore.id,
       accountName,
@@ -250,7 +250,7 @@ export const popupMessageListener = (request: Request) => {
   };
 
   const _activatePublicKey = async ({ publicKey }: { publicKey: string }) => {
-    const allAccounts = allAccountsSelector(store.getState());
+    const allAccounts = allAccountsSelector(sessionStore.getState());
     let publicKeyIndex = allAccounts.findIndex(
       (account: Account) => account.publicKey === publicKey,
     );
@@ -260,9 +260,9 @@ export const popupMessageListener = (request: Request) => {
 
     const activeKeyId = keyIdList[publicKeyIndex];
 
-    await dataStorageAccess.setItem(KEY_ID, activeKeyId);
+    await localStore.setItem(KEY_ID, activeKeyId);
 
-    store.dispatch(setActivePublicKey({ publicKey }));
+    sessionStore.dispatch(setActivePublicKey({ publicKey }));
   };
 
   const fundAccount = async () => {
@@ -290,7 +290,7 @@ export const popupMessageListener = (request: Request) => {
 
     const KEY_DERIVATION_NUMBER = 0;
 
-    await dataStorageAccess.setItem(
+    await localStore.setItem(
       KEY_DERIVATION_NUMBER_ID,
       KEY_DERIVATION_NUMBER.toString(),
     );
@@ -305,12 +305,12 @@ export const popupMessageListener = (request: Request) => {
       keyPair,
       mnemonicPhrase,
     });
-    await dataStorageAccess.setItem(
+    await localStore.setItem(
       APPLICATION_ID,
       APPLICATION_STATE.PASSWORD_CREATED,
     );
 
-    const currentState = store.getState();
+    const currentState = sessionStore.getState();
 
     return {
       allAccounts: allAccountsSelector(currentState),
@@ -320,7 +320,7 @@ export const popupMessageListener = (request: Request) => {
 
   const addAccount = async () => {
     const { password } = request;
-    const mnemonicPhrase = mnemonicPhraseSelector(store.getState());
+    const mnemonicPhrase = mnemonicPhraseSelector(sessionStore.getState());
 
     if (!mnemonicPhrase) {
       return { error: "Mnemonic phrase not found" };
@@ -328,7 +328,7 @@ export const popupMessageListener = (request: Request) => {
 
     const keyID = (await getIsHardwareWalletActive())
       ? await _getNonHwKeyID()
-      : (await dataStorageAccess.getItem(KEY_ID)) || "";
+      : (await localStore.getItem(KEY_ID)) || "";
 
     try {
       await _unlockKeystore({ keyID, password });
@@ -339,7 +339,7 @@ export const popupMessageListener = (request: Request) => {
 
     const wallet = fromMnemonic(mnemonicPhrase);
     const keyNumber =
-      Number(await dataStorageAccess.getItem(KEY_DERIVATION_NUMBER_ID)) + 1;
+      Number(await localStore.getItem(KEY_DERIVATION_NUMBER_ID)) + 1;
 
     const keyPair = {
       publicKey: wallet.getPublicKey(keyNumber),
@@ -352,17 +352,16 @@ export const popupMessageListener = (request: Request) => {
       mnemonicPhrase,
     });
 
-    await dataStorageAccess.setItem(
-      KEY_DERIVATION_NUMBER_ID,
-      keyNumber.toString(),
-    );
+    await localStore.setItem(KEY_DERIVATION_NUMBER_ID, keyNumber.toString());
 
-    store.dispatch(timeoutAccountAccess());
+    sessionStore.dispatch(timeoutAccountAccess());
 
     sessionTimer.startSession();
-    store.dispatch(setActivePrivateKey({ privateKey: keyPair.privateKey }));
+    sessionStore.dispatch(
+      setActivePrivateKey({ privateKey: keyPair.privateKey }),
+    );
 
-    const currentState = store.getState();
+    const currentState = sessionStore.getState();
 
     return {
       publicKey: publicKeySelector(currentState),
@@ -376,7 +375,7 @@ export const popupMessageListener = (request: Request) => {
     let sourceKeys;
     const keyID = (await getIsHardwareWalletActive())
       ? await _getNonHwKeyID()
-      : (await dataStorageAccess.getItem(KEY_ID)) || "";
+      : (await localStore.getItem(KEY_ID)) || "";
 
     try {
       await _unlockKeystore({ keyID, password });
@@ -391,7 +390,7 @@ export const popupMessageListener = (request: Request) => {
       privateKey,
     };
 
-    const mnemonicPhrase = mnemonicPhraseSelector(store.getState());
+    const mnemonicPhrase = mnemonicPhraseSelector(sessionStore.getState());
 
     if (!mnemonicPhrase) {
       return { error: "Mnemonic phrase not found" };
@@ -405,9 +404,9 @@ export const popupMessageListener = (request: Request) => {
     });
 
     sessionTimer.startSession();
-    store.dispatch(setActivePrivateKey({ privateKey }));
+    sessionStore.dispatch(setActivePrivateKey({ privateKey }));
 
-    const currentState = store.getState();
+    const currentState = sessionStore.getState();
 
     return {
       publicKey: publicKeySelector(currentState),
@@ -426,9 +425,9 @@ export const popupMessageListener = (request: Request) => {
     });
 
     return {
-      publicKey: publicKeySelector(store.getState()),
-      allAccounts: allAccountsSelector(store.getState()),
-      hasPrivateKey: await hasPrivateKeySelector(store.getState()),
+      publicKey: publicKeySelector(sessionStore.getState()),
+      allAccounts: allAccountsSelector(sessionStore.getState()),
+      hasPrivateKey: await hasPrivateKeySelector(sessionStore.getState()),
       bipPath: await getBipPath(),
     };
   };
@@ -437,9 +436,9 @@ export const popupMessageListener = (request: Request) => {
     const { publicKey } = request;
     await _activatePublicKey({ publicKey });
 
-    store.dispatch(timeoutAccountAccess());
+    sessionStore.dispatch(timeoutAccountAccess());
 
-    const currentState = store.getState();
+    const currentState = sessionStore.getState();
 
     return {
       publicKey: publicKeySelector(currentState),
@@ -450,15 +449,15 @@ export const popupMessageListener = (request: Request) => {
 
   const updateAccountName = async () => {
     const { accountName } = request;
-    const keyId = (await dataStorageAccess.getItem(KEY_ID)) || "";
+    const keyId = (await localStore.getItem(KEY_ID)) || "";
 
-    store.dispatch(
+    sessionStore.dispatch(
       updateAllAccountsAccountName({ updatedAccountName: accountName }),
     );
     await addAccountName({ keyId, accountName });
 
     return {
-      allAccounts: allAccountsSelector(store.getState()),
+      allAccounts: allAccountsSelector(sessionStore.getState()),
     };
   };
 
@@ -480,7 +479,7 @@ export const popupMessageListener = (request: Request) => {
 
     const networksList: NetworkDetails[] = [...savedNetworks, networkDetails];
 
-    await dataStorageAccess.setItem(NETWORKS_LIST_ID, networksList);
+    await localStore.setItem(NETWORKS_LIST_ID, networksList);
 
     return {
       networksList,
@@ -497,7 +496,7 @@ export const popupMessageListener = (request: Request) => {
 
     savedNetworks.splice(networkIndex, 1);
 
-    await dataStorageAccess.setItem(NETWORKS_LIST_ID, savedNetworks);
+    await localStore.setItem(NETWORKS_LIST_ID, savedNetworks);
 
     return {
       networksList: savedNetworks,
@@ -509,7 +508,7 @@ export const popupMessageListener = (request: Request) => {
 
     const savedNetworks = await getSavedNetworks();
     const activeNetworkDetails =
-      (await dataStorageAccess.getItem(NETWORK_ID)) || MAINNET_NETWORK_DETAILS;
+      (await localStore.getItem(NETWORK_ID)) || MAINNET_NETWORK_DETAILS;
     const activeIndex =
       savedNetworks.findIndex(
         ({ networkName: savedNetworkName }) =>
@@ -518,11 +517,11 @@ export const popupMessageListener = (request: Request) => {
 
     savedNetworks.splice(networkIndex, 1, networkDetails);
 
-    await dataStorageAccess.setItem(NETWORKS_LIST_ID, savedNetworks);
+    await localStore.setItem(NETWORKS_LIST_ID, savedNetworks);
 
     if (activeIndex === networkIndex) {
       // editing active network, so we need to update this in storage
-      await dataStorageAccess.setItem(NETWORK_ID, savedNetworks[activeIndex]);
+      await localStore.setItem(NETWORK_ID, savedNetworks[activeIndex]);
     }
 
     return {
@@ -540,7 +539,7 @@ export const popupMessageListener = (request: Request) => {
         ({ networkName: savedNetworkName }) => savedNetworkName === networkName,
       ) || MAINNET_NETWORK_DETAILS;
 
-    await dataStorageAccess.setItem(NETWORK_ID, networkDetails);
+    await localStore.setItem(NETWORK_ID, networkDetails);
 
     return { networkDetails };
   };
@@ -557,41 +556,41 @@ export const popupMessageListener = (request: Request) => {
     - in other places in code where we save keyId, we do so as a string
     Let's solve the issue at its source
   */
-    const keyId = (await dataStorageAccess.getItem(KEY_ID)) as string | number;
+    const keyId = (await localStore.getItem(KEY_ID)) as string | number;
     if (typeof keyId === "number") {
-      await dataStorageAccess.setItem(KEY_ID, keyId.toString());
+      await localStore.setItem(KEY_ID, keyId.toString());
     }
 
-    const currentState = store.getState();
+    const currentState = sessionStore.getState();
 
     return {
       hasPrivateKey: await hasPrivateKeySelector(currentState),
       publicKey: publicKeySelector(currentState),
-      applicationState: (await dataStorageAccess.getItem(APPLICATION_ID)) || "",
+      applicationState: (await localStore.getItem(APPLICATION_ID)) || "",
       allAccounts: allAccountsSelector(currentState),
       bipPath: await getBipPath(),
-      tokenIdList: (await dataStorageAccess.getItem(TOKEN_ID_LIST)) || {},
+      tokenIdList: (await localStore.getItem(TOKEN_ID_LIST)) || {},
     };
   };
 
   const getMnemonicPhrase = () => ({
-    mnemonicPhrase: mnemonicPhraseSelector(store.getState()),
+    mnemonicPhrase: mnemonicPhraseSelector(sessionStore.getState()),
   });
 
   const confirmMnemonicPhrase = async () => {
     const isCorrectPhrase =
-      mnemonicPhraseSelector(store.getState()) ===
+      mnemonicPhraseSelector(sessionStore.getState()) ===
       request.mnemonicPhraseToConfirm;
 
     const applicationState = isCorrectPhrase
       ? APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED
       : APPLICATION_STATE.MNEMONIC_PHRASE_FAILED;
 
-    await dataStorageAccess.setItem(APPLICATION_ID, applicationState);
+    await localStore.setItem(APPLICATION_ID, applicationState);
 
     return {
       isCorrectPhrase,
-      applicationState: (await dataStorageAccess.getItem(APPLICATION_ID)) || "",
+      applicationState: (await localStore.getItem(APPLICATION_ID)) || "",
     };
   };
 
@@ -613,21 +612,23 @@ export const popupMessageListener = (request: Request) => {
         publicKey: wallet.getPublicKey(0),
         privateKey: wallet.getSecret(0),
       };
-      dataStorageAccess.clear();
-      await dataStorageAccess.setItem(KEY_DERIVATION_NUMBER_ID, "0");
+      localStore.clear();
+      await localStore.setItem(KEY_DERIVATION_NUMBER_ID, "0");
 
       _storeAccount({ mnemonicPhrase: recoverMnemonic, password, keyPair });
 
       // if we don't have an application state, assign them one
       applicationState =
-        (await dataStorageAccess.getItem(APPLICATION_ID)) ||
+        (await localStore.getItem(APPLICATION_ID)) ||
         APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED;
 
-      await dataStorageAccess.setItem(APPLICATION_ID, applicationState);
+      await localStore.setItem(APPLICATION_ID, applicationState);
 
       // start the timer now that we have active private key
       sessionTimer.startSession();
-      store.dispatch(setActivePrivateKey({ privateKey: keyPair.privateKey }));
+      sessionStore.dispatch(
+        setActivePrivateKey({ privateKey: keyPair.privateKey }),
+      );
 
       // lets check first couple of accounts and pre-load them if funded on mainnet
       const numOfPublicKeysToCheck = 5;
@@ -657,10 +658,7 @@ export const popupMessageListener = (request: Request) => {
               imported: true,
             });
             // eslint-disable-next-line no-await-in-loop
-            await dataStorageAccess.setItem(
-              KEY_DERIVATION_NUMBER_ID,
-              String(i),
-            );
+            await localStore.setItem(KEY_DERIVATION_NUMBER_ID, String(i));
           }
         } catch (e) {
           // continue
@@ -671,12 +669,12 @@ export const popupMessageListener = (request: Request) => {
       await _activatePublicKey({ publicKey: wallet.getPublicKey(0) });
     }
 
-    const currentState = store.getState();
+    const currentState = sessionStore.getState();
 
     return {
       allAccounts: allAccountsSelector(currentState),
       publicKey: publicKeySelector(currentState),
-      applicationState: (await dataStorageAccess.getItem(APPLICATION_ID)) || "",
+      applicationState: (await localStore.getItem(APPLICATION_ID)) || "",
       hasPrivateKey: await hasPrivateKeySelector(currentState),
       error,
     };
@@ -687,7 +685,7 @@ export const popupMessageListener = (request: Request) => {
 
     try {
       await _unlockKeystore({
-        keyID: (await dataStorageAccess.getItem(KEY_ID)) || "",
+        keyID: (await localStore.getItem(KEY_ID)) || "",
         password,
       });
       return {};
@@ -752,11 +750,11 @@ export const popupMessageListener = (request: Request) => {
 
     /* migration needed to v1.0.6-beta data model */
     if (!keyIdList.length) {
-      const keyId = await dataStorageAccess.getItem(KEY_ID);
+      const keyId = await localStore.getItem(KEY_ID);
       if (keyId) {
         keyIdList.push(keyId);
-        await dataStorageAccess.setItem(KEY_ID_LIST, keyIdList);
-        await dataStorageAccess.setItem(KEY_DERIVATION_NUMBER_ID, "0");
+        await localStore.setItem(KEY_ID_LIST, keyIdList);
+        await localStore.setItem(KEY_DERIVATION_NUMBER_ID, "0");
         await addAccountName({ keyId, accountName: "Account 1" });
       }
     }
@@ -764,7 +762,7 @@ export const popupMessageListener = (request: Request) => {
 
     // if active hw then use the first non-hw keyID to check password
     // with keyManager
-    let keyID = (await dataStorageAccess.getItem(KEY_ID)) || "";
+    let keyID = (await localStore.getItem(KEY_ID)) || "";
     let hwPublicKey = "";
     if (await getIsHardwareWalletActive()) {
       hwPublicKey = keyID.split(":")[1];
@@ -793,14 +791,14 @@ export const popupMessageListener = (request: Request) => {
     const activeMnemonicPhrase = activeExtra.mnemonicPhrase;
 
     if (
-      !publicKeySelector(store.getState()) ||
-      !allAccountsSelector(store.getState()).length
+      !publicKeySelector(sessionStore.getState()) ||
+      !allAccountsSelector(sessionStore.getState()).length
     ) {
       // we have cleared redux store via reloading extension/browser
       // construct allAccounts from local storage
       // log the user in using all accounts and public key/phrase from above to create the store
 
-      store.dispatch(
+      sessionStore.dispatch(
         logIn({
           publicKey: hwPublicKey || activePublicKey,
           mnemonicPhrase: activeMnemonicPhrase,
@@ -812,14 +810,16 @@ export const popupMessageListener = (request: Request) => {
     // start the timer now that we have active private key
     sessionTimer.startSession();
     if (!(await getIsHardwareWalletActive())) {
-      store.dispatch(setActivePrivateKey({ privateKey: activePrivateKey }));
+      sessionStore.dispatch(
+        setActivePrivateKey({ privateKey: activePrivateKey }),
+      );
     }
 
     return {
-      publicKey: publicKeySelector(store.getState()),
-      hasPrivateKey: await hasPrivateKeySelector(store.getState()),
-      applicationState: (await dataStorageAccess.getItem(APPLICATION_ID)) || "",
-      allAccounts: allAccountsSelector(store.getState()),
+      publicKey: publicKeySelector(sessionStore.getState()),
+      hasPrivateKey: await hasPrivateKeySelector(sessionStore.getState()),
+      applicationState: (await localStore.getItem(APPLICATION_ID)) || "",
+      allAccounts: allAccountsSelector(sessionStore.getState()),
       bipPath: await getBipPath(),
     };
   };
@@ -832,11 +832,11 @@ export const popupMessageListener = (request: Request) => {
     // TODO: right now we're just grabbing the last thing in the queue, but this should be smarter.
     // Maybe we need to search through responses to find a matching reponse :thinking_face
     const response = responseQueue.pop();
-    const allowListStr = (await dataStorageAccess.getItem(ALLOWLIST_ID)) || "";
+    const allowListStr = (await localStore.getItem(ALLOWLIST_ID)) || "";
     const allowList = allowListStr.split(",");
     allowList.push(punycodedDomain);
 
-    await dataStorageAccess.setItem(ALLOWLIST_ID, allowList.join());
+    await localStore.setItem(ALLOWLIST_ID, allowList.join());
 
     if (typeof response === "function") {
       return response(url);
@@ -866,7 +866,7 @@ export const popupMessageListener = (request: Request) => {
   };
 
   const signTransaction = async () => {
-    const privateKey = privateKeySelector(store.getState());
+    const privateKey = privateKeySelector(sessionStore.getState());
 
     if (privateKey.length) {
       const isExperimentalModeEnabled = await getIsExperimentalModeEnabled();
@@ -912,7 +912,7 @@ export const popupMessageListener = (request: Request) => {
     const SDK = isExperimentalModeEnabled ? SorobanSdk : StellarSdk;
     const transaction = SDK.TransactionBuilder.fromXDR(transactionXDR, network);
 
-    const privateKey = privateKeySelector(store.getState());
+    const privateKey = privateKeySelector(sessionStore.getState());
     if (privateKey.length) {
       const sourceKeys = SDK.Keypair.fromSecret(privateKey);
       transaction.sign(sourceKeys);
@@ -930,7 +930,7 @@ export const popupMessageListener = (request: Request) => {
       network,
     );
 
-    const privateKey = privateKeySelector(store.getState());
+    const privateKey = privateKeySelector(sessionStore.getState());
     if (privateKey.length) {
       const sourceKeys = SorobanSdk.Keypair.fromSecret(privateKey);
       transaction.sign(sourceKeys);
@@ -942,30 +942,28 @@ export const popupMessageListener = (request: Request) => {
 
   const addRecentAddress = async () => {
     const { publicKey } = request;
-    const storedData =
-      (await dataStorageAccess.getItem(RECENT_ADDRESSES)) || [];
+    const storedData = (await localStore.getItem(RECENT_ADDRESSES)) || [];
     const recentAddresses = storedData;
     if (recentAddresses.indexOf(publicKey) === -1) {
       recentAddresses.push(publicKey);
     }
-    await dataStorageAccess.setItem(RECENT_ADDRESSES, recentAddresses);
+    await localStore.setItem(RECENT_ADDRESSES, recentAddresses);
 
     return { recentAddresses };
   };
 
   const loadRecentAddresses = async () => {
-    const storedData =
-      (await dataStorageAccess.getItem(RECENT_ADDRESSES)) || [];
+    const storedData = (await localStore.getItem(RECENT_ADDRESSES)) || [];
     const recentAddresses = storedData;
     return { recentAddresses };
   };
 
   const signOut = async () => {
-    store.dispatch(logOut());
+    sessionStore.dispatch(logOut());
 
     return {
-      publicKey: publicKeySelector(store.getState()),
-      applicationState: (await dataStorageAccess.getItem(APPLICATION_ID)) || "",
+      publicKey: publicKeySelector(sessionStore.getState()),
+      applicationState: (await localStore.getItem(APPLICATION_ID)) || "",
     };
   };
 
@@ -980,16 +978,13 @@ export const popupMessageListener = (request: Request) => {
 
     const currentIsExperimentalModeEnabled = await getIsExperimentalModeEnabled();
 
-    await dataStorageAccess.setItem(DATA_SHARING_ID, isDataSharingAllowed);
-    await dataStorageAccess.setItem(
-      IS_VALIDATING_MEMO_ID,
-      isMemoValidationEnabled,
-    );
-    await dataStorageAccess.setItem(
+    await localStore.setItem(DATA_SHARING_ID, isDataSharingAllowed);
+    await localStore.setItem(IS_VALIDATING_MEMO_ID, isMemoValidationEnabled);
+    await localStore.setItem(
       IS_VALIDATING_SAFETY_ID,
       isSafetyValidationEnabled,
     );
-    await dataStorageAccess.setItem(
+    await localStore.setItem(
       IS_VALIDATING_SAFE_ASSETS_ID,
       isValidatingSafeAssetsEnabled,
     );
@@ -1005,11 +1000,11 @@ export const popupMessageListener = (request: Request) => {
 
       currentNetworksList.splice(0, 1, defaultNetworkDetails);
 
-      await dataStorageAccess.setItem(NETWORKS_LIST_ID, currentNetworksList);
-      await dataStorageAccess.setItem(NETWORK_ID, defaultNetworkDetails);
+      await localStore.setItem(NETWORKS_LIST_ID, currentNetworksList);
+      await localStore.setItem(NETWORK_ID, defaultNetworkDetails);
     }
 
-    await dataStorageAccess.setItem(
+    await localStore.setItem(
       IS_EXPERIMENTAL_MODE_ID,
       isExperimentalModeEnabled,
     );
@@ -1027,7 +1022,7 @@ export const popupMessageListener = (request: Request) => {
 
   const loadSettings = async () => {
     const isDataSharingAllowed =
-      (await dataStorage.getItem(DATA_SHARING_ID)) || true;
+      (await localStore.getItem(DATA_SHARING_ID)) || true;
 
     return {
       isDataSharingAllowed,
@@ -1044,7 +1039,7 @@ export const popupMessageListener = (request: Request) => {
     const { assetCanonical } = request;
 
     const assetIconCache =
-      (await dataStorageAccess.getItem(CACHED_ASSET_ICONS_ID)) || {};
+      (await localStore.getItem(CACHED_ASSET_ICONS_ID)) || {};
 
     return {
       iconUrl: assetIconCache[assetCanonical] || "",
@@ -1055,16 +1050,16 @@ export const popupMessageListener = (request: Request) => {
     const { assetCanonical, iconUrl } = request;
 
     const assetIconCache =
-      (await dataStorageAccess.getItem(CACHED_ASSET_ICONS_ID)) || {};
+      (await localStore.getItem(CACHED_ASSET_ICONS_ID)) || {};
     assetIconCache[assetCanonical] = iconUrl;
-    await dataStorageAccess.setItem(CACHED_ASSET_ICONS_ID, assetIconCache);
+    await localStore.setItem(CACHED_ASSET_ICONS_ID, assetIconCache);
   };
 
   const getCachedAssetDomain = async () => {
     const { assetCanonical } = request;
 
     let assetDomainCache =
-      (await dataStorageAccess.getItem(CACHED_ASSET_DOMAINS_ID)) || {};
+      (await localStore.getItem(CACHED_ASSET_DOMAINS_ID)) || {};
 
     // works around a 3.0.0 migration issue
     if (typeof assetDomainCache === "string") {
@@ -1080,15 +1075,15 @@ export const popupMessageListener = (request: Request) => {
     const { assetCanonical, assetDomain } = request;
 
     let assetDomainCache =
-      (await dataStorageAccess.getItem(CACHED_ASSET_DOMAINS_ID)) || {};
+      (await localStore.getItem(CACHED_ASSET_DOMAINS_ID)) || {};
 
     // works around a 3.0.0 migration issue
     if (typeof assetDomainCache === "string") {
       assetDomainCache = JSON.parse(assetDomainCache);
     }
-    
+
     assetDomainCache[assetCanonical] = assetDomain;
-    await dataStorageAccess.setItem(CACHED_ASSET_DOMAINS_ID, assetDomainCache);
+    await localStore.setItem(CACHED_ASSET_DOMAINS_ID, assetDomainCache);
   };
 
   const getBlockedDomains = async () => {
@@ -1130,17 +1125,17 @@ export const popupMessageListener = (request: Request) => {
     if (EXPERIMENTAL !== true) {
       return { error: "Not in experimental mode" };
     }
-    await dataStorageAccess.clear();
-    store.dispatch(reset());
+    await localStore.clear();
+    sessionStore.dispatch(reset());
     return {};
   };
 
   const addTokenId = async () => {
     const { tokenId } = request;
     const tokenIdList = JSON.parse(
-      (await dataStorageAccess.getItem(TOKEN_ID_LIST)) || "{}",
+      (await localStore.getItem(TOKEN_ID_LIST)) || "{}",
     );
-    const keyId = (await dataStorageAccess.getItem(KEY_ID)) || "";
+    const keyId = (await localStore.getItem(KEY_ID)) || "";
 
     const accountTokenIdList = tokenIdList[keyId] || [];
 
@@ -1149,7 +1144,7 @@ export const popupMessageListener = (request: Request) => {
     }
 
     accountTokenIdList.push(tokenId);
-    await dataStorageAccess.setItem(
+    await localStore.setItem(
       TOKEN_ID_LIST,
       JSON.stringify({
         ...tokenIdList,
@@ -1161,8 +1156,8 @@ export const popupMessageListener = (request: Request) => {
   };
 
   const getTokenIds = async () => {
-    const tokenIdList = (await dataStorageAccess.getItem(TOKEN_ID_LIST)) || {};
-    const keyId = (await dataStorageAccess.getItem(KEY_ID)) || "";
+    const tokenIdList = (await localStore.getItem(TOKEN_ID_LIST)) || {};
+    const keyId = (await localStore.getItem(KEY_ID)) || "";
 
     return { tokenIdList: tokenIdList[keyId] || [] };
   };

--- a/extension/src/background/store.ts
+++ b/extension/src/background/store.ts
@@ -2,9 +2,57 @@ import { combineReducers } from "redux";
 import { configureStore } from "@reduxjs/toolkit";
 
 import { sessionSlice } from "background/ducks/session";
+import {
+  SESSION_STORAGE_ENABLED,
+  dataStorageAccess,
+  sessionStorage,
+} from "./helpers/dataStorage";
 
-export const store = configureStore({
+// Session storage can be used to persist redux store in Manifest v3 because service workers go idle after 30 seconds
+// Session storage is not currently supported in Firefox, which blocks our migration to using this by default
+const REDUX_STORE_KEY = "session-store";
+const sessionStore = dataStorageAccess(sessionStorage);
+
+export async function loadState() {
+  try {
+    const state = await sessionStore.getItem(REDUX_STORE_KEY);
+    if (!state) return undefined;
+    return JSON.parse(state);
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+function saveStore(state: Record<string, unknown>) {
+  const serializedState = JSON.stringify(state);
+  sessionStore.setItem(REDUX_STORE_KEY, serializedState);
+}
+
+const store = configureStore({
   reducer: combineReducers({
     session: sessionSlice.reducer,
   }),
 });
+
+/*
+  When session store is enabled, we need to return a hydrated store that syncs to
+  to/from the session store because service workers are ephemeral.
+  When session store is disabled, we need to return a store that lives on the top
+  level scope of this script because it will run in a persistent background script.
+*/
+export const buildStore = async () => {
+  if (SESSION_STORAGE_ENABLED) {
+    const reduxState = await loadState();
+    const hydratedStore = configureStore({
+      reducer: combineReducers({
+        session: sessionSlice.reducer,
+      }),
+      preloadedState: reduxState,
+    });
+
+    hydratedStore.subscribe(() => saveStore(hydratedStore.getState()));
+    return hydratedStore;
+  }
+
+  return store;
+};

--- a/extension/webpack.common.js
+++ b/extension/webpack.common.js
@@ -112,7 +112,14 @@ const commonConfig = (env = { EXPERIMENTAL: false }) => ({
       failOnWarning: true,
     }),
     new CopyWebpackPlugin([
-      { from: path.resolve(__dirname, "./public/static"), to: BUILD_PATH },
+      {
+        from: path.resolve(__dirname, "./public/static"),
+        to: BUILD_PATH,
+      },
+      {
+        from: path.resolve(__dirname, "./public/static/manifest/v2.json"),
+        to: `${BUILD_PATH}/manifest.json`,
+      },
     ]),
     new HtmlWebPackPlugin({
       template: path.resolve(__dirname, "./public/index.html"),


### PR DESCRIPTION
[Ticket](https://stellarorg.atlassian.net/jira/software/c/projects/WAL/boards/36?modal=detail&selectedIssue=WAL-751)

In an effort to merge the manifest v3 changes, I've added an option to set a static feature flag in order to use session storage to persist the background redux store.

This change is required after Manifest v3 because the background script is deprecated in favor of service workers, but service workers are ephemeral and go idle after 30 seconds of inactivity which means our redux store in the background is garbage collected.

The reason we need a feature flag and can't use this approach as the default is because [Firefox currently does not support the session storage APIs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/session). So we cannot migrate to manifest v3 until they either add support or we decide to add special casing for each browser. Right now, we can stay on manifest v2 until Chrome forces us to upgrade to v3.

Notable changes:
Both manifest versions are supported, we now have a `/public/manifest/{v2|v3}.json` and the common webpack config uses the v2 version as a default. The `SESSION_STORAGE_ENABLED` feature flag in dataStorage is set to false which means the redux store will be kept on the top level scope of the background script.

To switch to manifest v3 mode, flip `SESSION_STORAGE_ENABLED` to true and update `webpack.common.ts` to use `manifest/v3.json` for the manifest in the build output.

The dataStore now supports local storage or session storage(they use the same APIs), it's configured to use browser storage everywhere that it did before and uses sessions storage for the redux store hydration when it is enabled.

The SessionTimer now uses `chrome.alarms` in order to timeout session after a day.