### PR TITLE
refactors getTxArgs to be able to use args instead of auth args

### DIFF
--- a/@shared/api/helpers/soroban.ts
+++ b/@shared/api/helpers/soroban.ts
@@ -16,7 +16,6 @@ export const valueToI128String = (value: SorobanClient.xdr.ScVal) =>
     BigInt(value.i128().hi().high),
   ]).toString();
 
-// How do we decode these in a more generic way?
 export const decodei128 = (xdr: string) => {
   const value = SorobanClient.xdr.ScVal.fromXDR(xdr, "base64");
   try {


### PR DESCRIPTION
Bringing these learnings back from the example dapps.

It turns out that our arg parsing here kinda worked by coincidence. Since both mint & transfer on the token interface only use tx arg, auth args had all arguments but in any case that uses auth next this will only represent the args that were used in contract auth.

This updates our helpers to pull args from `hostFn.args` instead which is the raw list of `[contractId, methodSymbol, ...method arguments]`