### PR TITLE
Adds tests for Soroban operations in sign flow

### DIFF
--- a/extension/src/popup/components/signTransaction/Operations/index.tsx
+++ b/extension/src/popup/components/signTransaction/Operations/index.tsx
@@ -125,7 +125,7 @@ const KeyValueList = ({
   operationKey: string;
   operationValue: string | number | React.ReactNode;
 }) => (
-  <div className="Operations__pair">
+  <div className="Operations__pair" data-testid="OperationKeyVal">
     <div>
       {operationKey}
       {operationKey ? ":" : null}
@@ -185,13 +185,11 @@ const KeyValueWithScAuth = ({
       <SimpleBarWrapper className="Operations__scValue">
         <div>
           <pre>
-            {
-              JSON.stringify(
-                rootJson,
-                (_, val) => (typeof val === 'bigint' ? val.toString() : val),
-                2
-              )
-            }
+            {JSON.stringify(
+              rootJson,
+              (_, val) => (typeof val === "bigint" ? val.toString() : val),
+              2,
+            )}
           </pre>
         </div>
       </SimpleBarWrapper>

--- a/extension/src/popup/helpers/soroban.ts
+++ b/extension/src/popup/helpers/soroban.ts
@@ -101,7 +101,7 @@ export const parseTokenAmount = (value: string, decimals: number) => {
 };
 
 export const getOpArgs = (fnName: string, args: SorobanClient.xdr.ScVal[]) => {
-  let amount;
+  let amount: BigNumber;
   let from;
   let to;
 
@@ -122,7 +122,7 @@ export const getOpArgs = (fnName: string, args: SorobanClient.xdr.ScVal[]) => {
       amount = SorobanClient.scValToNative(args[1]);
       break;
     default:
-      amount = 0;
+      amount = new BigNumber(0);
   }
 
   return { from, to, amount };

--- a/extension/src/popup/views/AccountHistory/index.tsx
+++ b/extension/src/popup/views/AccountHistory/index.tsx
@@ -17,7 +17,6 @@ import {
 } from "popup/ducks/soroban";
 import {
   settingsNetworkDetailsSelector,
-  settingsSelector,
   settingsSorobanSupportedSelector,
 } from "popup/ducks/settings";
 import {
@@ -67,7 +66,6 @@ export const AccountHistory = () => {
   const dispatch = useDispatch();
   const publicKey = useSelector(publicKeySelector);
   const networkDetails = useSelector(settingsNetworkDetailsSelector);
-  const { isExperimentalModeEnabled } = useSelector(settingsSelector);
   const { tokenBalances, getTokenBalancesStatus } = useSelector(
     sorobanSelector,
   );
@@ -94,7 +92,7 @@ export const AccountHistory = () => {
     (getTokenBalancesStatus === ActionStatus.IDLE ||
       getTokenBalancesStatus === ActionStatus.PENDING) &&
     isSorobanSuported;
-  const isAccountHistoryLoading = isExperimentalModeEnabled
+  const isAccountHistoryLoading = isSorobanSuported
     ? historySegments === null || isTokenBalanceLoading
     : historySegments === null;
 
@@ -154,7 +152,7 @@ export const AccountHistory = () => {
       try {
         const res = await getAccountHistory({ publicKey, networkDetails });
         setHistorySegments(
-          createSegments(res.operations, isExperimentalModeEnabled),
+          createSegments(res.operations, isSorobanSuported as boolean),
         );
 
         if (isSorobanSuported) {
@@ -183,14 +181,7 @@ export const AccountHistory = () => {
         dispatch(resetSorobanTokensStatus());
       }
     };
-  }, [
-    publicKey,
-    networkDetails,
-    isExperimentalModeEnabled,
-    sorobanClient,
-    isSorobanSuported,
-    dispatch,
-  ]);
+  }, [publicKey, networkDetails, sorobanClient, isSorobanSuported, dispatch]);
 
   return isDetailViewShowing ? (
     <TransactionDetail {...detailViewProps} />

--- a/extension/src/popup/views/AccountHistory/index.tsx
+++ b/extension/src/popup/views/AccountHistory/index.tsx
@@ -8,7 +8,6 @@ import { Networks } from "soroban-client";
 import { getAccountHistory } from "@shared/api/internal";
 import { HorizonOperation, ActionStatus } from "@shared/api/types";
 import { SorobanTokenInterface } from "@shared/constants/soroban/token";
-import { NETWORKS } from "@shared/constants/stellar";
 
 import { publicKeySelector } from "popup/ducks/accountServices";
 import {
@@ -19,6 +18,7 @@ import {
 import {
   settingsNetworkDetailsSelector,
   settingsSelector,
+  settingsSorobanSupportedSelector,
 } from "popup/ducks/settings";
 import {
   getIsPayment,
@@ -71,6 +71,7 @@ export const AccountHistory = () => {
   const { tokenBalances, getTokenBalancesStatus } = useSelector(
     sorobanSelector,
   );
+  const isSorobanSuported = useSelector(settingsSorobanSupportedSelector);
 
   const [selectedSegment, setSelectedSegment] = useState(SELECTOR_OPTIONS.ALL);
   const [historySegments, setHistorySegments] = useState(
@@ -89,13 +90,10 @@ export const AccountHistory = () => {
 
   const stellarExpertUrl = getStellarExpertUrl(networkDetails);
 
-  // differentiate between if data is still loading and if no account history results came back from Horizon
-  const shouldLoadToken =
-    isExperimentalModeEnabled || networkDetails.network === NETWORKS.FUTURENET;
   const isTokenBalanceLoading =
     (getTokenBalancesStatus === ActionStatus.IDLE ||
       getTokenBalancesStatus === ActionStatus.PENDING) &&
-    shouldLoadToken;
+    isSorobanSuported;
   const isAccountHistoryLoading = isExperimentalModeEnabled
     ? historySegments === null || isTokenBalanceLoading
     : historySegments === null;
@@ -159,7 +157,7 @@ export const AccountHistory = () => {
           createSegments(res.operations, isExperimentalModeEnabled),
         );
 
-        if (shouldLoadToken) {
+        if (isSorobanSuported) {
           dispatch(
             getTokenBalances({
               sorobanClient,
@@ -181,7 +179,7 @@ export const AccountHistory = () => {
     getData();
 
     return () => {
-      if (shouldLoadToken) {
+      if (isSorobanSuported) {
         dispatch(resetSorobanTokensStatus());
       }
     };
@@ -190,7 +188,7 @@ export const AccountHistory = () => {
     networkDetails,
     isExperimentalModeEnabled,
     sorobanClient,
-    shouldLoadToken,
+    isSorobanSuported,
     dispatch,
   ]);
 

--- a/extension/src/popup/views/__tests__/SignTransaction.test.tsx
+++ b/extension/src/popup/views/__tests__/SignTransaction.test.tsx
@@ -1,8 +1,10 @@
 import React from "react";
+import * as SDK from "soroban-client";
 import { render, waitFor, screen } from "@testing-library/react";
 import * as createStellarIdenticon from "stellar-identicon-js";
 
 import * as Stellar from "helpers/stellar";
+import { getAttrsFromSorobanTxOp } from "popup/helpers/soroban";
 
 import { SignTransaction } from "../SignTransaction";
 
@@ -45,15 +47,14 @@ const mockTransactionInfo = {
   flaggedKeys: { test: { tags: [""] } },
 };
 
-jest.mock("stellar-sdk", () => {
-  const original = jest.requireActual("stellar-sdk");
-  return {
-    ...original,
-    TransactionBuilder: {
-      fromXDR: () => mockTransactionInfo.transaction,
-    },
-  };
-});
+const transactions = {
+  classic:
+    "AAAAAgAAAACCMXQVfkjpO2gAJQzKsUsPfdBCyfrvy7sr8+35cOxOSwAAAGQABqQMAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAACCMXQVfkjpO2gAJQzKsUsPfdBCyfrvy7sr8+35cOxOSwAAAAAAmJaAAAAAAAAAAAFw7E5LAAAAQBu4V+/lttEONNM6KFwdSf5TEEogyEBy0jTOHJKuUzKScpLHyvDJGY+xH9Ri4cIuA7AaB8aL+VdlucCfsNYpKAY=",
+  sorobanTransfer:
+    "AAAAAgAAAACM6IR9GHiRoVVAO78JJNksy2fKDQNs2jBn8bacsRLcrDucaFsAAAWIAAAAMQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABHkEVdJ+UfDnWpBr/qF582IEoDQ0iW0WPzO9CEUdvvh8AAAAIdHJhbnNmZXIAAAADAAAAEgAAAAAAAAAAjOiEfRh4kaFVQDu/CSTZLMtnyg0DbNowZ/G2nLES3KwAAAASAAAAAAAAAADoFl2ACT9HZkbCeuaT9MAIdStpdf58wM3P24nl738AnQAAAAoAAAAAAAAAAAAAAAAAAAAFAAAAAQAAAAAAAAAAAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAACHRyYW5zZmVyAAAAAwAAABIAAAAAAAAAAIzohH0YeJGhVUA7vwkk2SzLZ8oNA2zaMGfxtpyxEtysAAAAEgAAAAAAAAAA6BZdgAk/R2ZGwnrmk/TACHUraXX+fMDNz9uJ5e9/AJ0AAAAKAAAAAAAAAAAAAAAAAAAABQAAAAAAAAABAAAAAAAAAAIAAAAGAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAAFAAAAAEAAAAHa35L+/RxV6EuJOVk78H5rCN+eubXBWtsKrRxeLnnpRAAAAACAAAABgAAAAEeQRV0n5R8OdakGv+oXnzYgSgNDSJbRY/M70IRR2++HwAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAAAAAAACM6IR9GHiRoVVAO78JJNksy2fKDQNs2jBn8bacsRLcrAAAAAEAAAAGAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAAAAAAAAOgWXYAJP0dmRsJ65pP0wAh1K2l1/nzAzc/bieXvfwCdAAAAAQBkcwsAACBwAAABKAAAAAAAAB1kAAAAAA==",
+  sorobanMint:
+    "AAAAAgAAAACM6IR9GHiRoVVAO78JJNksy2fKDQNs2jBn8bacsRLcrDucQIQAAAWIAAAAMQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABHkEVdJ+UfDnWpBr/qF582IEoDQ0iW0WPzO9CEUdvvh8AAAAEbWludAAAAAIAAAASAAAAAAAAAADoFl2ACT9HZkbCeuaT9MAIdStpdf58wM3P24nl738AnQAAAAoAAAAAAAAAAAAAAAAAAAAFAAAAAQAAAAAAAAAAAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAABG1pbnQAAAACAAAAEgAAAAAAAAAA6BZdgAk/R2ZGwnrmk/TACHUraXX+fMDNz9uJ5e9/AJ0AAAAKAAAAAAAAAAAAAAAAAAAABQAAAAAAAAABAAAAAAAAAAIAAAAGAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAAFAAAAAEAAAAHa35L+/RxV6EuJOVk78H5rCN+eubXBWtsKrRxeLnnpRAAAAABAAAABgAAAAEeQRV0n5R8OdakGv+oXnzYgSgNDSJbRY/M70IRR2++HwAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAAAAAAADoFl2ACT9HZkbCeuaT9MAIdStpdf58wM3P24nl738AnQAAAAEAYpBIAAAfrAAAAJQAAAAAAAAdYwAAAAA=",
+};
 
 describe("SignTransactions", () => {
   beforeEach(() => {
@@ -61,14 +62,33 @@ describe("SignTransactions", () => {
     jest.spyOn(createStellarIdenticon, "default").mockReturnValue(mockCanvas);
   });
   it("renders", async () => {
-    jest
-      .spyOn(Stellar, "getTransactionInfo")
-      .mockImplementation(() => mockTransactionInfo);
+    const transaction = SDK.TransactionBuilder.fromXDR(
+      transactions.sorobanTransfer,
+      SDK.Networks.FUTURENET,
+    ) as SDK.Transaction<
+      SDK.Memo<SDK.MemoType>,
+      SDK.Operation.InvokeHostFunction[]
+    >;
+    const op = transaction.operations[0];
+    jest.spyOn(Stellar, "getTransactionInfo").mockImplementation(() => ({
+      ...mockTransactionInfo,
+      transactionXdr: transactions.sorobanTransfer,
+      transaction: {
+        networkPassphrase: SDK.Networks.FUTURENET,
+        _operations: [op],
+      },
+    }));
 
     render(
       <Wrapper
         state={{
-          settings: defaultSettingsState,
+          settings: {
+            isExperimentalModeEnabled: true,
+            networkDetails: {
+              ...defaultSettingsState.networkDetails,
+              networkPassphrase: "Test SDF Future Network ; October 2022",
+            },
+          },
         }}
       >
         <SignTransaction />
@@ -78,14 +98,33 @@ describe("SignTransactions", () => {
     expect(screen.getByTestId("SignTransaction")).toBeDefined();
   });
   it("shows non-https domain error", async () => {
+    const transaction = SDK.TransactionBuilder.fromXDR(
+      transactions.classic,
+      SDK.Networks.TESTNET,
+    ) as SDK.Transaction<
+      SDK.Memo<SDK.MemoType>,
+      SDK.Operation.InvokeHostFunction[]
+    >;
+    const op = transaction.operations[0];
     jest.spyOn(Stellar, "getTransactionInfo").mockImplementation(() => ({
       ...mockTransactionInfo,
+      transactionXdr: transactions.classic,
+      transaction: {
+        networkPassphrase: SDK.Networks.TESTNET,
+        _operations: [op],
+      },
       isHttpsDomain: false,
     }));
     render(
       <Wrapper
         state={{
-          settings: defaultSettingsState,
+          settings: {
+            isExperimentalModeEnabled: false,
+            networkDetails: {
+              ...defaultSettingsState.networkDetails,
+              networkPassphrase: "Test SDF Future Network ; October 2022",
+            },
+          },
         }}
       >
         <SignTransaction />
@@ -96,5 +135,115 @@ describe("SignTransactions", () => {
     expect(screen.getByTestId("WarningMessage")).toHaveTextContent(
       "WEBSITE CONNECTION IS NOT SECURE",
     );
+  });
+  it("displays token payment parameters for Soroban token payment operations", async () => {
+    const transaction = SDK.TransactionBuilder.fromXDR(
+      transactions.sorobanTransfer,
+      SDK.Networks.FUTURENET,
+    ) as SDK.Transaction<
+      SDK.Memo<SDK.MemoType>,
+      SDK.Operation.InvokeHostFunction[]
+    >;
+    const op = transaction.operations[0];
+    jest.spyOn(Stellar, "getTransactionInfo").mockImplementation(() => ({
+      ...mockTransactionInfo,
+      transactionXdr: transactions.sorobanTransfer,
+      transaction: {
+        networkPassphrase: SDK.Networks.FUTURENET,
+        _operations: [op],
+      },
+    }));
+
+    render(
+      <Wrapper
+        state={{
+          settings: {
+            isExperimentalModeEnabled: true,
+            networkDetails: {
+              ...defaultSettingsState.networkDetails,
+              networkPassphrase: "Test SDF Future Network ; October 2022",
+            },
+          },
+        }}
+      >
+        <SignTransaction />
+      </Wrapper>,
+    );
+
+    const args = getAttrsFromSorobanTxOp(op);
+    const opDetails = screen
+      .getAllByTestId("OperationKeyVal")
+      .map((node) => node.textContent);
+
+    expect(opDetails.includes(`Amount:${args?.amount.toString()}`));
+    expect(
+      opDetails.includes(
+        `Contract ID:${Stellar.truncatedPublicKey(args?.contractId!)}`,
+      ),
+    );
+    expect(
+      opDetails.includes(
+        `Destination:${Stellar.truncatedPublicKey(args?.to!)}`,
+      ),
+    );
+    expect(
+      opDetails.includes(`Source:${Stellar.truncatedPublicKey(args?.from!)}`),
+    );
+    expect(opDetails.includes(`Function Name:${args?.fnName}`));
+  });
+  it("displays mint parameters for Soroban mint operations", async () => {
+    const transaction = SDK.TransactionBuilder.fromXDR(
+      transactions.sorobanMint,
+      SDK.Networks.FUTURENET,
+    ) as SDK.Transaction<
+      SDK.Memo<SDK.MemoType>,
+      SDK.Operation.InvokeHostFunction[]
+    >;
+    const op = transaction.operations[0];
+    jest.spyOn(Stellar, "getTransactionInfo").mockImplementation(() => ({
+      ...mockTransactionInfo,
+      transactionXdr: transactions.sorobanMint,
+      transaction: {
+        networkPassphrase: SDK.Networks.FUTURENET,
+        _operations: [op],
+      },
+    }));
+
+    render(
+      <Wrapper
+        state={{
+          settings: {
+            isExperimentalModeEnabled: true,
+            networkDetails: {
+              ...defaultSettingsState.networkDetails,
+              networkPassphrase: "Test SDF Future Network ; October 2022",
+            },
+          },
+        }}
+      >
+        <SignTransaction />
+      </Wrapper>,
+    );
+
+    const args = getAttrsFromSorobanTxOp(op);
+    const opDetails = screen
+      .getAllByTestId("OperationKeyVal")
+      .map((node) => node.textContent);
+
+    expect(opDetails.includes(`Amount:${args?.amount.toString()}`));
+    expect(
+      opDetails.includes(
+        `Contract ID:${Stellar.truncatedPublicKey(args?.contractId!)}`,
+      ),
+    );
+    expect(
+      opDetails.includes(
+        `Destination:${Stellar.truncatedPublicKey(args?.to!)}`,
+      ),
+    );
+    expect(
+      opDetails.includes(`Source:${Stellar.truncatedPublicKey(args?.from!)}`),
+    );
+    expect(opDetails.includes(`Function Name:${args?.fnName}`));
   });
 });


### PR DESCRIPTION
Adds tests for soroban token payment & mint operations, targets display in sign tx workflow.
Fixes check that allows Soroban tx history to be displayed on testnet
Tickets: 
https://stellarorg.atlassian.net/browse/WAL-1133
https://stellarorg.atlassian.net/browse/WAL-974