### PR TITLE
[BUGFIX] Safely sets title default when tab title is not present

### DIFF
--- a/extension/src/popup/views/GrantAccess.tsx
+++ b/extension/src/popup/views/GrantAccess.tsx
@@ -28,10 +28,9 @@ export const GrantAccess = () => {
   const dispatch = useDispatch();
   const [isGranting, setIsGranting] = useState(false);
 
-  const {
-    tab: { title = "" },
-    url,
-  } = parsedSearchParam(location.search);
+  const { tab, url } = parsedSearchParam(location.search);
+
+  const title = tab && tab.title ? tab.title : "";
 
   const domain = getUrlHostname(url);
   const publicKey = useSelector(publicKeySelector);


### PR DESCRIPTION
Ticket: https://stellarorg.atlassian.net/browse/WAL-875

This is an edge case that happens when an external api call is made to Freighter but Freighter requires the user to login. In that case, the GrantAccess is rendered without a tab title and the helper does not always return a `tab`.