### PR TITLE
[BUG] properly handles display formatting for 0 decimal tokens

### DIFF
--- a/extension/src/popup/components/account/AccountAssets/styles.scss
+++ b/extension/src/popup/components/account/AccountAssets/styles.scss
@@ -26,6 +26,8 @@ $loader-light-color: #444961;
 
     &--lp-share,
     &--soroban-token {
+      height: 32px;
+      width: 32px;
       background: var(--pal-background-secondary);
       border-radius: 2rem;
       display: flex;

--- a/extension/src/popup/components/account/AssetDetail/index.tsx
+++ b/extension/src/popup/components/account/AssetDetail/index.tsx
@@ -87,13 +87,15 @@ export const AssetDetail = ({
           Number(balance.decimals),
         )
       : (balance && new BigNumber(balance?.total).toString()) || "0";
-  const balanceTotal = `${total} ${canonical.code}`;
 
   const balanceAvailable = getAvailableBalance({
     accountBalances,
     selectedAsset,
     subentryCount,
   });
+
+  const availableTotal = `${formatAmount(balanceAvailable)} ${canonical.code}`;
+  const displayTotal = `${formatAmount(total)} ${canonical.code}`;
 
   const stellarExpertUrl = getStellarExpertUrl(networkDetails);
 
@@ -138,7 +140,7 @@ export const AssetDetail = ({
         {isNative ? (
           <div className="AssetDetail__available">
             <span className="AssetDetail__available__copy">
-              {formatAmount(balanceAvailable)} {canonical.code} {t("available")}
+              {availableTotal} {t("available")}
             </span>
             <span
               className="AssetDetail__available__icon"
@@ -153,7 +155,7 @@ export const AssetDetail = ({
             className="AssetDetail__total__copy"
             data-testid="asset-detail-available-copy"
           >
-            {formatAmount(balanceTotal)}
+            {displayTotal}
           </div>
           <div className="AssetDetail__total__network">
             <AssetNetworkInfo
@@ -272,12 +274,12 @@ export const AssetDetail = ({
                 <img src={StellarLogo} alt="Network icon" />{" "}
                 <div>{canonical.code}</div>
               </div>
-              <div>{formatAmount(balanceTotal)}</div>
+              <div>{displayTotal}</div>
             </div>
             <div className="AssetDetail__info-modal__available-box">
               <div className="AssetDetail__info-modal__balance-row">
                 <div>{t("Total Balance")}</div>
-                <div>{formatAmount(balanceTotal)}</div>
+                <div>{displayTotal}</div>
               </div>
               <div className="AssetDetail__info-modal__balance-row">
                 <div>{t("Reserved Balance*")}</div>
@@ -297,9 +299,7 @@ export const AssetDetail = ({
               </div>
               <div className="AssetDetail__info-modal__total-available-row">
                 <div>{t("Total Available")}</div>
-                <div>
-                  {formatAmount(balanceAvailable)} {canonical.code}
-                </div>
+                <div>{availableTotal}</div>
               </div>
             </div>
             <div className="AssetDetail__info-modal__footnote">

--- a/extension/src/popup/helpers/soroban.ts
+++ b/extension/src/popup/helpers/soroban.ts
@@ -42,16 +42,21 @@ export const getAssetDecimals = (
 
 // Adopted from https://github.com/ethers-io/ethers.js/blob/master/packages/bignumber/src.ts/fixednumber.ts#L27
 export const formatTokenAmount = (amount: BigNumber, decimals: number) => {
-  let formatted = amount.shiftedBy(-decimals).toFixed(decimals).toString();
+  let formatted = amount.toString();
 
-  // Trim trailing zeros
-  while (formatted[formatted.length - 1] === "0") {
-    formatted = formatted.substring(0, formatted.length - 1);
+  if (decimals > 0) {
+    formatted = amount.shiftedBy(-decimals).toFixed(decimals).toString();
+
+    // Trim trailing zeros
+    while (formatted[formatted.length - 1] === "0") {
+      formatted = formatted.substring(0, formatted.length - 1);
+    }
+
+    if (formatted.endsWith(".")) {
+      formatted = formatted.substring(0, formatted.length - 1);
+    }
   }
 
-  if (formatted.endsWith(".")) {
-    formatted = formatted.substring(0, formatted.length - 1);
-  }
   return formatted;
 };
 


### PR DESCRIPTION
This was reported in Discord, bad handling of display formatting for 0 decimal tokens.
Ticket: https://stellarorg.atlassian.net/browse/WAL-919
Discord report: https://discord.com/channels/897514728459468821/1019346446014759013/1119625539460792370

This adds logic to properly handle display formatting for Tokens that are set to have 0 decimal places.
Also fixes a display bug for the token placeholder image.

Test token - `52b440f11811a4bc1c8f118839c63d5d5c1d78af569a0a4605ad37b6ae3a8e92`
Ping @aristidesstaffieri to get some minted to your address, or deploy a 0 decimal token to test.