### PR TITLE
normalize any faulty localstorage data and better naming for storage

### DIFF
--- a/extension/src/background/helpers/account.ts
+++ b/extension/src/background/helpers/account.ts
@@ -14,10 +14,10 @@ import { decodeString, encodeObject } from "helpers/urls";
 import { isMainnet, isTestnet, isFuturenet } from "helpers/stellar";
 import {
   dataStorageAccess,
-  localStorage,
+  browserLocalStorage,
 } from "background/helpers/dataStorage";
 
-const localStore = dataStorageAccess(localStorage);
+const localStore = dataStorageAccess(browserLocalStorage);
 
 export const getKeyIdList = async () =>
   (await localStore.getItem(KEY_ID_LIST)) || [];

--- a/extension/src/background/helpers/allowListAuthorization.ts
+++ b/extension/src/background/helpers/allowListAuthorization.ts
@@ -4,7 +4,7 @@ import { ALLOWLIST_ID } from "constants/localStorageTypes";
 import { getUrlHostname, getPunycodedDomain } from "helpers/urls";
 import {
   dataStorageAccess,
-  localStorage,
+  browserLocalStorage,
 } from "background/helpers/dataStorage";
 
 export const isSenderAllowed = async ({
@@ -12,7 +12,7 @@ export const isSenderAllowed = async ({
 }: {
   sender: browser.Runtime.MessageSender;
 }) => {
-  const localStore = dataStorageAccess(localStorage);
+  const localStore = dataStorageAccess(browserLocalStorage);
   const allowListStr = (await localStore.getItem(ALLOWLIST_ID)) || "";
   const allowList = allowListStr.split(",");
 

--- a/extension/src/background/helpers/cachedFetch.ts
+++ b/extension/src/background/helpers/cachedFetch.ts
@@ -1,9 +1,9 @@
 import {
   dataStorageAccess,
-  localStorage,
+  browserLocalStorage,
 } from "background/helpers/dataStorage";
 
-const localStore = dataStorageAccess(localStorage);
+const localStore = dataStorageAccess(browserLocalStorage);
 
 export const cachedFetch = async (url: string, storageKey: string) => {
   const cachedDateId = `${storageKey}_date`;

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -10,7 +10,10 @@ import { popupMessageListener } from "./messageListener/popupMessageListener";
 import { freighterApiMessageListener } from "./messageListener/freighterApiMessageListener";
 import { SESSION_ALARM_NAME } from "./helpers/session";
 import { timeoutAccountAccess } from "./ducks/session";
-import { migrateFriendBotUrlNetworkDetails } from "./helpers/dataStorage";
+import {
+  migrateFriendBotUrlNetworkDetails,
+  normalizeMigratedData,
+} from "./helpers/dataStorage";
 
 export const initContentScriptMessageListener = () => {
   browser?.runtime?.onMessage?.addListener((message) => {
@@ -52,6 +55,7 @@ export const initInstalledListener = () => {
     }
   });
   browser?.runtime?.onInstalled.addListener(migrateFriendBotUrlNetworkDetails);
+  browser?.runtime?.onInstalled.addListener(normalizeMigratedData);
 };
 
 export const initAlarmListener = (sessionStore: Store) => {

--- a/extension/src/background/messageListener/freighterApiMessageListener.ts
+++ b/extension/src/background/messageListener/freighterApiMessageListener.ts
@@ -30,13 +30,13 @@ import { cachedFetch } from "background/helpers/cachedFetch";
 import { encodeObject, getUrlHostname, getPunycodedDomain } from "helpers/urls";
 import {
   dataStorageAccess,
-  localStorage,
+  browserLocalStorage,
 } from "background/helpers/dataStorage";
 import { publicKeySelector } from "background/ducks/session";
 
 import { responseQueue, transactionQueue } from "./popupMessageListener";
 
-const localStore = dataStorageAccess(localStorage);
+const localStore = dataStorageAccess(browserLocalStorage);
 
 interface WINDOW_PARAMS {
   height: number;

--- a/extension/src/background/messageListener/popupMessageListener.ts
+++ b/extension/src/background/messageListener/popupMessageListener.ts
@@ -63,7 +63,7 @@ import { SessionTimer } from "background/helpers/session";
 import { cachedFetch } from "background/helpers/cachedFetch";
 import {
   dataStorageAccess,
-  localStorage,
+  browserLocalStorage,
 } from "background/helpers/dataStorage";
 
 import {
@@ -100,9 +100,9 @@ interface KeyPair {
 }
 
 export const popupMessageListener = (request: Request, sessionStore: Store) => {
-  const localStore = dataStorageAccess(localStorage);
+  const localStore = dataStorageAccess(browserLocalStorage);
   const localKeyStore = new KeyManagerPlugins.BrowserStorageKeyStore();
-  localKeyStore.configure({ storage: localStorage });
+  localKeyStore.configure({ storage: browserLocalStorage });
   const keyManager = new KeyManager({
     keyStore: localKeyStore,
   });
@@ -976,8 +976,7 @@ export const popupMessageListener = (request: Request, sessionStore: Store) => {
       isExperimentalModeEnabled,
     } = request;
 
-    const currentIsExperimentalModeEnabled =
-      await getIsExperimentalModeEnabled();
+    const currentIsExperimentalModeEnabled = await getIsExperimentalModeEnabled();
 
     await localStore.setItem(DATA_SHARING_ID, isDataSharingAllowed);
     await localStore.setItem(IS_VALIDATING_MEMO_ID, isMemoValidationEnabled);
@@ -1133,9 +1132,7 @@ export const popupMessageListener = (request: Request, sessionStore: Store) => {
 
   const addTokenId = async () => {
     const { tokenId } = request;
-    const tokenIdList = JSON.parse(
-      (await localStore.getItem(TOKEN_ID_LIST)) || "{}",
-    );
+    const tokenIdList = (await localStore.getItem(TOKEN_ID_LIST)) || {};
     const keyId = (await localStore.getItem(KEY_ID)) || "";
 
     const accountTokenIdList = tokenIdList[keyId] || [];
@@ -1183,8 +1180,7 @@ export const popupMessageListener = (request: Request, sessionStore: Store) => {
     [SERVICE_TYPES.HANDLE_SIGNED_HW_TRANSACTION]: handleSignedHwTransaction,
     [SERVICE_TYPES.REJECT_TRANSACTION]: rejectTransaction,
     [SERVICE_TYPES.SIGN_FREIGHTER_TRANSACTION]: signFreighterTransaction,
-    [SERVICE_TYPES.SIGN_FREIGHTER_SOROBAN_TRANSACTION]:
-      signFreighterSorobanTransaction,
+    [SERVICE_TYPES.SIGN_FREIGHTER_SOROBAN_TRANSACTION]: signFreighterSorobanTransaction,
     [SERVICE_TYPES.ADD_RECENT_ADDRESS]: addRecentAddress,
     [SERVICE_TYPES.LOAD_RECENT_ADDRESSES]: loadRecentAddresses,
     [SERVICE_TYPES.SIGN_OUT]: signOut,

--- a/extension/src/background/store.ts
+++ b/extension/src/background/store.ts
@@ -5,13 +5,13 @@ import { sessionSlice } from "background/ducks/session";
 import {
   SESSION_STORAGE_ENABLED,
   dataStorageAccess,
-  sessionStorage,
+  browserSessionStorage,
 } from "./helpers/dataStorage";
 
 // Session storage can be used to persist redux store in Manifest v3 because service workers go idle after 30 seconds
 // Session storage is not currently supported in Firefox, which blocks our migration to using this by default
 const REDUX_STORE_KEY = "session-store";
-const sessionStore = dataStorageAccess(sessionStorage);
+const sessionStore = dataStorageAccess(browserSessionStorage);
 
 export async function loadState() {
   try {


### PR DESCRIPTION
I ran into an edge case where I added a token id in 4.0.2 and the `migrateLocalStorageToBrowserStorage` function didn't run. When I switched to 5.0.0, my token data was in stringified json instead of just an object. This is an issue we keep running into in this migration, so I created a script that runs on install that finds any weird data and puts it into the right form for 5.0.0

This also led me to discover that it was a mistake to name the `browser.storage.local` var as `localStorage` because `localStorage` is a reserved var name when `window.localStorage` is available. So I had to rename the storage var's, as well. Not married to the new names. Open to suggestions there