### PR TITLE
fixes bad references to request/response keys in the listener layer

### DIFF
--- a/@shared/api/external.ts
+++ b/@shared/api/external.ts
@@ -21,7 +21,7 @@ export const requestPublicKey = async (): Promise<string> => {
 };
 
 export const submitTransaction = async (
-  blob: string,
+  transactionXdr: string,
   opts?:
     | string
     | {
@@ -52,7 +52,7 @@ export const submitTransaction = async (
   let response = { signedTransaction: "", error: "" };
   try {
     response = await sendMessageToContentScript({
-      blob,
+      transactionXdr,
       network,
       networkPassphrase,
       accountToSign: _accountToSign,
@@ -81,7 +81,7 @@ export const submitBlob = async (
   const { network, networkPassphrase, accountToSign } = opts;
   try {
     response = await sendMessageToContentScript({
-      transactionXDR: blob,
+      transactionXdr: blob,
       network,
       networkPassphrase,
       accountToSign,

--- a/extension/src/background/messageListener/freighterApiMessageListener.ts
+++ b/extension/src/background/messageListener/freighterApiMessageListener.ts
@@ -266,13 +266,13 @@ export const freighterApiMessageListener = (
           }),
         );
       }
-      const response = (signedBlob: string) => {
-        if (signedBlob) {
+      const response = (signedTransaction: string) => {
+        if (signedTransaction) {
           if (!isDomainListedAllowed) {
             allowList.push(punycodedDomain);
             localStore.setItem(ALLOWLIST_ID, allowList.join());
           }
-          resolve({ signedBlob });
+          resolve({ signedTransaction });
         }
 
         resolve({ error: "User declined access" });


### PR DESCRIPTION
I named these incorrectly when splitting the tx and blob paths, tested locally on both paths.