### PR TITLE
Bugfix/fix firefox sign tx error (#894)

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -492,14 +492,9 @@ export const handleSignedHwTransaction = async ({
   }
 };
 
-export const signTransaction = async ({
-  transaction,
-}: {
-  transaction: {};
-}): Promise<void> => {
+export const signTransaction = async (): Promise<void> => {
   try {
     await sendMessageToBackground({
-      transaction,
       type: SERVICE_TYPES.SIGN_TRANSACTION,
     });
   } catch (e) {

--- a/extension/src/popup/views/IntegrationTest.tsx
+++ b/extension/src/popup/views/IntegrationTest.tsx
@@ -252,7 +252,7 @@ export const IntegrationTest = () => {
       await handleSignedHwTransaction({ signedTransaction: "" });
       runAsserts("handleSignedHwTransaction", () => {});
 
-      await signTransaction({ transaction: testTxXDR });
+      await signTransaction();
       runAsserts("signTransaction", () => {});
 
       res = await signFreighterTransaction({

--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -141,7 +141,7 @@ export const SignTransaction = () => {
       );
       setStartedHwSign(true);
     } else {
-      await dispatch(signTransaction({ transaction }));
+      await dispatch(signTransaction());
       window.close();
     }
   };


### PR DESCRIPTION
* if we are unable to parse the args, fail gracefully

* don't pass transaction to signTransaction