### PR TITLE
[BUG] Allows Soroban RPC URLS in API response when available

### DIFF
--- a/@shared/api/external.ts
+++ b/@shared/api/external.ts
@@ -1,4 +1,5 @@
 import { EXTERNAL_SERVICE_TYPES } from "../constants/services";
+import { NetworkDetails } from "../constants/stellar";
 import { sendMessageToContentScript } from "./helpers/extensionMessaging";
 import { UserInfo } from "./types";
 
@@ -145,6 +146,7 @@ export const requestNetworkDetails = async (): Promise<{
   network: string;
   networkUrl: string;
   networkPassphrase: string;
+  sorobanRpcUrl?: string;
 }> => {
   let response = {
     networkDetails: {
@@ -152,7 +154,8 @@ export const requestNetworkDetails = async (): Promise<{
       networkName: "",
       networkUrl: "",
       networkPassphrase: "",
-    },
+      sorobanRpcUrl: undefined,
+    } as NetworkDetails,
     error: "",
   };
   try {
@@ -164,12 +167,17 @@ export const requestNetworkDetails = async (): Promise<{
   }
 
   const { networkDetails, error } = response;
-  const { network, networkUrl, networkPassphrase } = networkDetails;
+  const {
+    network,
+    networkUrl,
+    networkPassphrase,
+    sorobanRpcUrl,
+  } = networkDetails;
 
   if (error) {
     throw error;
   }
-  return { network, networkUrl, networkPassphrase };
+  return { network, networkUrl, networkPassphrase, sorobanRpcUrl };
 };
 
 export const requestConnectionStatus = async (): Promise<boolean> => {

--- a/@stellar/freighter-api/package.json
+++ b/@stellar/freighter-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/freighter-api",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "Apache-2.0",
   "author": "Stellar Development Foundation <hello@stellar.org>",
   "description": "Utility functions to interact with Freighter extension",

--- a/@stellar/freighter-api/src/getNetworkDetails.ts
+++ b/@stellar/freighter-api/src/getNetworkDetails.ts
@@ -5,6 +5,7 @@ export const getNetworkDetails = (): Promise<{
   network: string;
   networkUrl: string;
   networkPassphrase: string;
+  sorobanRpcUrl?: string;
 }> =>
   isBrowser
     ? requestNetworkDetails()
@@ -12,4 +13,5 @@ export const getNetworkDetails = (): Promise<{
         network: "",
         networkUrl: "",
         networkPassphrase: "",
+        sorobanRpcUrl: "",
       });

--- a/extension/src/background/helpers/account.ts
+++ b/extension/src/background/helpers/account.ts
@@ -102,7 +102,7 @@ export const getBipPath = async () => {
 export const getSavedNetworks = async (): Promise<NetworkDetails[]> =>
   (await localStore.getItem(NETWORKS_LIST_ID)) || DEFAULT_NETWORKS;
 
-export const getNetworkDetails = async () => {
+export const getNetworkDetails = async (): Promise<NetworkDetails> => {
   if (!(await localStore.getItem(NETWORK_ID))) {
     await localStore.setItem(NETWORK_ID, DEFAULT_NETWORKS[0]);
   }

--- a/extension/src/background/messageListener/freighterApiMessageListener.ts
+++ b/extension/src/background/messageListener/freighterApiMessageListener.ts
@@ -14,7 +14,10 @@ import { MessageResponder } from "background/types";
 import { FlaggedKeys, TransactionInfo } from "types/transactions";
 
 import { EXTERNAL_SERVICE_TYPES } from "@shared/constants/services";
-import { MAINNET_NETWORK_DETAILS } from "@shared/constants/stellar";
+import {
+  MAINNET_NETWORK_DETAILS,
+  NetworkDetails,
+} from "@shared/constants/stellar";
 import { STELLAR_EXPERT_BLOCKED_ACCOUNTS_URL } from "background/constants/apiUrls";
 import { POPUP_HEIGHT, POPUP_WIDTH } from "constants/dimensions";
 import {
@@ -373,7 +376,8 @@ export const freighterApiMessageListener = (
       networkName: "",
       networkUrl: "",
       networkPassphrase: "",
-    };
+      sorobanRpcUrl: undefined,
+    } as NetworkDetails;
 
     try {
       networkDetails = await getNetworkDetails();


### PR DESCRIPTION
A mismatch in response types was causing networks that have a Soroban RPC URL to not be included in API requests for network details.