### PR TITLE
[BUG] tweaks css so that remove trustline is not hidden

### DIFF
--- a/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/styles.scss
+++ b/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/styles.scss
@@ -90,7 +90,7 @@
 
   &__suggest-remove-tl {
     position: absolute;
-    top: calc(var(--popup--height) - 3.75 * var(--continue-btn-height));
+    top: calc(var(--popup--height) - 5.75 * var(--continue-btn-height));
     width: calc(var(--popup--width) - 2 * var(--popup--side-padding));
 
     .remove-tl-contents {


### PR DESCRIPTION
Tweaks styles so that the "remove trustline" button is not hidden when a user empties their balance of an asset on the classic side.
Ticket: https://stellarorg.atlassian.net/browse/WAL-1143

Before:
![Screenshot 2023-09-27 at 9 32 52 AM](https://github.com/stellar/freighter/assets/6886006/29a4b9d0-e02f-4c1b-9322-c34f15e588c4)

After:
![Screenshot 2023-09-27 at 9 34 15 AM](https://github.com/stellar/freighter/assets/6886006/1d9801db-f0ae-4dfb-8821-e4b1efb0c665)
