### PR TITLE
Bugfix/soroban decode i128

### DIFF
--- a/@shared/api/helpers/soroban.ts
+++ b/@shared/api/helpers/soroban.ts
@@ -1,15 +1,28 @@
 import BigNumber from "bignumber.js";
 import { xdr, Address } from "soroban-client";
 
+import { I128 } from "./xdr";
+
 /* eslint-disable */
 
 export const accountIdentifier = (account: string) =>
   new Address(account).toScVal();
 
 // How do we decode these in a more generic way?
-export const decodeAccountIdentifier = (scVal: Buffer) => {
-  const accountId = xdr.ScVal.fromXDR(scVal);
-  return accountId.i128().lo().low;
+export const decodei128 = (scVal: Buffer) => {
+  const value = xdr.ScVal.fromXDR(scVal);
+
+  try {
+    return new I128([
+      BigInt(value.i128().lo().low),
+      BigInt(value.i128().lo().high),
+      BigInt(value.i128().hi().low),
+      BigInt(value.i128().hi().high),
+    ]).toString();
+  } catch (error) {
+    console.log(error);
+    return 0;
+  }
 };
 
 export const decodeBytesN = (scVal: Buffer) => {

--- a/@shared/api/helpers/xdr/bigint-encoder.ts
+++ b/@shared/api/helpers/xdr/bigint-encoder.ts
@@ -1,0 +1,85 @@
+// Ported from https://github.com/stellar/js-xdr/pull/96
+// Can remove this and use them through stellar base once it is merged
+
+/* eslint-disable */
+export function encodeBigIntFromBits(
+  parts: any[],
+  size: number,
+  unsigned: boolean,
+) {
+  let result = BigInt(0);
+  // check arguments length
+  if (parts.length && parts[0] instanceof Array) {
+    parts = parts[0];
+  }
+  const total = parts.length;
+  if (total === 1) {
+    try {
+      result = BigInt(parts[0]);
+      if (!unsigned) {
+        result = BigInt.asIntN(size, result);
+      }
+    } catch (e) {
+      throw new TypeError(`Invalid integer value: ${parts[0]}`);
+    }
+  } else {
+    const sliceSize = size / total;
+    if (sliceSize !== 32 && sliceSize !== 64 && sliceSize !== 128)
+      throw new TypeError("Invalid number of arguments");
+    // combine parts
+    for (let i = 0; i < total; i++) {
+      let part = BigInt.asUintN(sliceSize, BigInt(parts[i].valueOf()));
+      if (i > 0) {
+        // shift if needed
+        part <<= BigInt(i * sliceSize);
+      }
+      result |= part;
+    }
+    if (!unsigned) {
+      // clamp value to the requested size
+      result = BigInt.asIntN(size, result);
+    }
+  }
+  // check type
+  if (typeof result === "bigint") {
+    // check boundaries
+    const [min, max] = calculateBigIntBoundaries(size, unsigned);
+    if (result >= min && result <= max) return result;
+  }
+  // failed to encode
+  throw new TypeError(`Invalid ${formatIntName(size, unsigned)} value`);
+}
+
+export function sliceBigInt(value: BigInt, size: number, sliceSize: number) {
+  if (typeof value !== "bigint") throw new TypeError("Invalid BigInt value");
+  const total = size / sliceSize;
+  if (total === 1) return [value];
+  if (
+    sliceSize < 32 ||
+    sliceSize > 128 ||
+    (total !== 2 && total !== 4 && total !== 8)
+  )
+    throw new TypeError("Invalid slice size");
+  // prepare shift and mask
+  const shift = BigInt(sliceSize);
+  const mask = (BigInt(1) << shift) - BigInt(1);
+  // iterate shift and mask application
+  const result = new Array(total);
+  for (let i = 0; i < total; i++) {
+    if (i > 0) {
+      value >>= shift;
+    }
+    result[i] = BigInt.asIntN(sliceSize, value & mask); // clamp value
+  }
+  return result;
+}
+
+export function formatIntName(precision: number, unsigned: boolean) {
+  return `${unsigned ? "u" : "i"}${precision}`;
+}
+
+export function calculateBigIntBoundaries(size: number, unsigned: boolean) {
+  if (unsigned) return [BigInt(0), (BigInt(1) << BigInt(size)) - BigInt(1)];
+  const boundary = BigInt(1) << BigInt(size - 1);
+  return [BigInt(0) - boundary, boundary - BigInt(1)];
+}

--- a/@shared/api/helpers/xdr/errors.ts
+++ b/@shared/api/helpers/xdr/errors.ts
@@ -1,0 +1,25 @@
+export class XdrWriterError extends TypeError {
+  constructor(message: string) {
+    super(`XDR Write Error: ${message}`);
+  }
+}
+
+export class XdrReaderError extends TypeError {
+  constructor(message: string) {
+    super(`XDR Read Error: ${message}`);
+  }
+}
+
+export class XdrDefinitionError extends TypeError {
+  constructor(message: string) {
+    super(`XDR Type Definition Error: ${message}`);
+  }
+}
+
+export class XdrNotImplementedDefinitionError extends XdrDefinitionError {
+  constructor() {
+    super(
+      `method not implemented, it should be overloaded in the descendant class.`,
+    );
+  }
+}

--- a/@shared/api/helpers/xdr/i128.ts
+++ b/@shared/api/helpers/xdr/i128.ts
@@ -1,0 +1,17 @@
+import { LargeInt } from "./large-int";
+
+export class I128 extends LargeInt {
+  constructor(...args: any) {
+    super(args);
+  }
+
+  get unsigned(): any {
+    return false;
+  }
+
+  get size(): any {
+    return 128;
+  }
+}
+
+I128.defineIntBoundaries();

--- a/@shared/api/helpers/xdr/index.ts
+++ b/@shared/api/helpers/xdr/index.ts
@@ -1,0 +1,1 @@
+export * from "./i128";

--- a/@shared/api/helpers/xdr/large-int.ts
+++ b/@shared/api/helpers/xdr/large-int.ts
@@ -1,0 +1,131 @@
+// @ts-nocheck
+
+import { XdrPrimitiveType } from "./xdr-type";
+import {
+  calculateBigIntBoundaries,
+  encodeBigIntFromBits,
+  sliceBigInt,
+} from "./bigint-encoder";
+import { XdrNotImplementedDefinitionError, XdrWriterError } from "./errors";
+
+/* eslint-disable */
+
+/* tslint:disable */
+export class LargeInt extends XdrPrimitiveType {
+  constructor(args) {
+    super();
+    this._value = encodeBigIntFromBits(args, this.size, this.unsigned);
+  }
+
+  /**
+   * Signed/unsigned representation
+   * @type {Boolean}
+   * @abstract
+   */
+  get unsigned() {
+    throw new XdrNotImplementedDefinitionError();
+  }
+
+  /**
+   * Size of the integer in bits
+   * @type {Number}
+   * @abstract
+   */
+  get size() {
+    throw new XdrNotImplementedDefinitionError();
+  }
+
+  /**
+   * Slice integer to parts with smaller bit size
+   * @param {32|64|128} sliceSize - Size of each part in bits
+   * @return {BigInt[]}
+   */
+  slice(sliceSize) {
+    return sliceBigInt(this._value, this.size, sliceSize);
+  }
+
+  toString() {
+    return this._value.toString();
+  }
+
+  toJSON() {
+    return { _value: this._value.toString() };
+  }
+
+  /**
+   * @inheritDoc
+   */
+  static read(reader) {
+    const { size } = this.prototype;
+    if (size === 64) return new this(reader.readBigUInt64BE());
+    return new this(
+      ...Array.from({ length: size / 64 }, () =>
+        reader.readBigUInt64BE(),
+      ).reverse(),
+    );
+  }
+
+  /**
+   * @inheritDoc
+   */
+  static write(value, writer) {
+    if (value instanceof this) {
+      value = value._value;
+    } else if (
+      typeof value !== "bigint" ||
+      value > this.MAX_VALUE ||
+      value < this.MIN_VALUE
+    )
+      throw new XdrWriterError(`${value} is not a ${this.name}`);
+
+    const { unsigned, size } = this.prototype;
+    if (size === 64) {
+      if (unsigned) {
+        writer.writeBigUInt64BE(value);
+      } else {
+        writer.writeBigInt64BE(value);
+      }
+    } else {
+      for (const part of sliceBigInt(value, size, 64).reverse()) {
+        if (unsigned) {
+          writer.writeBigUInt64BE(part);
+        } else {
+          writer.writeBigInt64BE(part);
+        }
+      }
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  static isValid(value) {
+    return typeof value === "bigint" || value instanceof this;
+  }
+
+  /**
+   * Create instance from string
+   * @param {String} string - Numeric representation
+   * @return {LargeInt}
+   */
+  static fromString(string) {
+    return new this(string);
+  }
+
+  static MAX_VALUE = 0n;
+
+  static MIN_VALUE = 0n;
+
+  /**
+   * @internal
+   * @return {void}
+   */
+  static defineIntBoundaries() {
+    const [min, max] = calculateBigIntBoundaries(
+      this.prototype.size,
+      this.prototype.unsigned,
+    );
+    this.MIN_VALUE = min;
+    this.MAX_VALUE = max;
+  }
+}

--- a/@shared/api/helpers/xdr/serialization/xdr-reader.ts
+++ b/@shared/api/helpers/xdr/serialization/xdr-reader.ts
@@ -1,0 +1,86 @@
+import { XdrReaderError } from "../errors";
+
+export class XdrReader {
+  private _buffer: any;
+  private _length: number;
+  private _index: number;
+
+  constructor(source: any) {
+    if (!Buffer.isBuffer(source)) {
+      if (source instanceof Array) {
+        source = Buffer.from(source);
+      } else {
+        throw new XdrReaderError("source not specified");
+      }
+    }
+
+    this._buffer = source;
+    this._length = source.length;
+    this._index = 0;
+  }
+
+  get eof() {
+    return this._index === this._length;
+  }
+
+  advance(size: number) {
+    const from = this._index;
+    // advance cursor position
+    this._index += size;
+    // check buffer boundaries
+    if (this._length < this._index)
+      throw new XdrReaderError(
+        "attempt to read outside the boundary of the buffer",
+      );
+    // check that padding is correct for Opaque and String
+    const padding = 4 - (size % 4 || 4);
+    if (padding > 0) {
+      for (let i = 0; i < padding; i++)
+        if (this._buffer[this._index + i] !== 0)
+          // all bytes in the padding should be zeros
+          throw new XdrReaderError("invalid padding");
+      this._index += padding;
+    }
+    return from;
+  }
+
+  rewind() {
+    this._index = 0;
+  }
+
+  read(size: number) {
+    const from = this.advance(size);
+    return this._buffer.subarray(from, from + size);
+  }
+
+  readInt32BE() {
+    return this._buffer.readInt32BE(this.advance(4));
+  }
+
+  readUInt32BE() {
+    return this._buffer.readUInt32BE(this.advance(4));
+  }
+
+  readBigInt64BE() {
+    return this._buffer.readBigInt64BE(this.advance(8));
+  }
+
+  readBigUInt64BE() {
+    return this._buffer.readBigUInt64BE(this.advance(8));
+  }
+
+  readFloatBE() {
+    return this._buffer.readFloatBE(this.advance(4));
+  }
+
+  readDoubleBE() {
+    return this._buffer.readDoubleBE(this.advance(8));
+  }
+
+  ensureInputConsumed() {
+    if (this._index !== this._length)
+      throw new XdrReaderError(
+        `invalid XDR contract typecast - source buffer not entirely consumed`,
+      );
+  }
+}

--- a/@shared/api/helpers/xdr/serialization/xdr-writer.ts
+++ b/@shared/api/helpers/xdr/serialization/xdr-writer.ts
@@ -1,0 +1,103 @@
+const BUFFER_CHUNK = 8192; // 8 KB chunk size increment
+
+export class XdrWriter {
+  private _buffer: any;
+  private _length: any;
+
+  constructor(buffer: any) {
+    if (typeof buffer === "number") {
+      buffer = Buffer.allocUnsafe(buffer);
+    } else if (!(buffer instanceof Buffer)) {
+      buffer = Buffer.allocUnsafe(BUFFER_CHUNK);
+    }
+    this._buffer = buffer;
+    this._length = buffer.length;
+  }
+
+  _index = 0;
+
+  alloc(size: number) {
+    const from = this._index;
+    // advance cursor position
+    this._index += size;
+    // ensure sufficient buffer size
+    if (this._length < this._index) {
+      this.resize(this._index);
+    }
+    return from;
+  }
+
+  resize(minRequiredSize: number) {
+    // calculate new length, align new buffer length by chunk size
+    const newLength = Math.ceil(minRequiredSize / BUFFER_CHUNK) * BUFFER_CHUNK;
+    // create new buffer and copy previous data
+    const newBuffer = Buffer.allocUnsafe(newLength);
+    this._buffer.copy(newBuffer, 0, 0, this._length);
+    // update references
+    this._buffer = newBuffer;
+    this._length = newLength;
+  }
+
+  finalize() {
+    // clip underlying buffer to the actually written value
+    return this._buffer.subarray(0, this._index);
+  }
+
+  toArray() {
+    return [...this.finalize()];
+  }
+
+  write(value: any, size: number) {
+    if (typeof value === "string") {
+      // serialize string directly to the output buffer
+      const offset = this.alloc(size);
+      this._buffer.write(value, offset, "utf8");
+    } else {
+      // copy data to the output buffer
+      if (!(value instanceof Buffer)) {
+        value = Buffer.from(value);
+      }
+      const offset = this.alloc(size);
+      value.copy(this._buffer, offset, 0, size);
+    }
+
+    // add padding for 4-byte XDR alignment
+    const padding = 4 - (size % 4 || 4);
+    if (padding > 0) {
+      const offset = this.alloc(padding);
+      this._buffer.fill(0, offset, this._index);
+    }
+  }
+
+  writeInt32BE(value: string) {
+    const offset = this.alloc(4);
+    this._buffer.writeInt32BE(value, offset);
+  }
+
+  writeUInt32BE(value: string) {
+    const offset = this.alloc(4);
+    this._buffer.writeUInt32BE(value, offset);
+  }
+
+  writeBigInt64BE(value: string) {
+    const offset = this.alloc(8);
+    this._buffer.writeBigInt64BE(value, offset);
+  }
+
+  writeBigUInt64BE(value: string) {
+    const offset = this.alloc(8);
+    this._buffer.writeBigUInt64BE(value, offset);
+  }
+
+  writeFloatBE(value: string) {
+    const offset = this.alloc(4);
+    this._buffer.writeFloatBE(value, offset);
+  }
+
+  writeDoubleBE(value: string) {
+    const offset = this.alloc(8);
+    this._buffer.writeDoubleBE(value, offset);
+  }
+
+  static bufferChunkSize = BUFFER_CHUNK;
+}

--- a/@shared/api/helpers/xdr/xdr-type.ts
+++ b/@shared/api/helpers/xdr/xdr-type.ts
@@ -1,0 +1,171 @@
+// @ts-nocheck
+
+import { XdrReader } from "./serialization/xdr-reader";
+import { XdrWriter } from "./serialization/xdr-writer";
+import { XdrNotImplementedDefinitionError } from "./errors";
+
+/* eslint-disable */
+
+/* tslint:disable */
+class XdrType {
+  write: any;
+
+  toXDR(format = "raw") {
+    if (!this.write) return this.constructor.toXDR(this, format);
+
+    const writer = new XdrWriter();
+    this.write(this, writer);
+    return encodeResult(writer.finalize(), format);
+  }
+
+  fromXDR(input, format = "raw") {
+    if (!this.read) return this.constructor.fromXDR(input, format);
+
+    const reader = new XdrReader(decodeInput(input, format));
+    const result = this.read(reader);
+    reader.ensureInputConsumed();
+    return result;
+  }
+
+  /**
+   * Check whether input contains a valid XDR-encoded value
+   * @param {Buffer|String} input - XDR-encoded input data
+   * @param {XdrEncodingFormat} [format] - Encoding format (one of "raw", "hex", "base64")
+   * @return {Boolean}
+   */
+  validateXDR(input, format = "raw") {
+    try {
+      this.fromXDR(input, format);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /**
+   * Encode value to XDR format
+   * @param {this} value - Value to serialize
+   * @param {XdrEncodingFormat} [format] - Encoding format (one of "raw", "hex", "base64")
+   * @return {Buffer}
+   */
+  static toXDR(value, format = "raw") {
+    const writer = new XdrWriter();
+    this.write(value, writer);
+    return encodeResult(writer.finalize(), format);
+  }
+
+  /**
+   * Decode XDR-encoded value
+   * @param {Buffer|String} input - XDR-encoded input data
+   * @param {XdrEncodingFormat} [format] - Encoding format (one of "raw", "hex", "base64")
+   * @return {this}
+   */
+  static fromXDR(input, format = "raw") {
+    const reader = new XdrReader(decodeInput(input, format));
+    const result = this.read(reader);
+    reader.ensureInputConsumed();
+    return result;
+  }
+
+  /**
+   * Check whether input contains a valid XDR-encoded value
+   * @param {Buffer|String} input - XDR-encoded input data
+   * @param {XdrEncodingFormat} [format] - Encoding format (one of "raw", "hex", "base64")
+   * @return {Boolean}
+   */
+  static validateXDR(input, format = "raw") {
+    try {
+      this.fromXDR(input, format);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+}
+
+export class XdrPrimitiveType extends XdrType {
+  /**
+   * Read value from the XDR-serialized input
+   * @param {XdrReader} reader - XdrReader instance
+   * @return {this}
+   * @abstract
+   */
+  // eslint-disable-next-line no-unused-vars
+  static read(reader) {
+    throw new XdrNotImplementedDefinitionError();
+  }
+
+  /**
+   * Write XDR value to the buffer
+   * @param {this} value - Value to write
+   * @param {XdrWriter} writer - XdrWriter instance
+   * @return {void}
+   * @abstract
+   */
+  // eslint-disable-next-line no-unused-vars
+  static write(value, writer) {
+    throw new XdrNotImplementedDefinitionError();
+  }
+
+  /**
+   * Check whether XDR primitive value is valid
+   * @param {this} value - Value to check
+   * @return {Boolean}
+   * @abstract
+   */
+  // eslint-disable-next-line no-unused-vars
+  static isValid(value) {
+    return false;
+  }
+}
+
+export class XdrCompositeType extends XdrType {
+  // Every descendant should implement two methods: read(reader) and write(value, writer)
+
+  /**
+   * Check whether XDR primitive value is valid
+   * @param {this} value - Value to check
+   * @return {Boolean}
+   * @abstract
+   */
+  // eslint-disable-next-line no-unused-vars
+  isValid(value) {
+    return false;
+  }
+}
+
+class InvalidXdrEncodingFormatError extends TypeError {
+  constructor(format) {
+    super(`Invalid format ${format}, must be one of "raw", "hex", "base64"`);
+  }
+}
+
+function encodeResult(buffer, format) {
+  switch (format) {
+    case "raw":
+      return buffer;
+    case "hex":
+      return buffer.toString("hex");
+    case "base64":
+      return buffer.toString("base64");
+    default:
+      throw new InvalidXdrEncodingFormatError(format);
+  }
+}
+
+function decodeInput(input, format) {
+  switch (format) {
+    case "raw":
+      return input;
+    case "hex":
+      return Buffer.from(input, "hex");
+    case "base64":
+      return Buffer.from(input, "base64");
+    default:
+      throw new InvalidXdrEncodingFormatError(format);
+  }
+}
+
+/**
+ * @typedef {'raw'|'hex'|'base64'} XdrEncodingFormat
+ */

--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -24,11 +24,7 @@ import { getIconUrlFromIssuer } from "./helpers/getIconUrlFromIssuer";
 import { getDomainFromIssuer } from "./helpers/getDomainFromIssuer";
 import { stellarSdkServer } from "./helpers/stellarSdkServer";
 
-import {
-  decodeAccountIdentifier,
-  decodeScVal,
-  decodeBytesN,
-} from "./helpers/soroban";
+import { decodei128, decodeScVal, decodeBytesN } from "./helpers/soroban";
 
 const TRANSACTIONS_LIMIT = 100;
 
@@ -874,7 +870,7 @@ export const getSorobanTokenBalance = (
   const txs: TxToOp = {
     balance: {
       tx: balanceTx,
-      decoder: decodeAccountIdentifier,
+      decoder: decodei128,
     },
     name: {
       tx: nameTx,

--- a/extension/src/popup/helpers/__tests__/formatters.test.js
+++ b/extension/src/popup/helpers/__tests__/formatters.test.js
@@ -1,0 +1,17 @@
+import BigNumber from "bignumber.js";
+import { formatAmount } from "../formatters";
+import { formatTokenAmount } from "../soroban";
+
+describe("formatAmount", () => {
+  it("should format a value", () => {
+    const value = "1000.0001000";
+    const formatted = "1,000.0001000";
+    expect(formatAmount(value, value, 7).amount).toBe(formatted);
+  });
+
+  it("should format a token value", () => {
+    const value = new BigNumber("10000001000");
+    const formatted = "1000.0001";
+    expect(formatTokenAmount(value, 7)).toBe(formatted);
+  });
+});


### PR DESCRIPTION
[Ticket](https://stellarorg.atlassian.net/jira/software/c/projects/WAL/boards/36?modal=detail&selectedIssue=WAL-809)

Reported in Discord. Issue opened here. https://github.com/stellar/freighter/issues/815

For some values, our `i128` decoder which was previously named `decodeAccountIdentifier` fails to correctly represent the balance value.

Renames `decodeAccountIdentifier` to `decodei128`
Ports`i128` xdr decoder and deps from [this open PR](https://github.com/stellar/js-xdr/pull/96/files), can eventually be deleted when this is merged and available through stellar base.
Uses `i128` decoder to correctly decode sc val from response.