### PR TITLE
hash preimage xdr before signing in signAuthEntry

### DIFF
--- a/extension/src/background/messageListener/popupMessageListener.ts
+++ b/extension/src/background/messageListener/popupMessageListener.ts
@@ -965,7 +965,7 @@ export const popupMessageListener = (request: Request, sessionStore: Store) => {
       const authEntry = authEntryQueue.pop();
 
       const response = authEntry
-        ? await sourceKeys.sign(Buffer.from(authEntry.entry))
+        ? await sourceKeys.sign(Buffer.from(SorobanSdk.hash(Buffer.from(authEntry.entry))))
         : null;
 
       const entryResponse = responseQueue.pop();

--- a/extension/src/popup/components/signAuthEntry/AuthEntry/index.tsx
+++ b/extension/src/popup/components/signAuthEntry/AuthEntry/index.tsx
@@ -7,16 +7,17 @@ import { buildInvocationTree } from "../invocation";
 import "./styles.scss";
 
 interface TransactionProps {
-  authEntryXdr: string;
+  preimageXdr: string;
 }
 
-export const AuthEntry = ({ authEntryXdr }: TransactionProps) => {
+export const AuthEntry = ({ preimageXdr }: TransactionProps) => {
   const { t } = useTranslation();
-  const authEntry = xdr.SorobanAuthorizationEntry.fromXDR(
-    authEntryXdr,
+  const preimage = xdr.HashIdPreimage.fromXDR(
+    preimageXdr,
     "base64",
   );
-  const rootJson = buildInvocationTree(authEntry.rootInvocation());
+
+  const rootJson = buildInvocationTree(preimage.sorobanAuthorization().invocation());
 
   return (
     <div className="AuthEntry">

--- a/extension/src/popup/views/SignAuthEntry/index.tsx
+++ b/extension/src/popup/views/SignAuthEntry/index.tsx
@@ -184,7 +184,7 @@ export const SignAuthEntry = () => {
             isMemoRequired={false}
             transaction={{ _operations: [{ auth: params.entry }] }}
           /> */}
-          <AuthEntry authEntryXdr={params.entry} />
+          <AuthEntry preimageXdr={params.entry} />
         </ModalWrapper>
         <ButtonsContainer>
           <Button


### PR DESCRIPTION
This API actually takes a preimage xdr in order to be able to keep access to the root invocation, but the required signature should be the hash of this.