### PR TITLE
feat: make compatible with node envs

### DIFF
--- a/@stellar/freighter-api/jest.config.js
+++ b/@stellar/freighter-api/jest.config.js
@@ -1,5 +1,0 @@
-const parentConfig = require("../../jest.config");
-
-module.exports = {
-  ...parentConfig
-};

--- a/@stellar/freighter-api/src/getNetwork.ts
+++ b/@stellar/freighter-api/src/getNetwork.ts
@@ -1,3 +1,5 @@
 import { requestNetwork } from "@shared/api/external";
+import { isBrowser } from ".";
 
-export const getNetwork = () => requestNetwork();
+export const getNetwork = (): Promise<string> =>
+  isBrowser ? requestNetwork() : Promise.resolve("");

--- a/@stellar/freighter-api/src/getNetworkDetails.ts
+++ b/@stellar/freighter-api/src/getNetworkDetails.ts
@@ -1,3 +1,15 @@
 import { requestNetworkDetails } from "@shared/api/external";
+import { isBrowser } from ".";
 
-export const getNetworkDetails = () => requestNetworkDetails();
+export const getNetworkDetails = (): Promise<{
+  network: string;
+  networkUrl: string;
+  networkPassphrase: string;
+}> =>
+  isBrowser
+    ? requestNetworkDetails()
+    : Promise.resolve({
+        network: "",
+        networkUrl: "",
+        networkPassphrase: "",
+      });

--- a/@stellar/freighter-api/src/getPublicKey.ts
+++ b/@stellar/freighter-api/src/getPublicKey.ts
@@ -1,3 +1,5 @@
 import { requestPublicKey } from "@shared/api/external";
+import { isBrowser } from ".";
 
-export const getPublicKey = () => requestPublicKey();
+export const getPublicKey = (): Promise<string> =>
+  isBrowser ? requestPublicKey() : Promise.resolve("");

--- a/@stellar/freighter-api/src/getUserInfo.ts
+++ b/@stellar/freighter-api/src/getUserInfo.ts
@@ -1,3 +1,5 @@
 import { requestUserInfo } from "@shared/api/external";
+import { isBrowser } from ".";
 
-export const getUserInfo = () => requestUserInfo();
+export const getUserInfo = (): Promise<{ publicKey: string }> =>
+  isBrowser ? requestUserInfo() : Promise.resolve({ publicKey: "" });

--- a/@stellar/freighter-api/src/index.ts
+++ b/@stellar/freighter-api/src/index.ts
@@ -7,6 +7,8 @@ import { isAllowed } from "./isAllowed";
 import { setAllowed } from "./setAllowed";
 import { getUserInfo } from "./getUserInfo";
 
+export const isBrowser = typeof window !== "undefined";
+
 export {
   getPublicKey,
   signTransaction,

--- a/@stellar/freighter-api/src/isAllowed.ts
+++ b/@stellar/freighter-api/src/isAllowed.ts
@@ -1,3 +1,5 @@
 import { requestAllowedStatus } from "@shared/api/external";
+import { isBrowser } from ".";
 
-export const isAllowed = () => requestAllowedStatus();
+export const isAllowed = (): Promise<boolean> =>
+  isBrowser ? requestAllowedStatus() : Promise.resolve(false);

--- a/@stellar/freighter-api/src/isConnected.ts
+++ b/@stellar/freighter-api/src/isConnected.ts
@@ -1,8 +1,11 @@
 import { requestConnectionStatus } from "@shared/api/external";
+import { isBrowser } from ".";
 
-export const isConnected = () => {
-  if (window?.freighter) {
-    return window.freighter;
+export const isConnected = (): Promise<boolean> => {
+  if (!isBrowser) return Promise.resolve(false);
+
+  if (window.freighter) {
+    return Promise.resolve(window.freighter);
   }
 
   return requestConnectionStatus();

--- a/@stellar/freighter-api/src/setAllowed.ts
+++ b/@stellar/freighter-api/src/setAllowed.ts
@@ -1,3 +1,5 @@
 import { setAllowedStatus } from "@shared/api/external";
+import { isBrowser } from ".";
 
-export const setAllowed = () => setAllowedStatus();
+export const setAllowed = (): Promise<boolean> =>
+  isBrowser ? setAllowedStatus() : Promise.resolve(false);

--- a/@stellar/freighter-api/src/signTransaction.ts
+++ b/@stellar/freighter-api/src/signTransaction.ts
@@ -1,4 +1,5 @@
 import { submitTransaction } from "@shared/api/external";
+import { isBrowser } from ".";
 
 export const signTransaction = (
   transactionXdr: string,
@@ -7,4 +8,5 @@ export const signTransaction = (
     networkPassphrase?: string;
     accountToSign?: string;
   }
-) => submitTransaction(transactionXdr, opts);
+): Promise<string> =>
+  isBrowser ? submitTransaction(transactionXdr, opts) : Promise.resolve("");

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 const esModules = ["@stellar/wallet-sdk"];
 
-module.exports = {
+const jsdomTests = {
   rootDir: __dirname,
   roots: ["./", "./extension", "./@shared/api", "./@stellar/freighter-api"],
   collectCoverageFrom: ["src/**/*.{ts,tsx,mjs}"],
@@ -27,4 +27,17 @@ module.exports = {
   moduleFileExtensions: ["js", "jsx", "json", "node", "mjs", "ts", "tsx"],
   moduleDirectories: ["node_modules", "<rootDir>/extension/src", "<rootDir>/."],
   testEnvironment: "jsdom",
+};
+
+module.exports = {
+  projects: [
+    {
+      displayName: "jsdom",
+      ...jsdomTests,
+    },
+    {
+      displayName: "node",
+      testMatch: ["<rootDir>/testNodeCompat.js"],
+    },
+  ],
 };

--- a/testNodeCompat.js
+++ b/testNodeCompat.js
@@ -1,0 +1,9 @@
+import * as publicInterface from "@stellar/freighter-api";
+
+describe.each(Object.keys(publicInterface.default))("%s", (fn) => {
+  test("exits gracefully in node", async () => {
+    // just call the function and make sure it doesn't throw
+    // in node, all of them should exit gracefully before even checking args, so we can pass nothing
+    await publicInterface[fn]();
+  });
+});


### PR DESCRIPTION
You can see that a recent addition of `isConnected` to some app logic caused my builds to start failing: https://github.com/stellar/soroban-example-dapp/pull/117/commits

In general, Freighter needs to be careful to exit gracefully in Node, in order to support isomorphic/universal apps, and even just build scripts for NextJS and such. There's no reason to make app authors perform these checks themselves.

The messiest part of this was getting the types to be sensible. This part is also somewhat untested! However, since the exports from `@stellar/freighter-api/src/*` are all pretty thin wrappers around other logic, the hard-coded types I've added here to those files should alert us to problems if the functions they wrap change signatures.