### PR TITLE
Feature/edge support

### DIFF
--- a/.github/workflows/submitProduction.yml
+++ b/.github/workflows/submitProduction.yml
@@ -109,6 +109,14 @@ jobs:
           client-id: ${{ secrets.EXTENSION_CLIENT_ID }}
           client-secret: ${{ secrets.EXTENSION_CLIENT_SECRET }}
           refresh-token: ${{ secrets.EXTENSION_REFRESH_TOKEN }}
+      - name: Submit extension to Edge
+        uses: wdzeng/edge-addon@v1
+        with:
+          product-id: ${{ secrets.EDGE_PRODUCT_ID }}
+          zip-path: ${{ secrets.EDGE_ZIP_PATH }}
+          client-id: ${{ secrets.EDGE_CLIENT_ID }}
+          client-secret: ${{ secrets.EDGE_CLIENT_SECRET }}
+          access-token-url: ${{ secrets.EDGE_ACCESS_TOKEN_URL }}
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 #v2.2.0
         env:

--- a/.github/workflows/submitProduction.yml
+++ b/.github/workflows/submitProduction.yml
@@ -109,14 +109,14 @@ jobs:
           client-id: ${{ secrets.EXTENSION_CLIENT_ID }}
           client-secret: ${{ secrets.EXTENSION_CLIENT_SECRET }}
           refresh-token: ${{ secrets.EXTENSION_REFRESH_TOKEN }}
-      - name: Submit extension to Edge
-        uses: wdzeng/edge-addon@v1
-        with:
-          product-id: ${{ secrets.EDGE_PRODUCT_ID }}
-          zip-path: ${{ secrets.EDGE_ZIP_PATH }}
-          client-id: ${{ secrets.EDGE_CLIENT_ID }}
-          client-secret: ${{ secrets.EDGE_CLIENT_SECRET }}
-          access-token-url: ${{ secrets.EDGE_ACCESS_TOKEN_URL }}
+      # - name: Submit extension to Edge
+      #   uses: wdzeng/edge-addon@v1
+      #   with:
+      #     product-id: ${{ secrets.EDGE_PRODUCT_ID }}
+      #     zip-path: ${{ secrets.EDGE_ZIP_PATH }}
+      #     client-id: ${{ secrets.EDGE_CLIENT_ID }}
+      #     client-secret: ${{ secrets.EDGE_CLIENT_SECRET }}
+      #     access-token-url: ${{ secrets.EDGE_ACCESS_TOKEN_URL }}
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@12e36fc18b0689399306c2e0b3e0f2978b7f1ee7 #v2.2.0
         env:


### PR DESCRIPTION
This adds a job(commented out until we get account from ops) to deploy our bundle to the edge store. I leave it commented because it sounds like we won't get past legal/ops in this sprint so I think we can leave this and comment in back in once we have an account and secrets provisioned. 