### PR TITLE
[BUG] correctly gets networkList in networkList migrator

### DIFF
--- a/@shared/constants/stellar.ts
+++ b/@shared/constants/stellar.ts
@@ -40,7 +40,6 @@ export const MAINNET_NETWORK_DETAILS: NetworkDetails = {
   networkName: NETWORK_NAMES.PUBNET,
   networkUrl: NETWORK_URLS.PUBLIC,
   networkPassphrase: StellarSdk.Networks.PUBLIC,
-  friendbotUrl: FRIENDBOT_URLS.TESTNET,
 };
 
 export const TESTNET_NETWORK_DETAILS: NetworkDetails = {

--- a/extension/src/background/helpers/dataStorage.ts
+++ b/extension/src/background/helpers/dataStorage.ts
@@ -73,9 +73,10 @@ export const dataStorageAccess = {
 
 // This migration adds a friendbotUrl to testnet and futurenet network details
 export const migrateFriendBotUrlNetworkDetails = async () => {
-  const networksList: NetworkDetails[] =
-    JSON.parse((await dataStorageAccess.getItem(NETWORKS_LIST_ID)) || "[]") ||
-    DEFAULT_NETWORKS;
+  const networkList = await dataStorageAccess.getItem(NETWORKS_LIST_ID);
+  const networksList: NetworkDetails[] = networkList
+    ? JSON.parse(networkList)
+    : DEFAULT_NETWORKS;
 
   const migratedNetworkList = networksList.map((network) => {
     if (network.network === NETWORKS.TESTNET) {


### PR DESCRIPTION
Refactors to not always set an empty networksList during the migration.