### PR TITLE
[BUG] Correctly check for sourceAsset on createAccount payment

### DIFF
--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
@@ -165,8 +165,9 @@ const getOperation = (
       path: path.map((p) => getAssetFromCanonical(p)),
     });
   }
+
   // create account if unfunded and sending xlm
-  if (!isFunded && sourceAsset === StellarSdk.Asset.native().toString()) {
+  if (!isFunded && sourceAsset.code === StellarSdk.Asset.native().code) {
     return StellarSdk.Operation.createAccount({
       destination,
       startingBalance: amount,


### PR DESCRIPTION
This was reported internally.
During a previous refactor, a bug was introduced that caused the check for sourceAsset on the createAccount step of sendPayment to incorrectly check for XLM as the source account so the operation was being skipped and the following payment would then fail.