### PR TITLE
[BUG] Allow signing Soroban transactions without experimental mode enabled

### DIFF
--- a/extension/src/background/helpers/account.ts
+++ b/extension/src/background/helpers/account.ts
@@ -123,3 +123,8 @@ export const getNetworksList = async () => {
 
   return networksList;
 };
+
+export const getIsSorobanSupported = async () => {
+  const networkDetails = await getNetworkDetails();
+  return !!networkDetails.sorobanRpcUrl;
+};

--- a/extension/src/background/messageListener/freighterApiMessageListener.ts
+++ b/extension/src/background/messageListener/freighterApiMessageListener.ts
@@ -30,8 +30,8 @@ import {
   getIsMainnet,
   getIsMemoValidationEnabled,
   getIsSafetyValidationEnabled,
-  getIsExperimentalModeEnabled,
   getNetworkDetails,
+  getIsSorobanSupported,
 } from "background/helpers/account";
 import { isSenderAllowed } from "background/helpers/allowListAuthorization";
 import { cachedFetch } from "background/helpers/cachedFetch";
@@ -118,8 +118,8 @@ export const freighterApiMessageListener = (
 
     const isMainnet = await getIsMainnet();
     const { networkUrl } = await getNetworkDetails();
-    const isExperimentalModeEnabled = await getIsExperimentalModeEnabled();
-    const SDK = isExperimentalModeEnabled ? SorobanSdk : StellarSdk;
+    const isSorobanSupported = await getIsSorobanSupported();
+    const SDK = isSorobanSupported ? SorobanSdk : StellarSdk;
 
     const { tab, url: tabUrl = "" } = sender;
     const domain = getUrlHostname(tabUrl);
@@ -129,7 +129,6 @@ export const freighterApiMessageListener = (
     const allowList = allowListStr.split(",");
     const isDomainListedAllowed = await isSenderAllowed({ sender });
 
-    // try to build a tx xdr, if you cannot then assume the user wants to sign an arbitrary blob
     const transaction = SDK.TransactionBuilder.fromXDR(
       transactionXdr,
       networkPassphrase || SDK.Networks[network as keyof typeof SDK.Networks],

--- a/extension/src/background/messageListener/popupMessageListener.ts
+++ b/extension/src/background/messageListener/popupMessageListener.ts
@@ -60,6 +60,7 @@ import {
   getNetworksList,
   HW_PREFIX,
   getBipPath,
+  getIsSorobanSupported,
 } from "background/helpers/account";
 import { SessionTimer } from "background/helpers/session";
 import { cachedFetch } from "background/helpers/cachedFetch";
@@ -902,8 +903,8 @@ export const popupMessageListener = (request: Request, sessionStore: Store) => {
     const privateKey = privateKeySelector(sessionStore.getState());
 
     if (privateKey.length) {
-      const isExperimentalModeEnabled = await getIsExperimentalModeEnabled();
-      const SDK = isExperimentalModeEnabled ? SorobanSdk : StellarSdk;
+      const isSorobanSupported = await getIsSorobanSupported();
+      const SDK = isSorobanSupported ? SorobanSdk : StellarSdk;
       const sourceKeys = SDK.Keypair.fromSecret(privateKey);
 
       let response;
@@ -935,9 +936,7 @@ export const popupMessageListener = (request: Request, sessionStore: Store) => {
     const privateKey = privateKeySelector(sessionStore.getState());
 
     if (privateKey.length) {
-      const isExperimentalModeEnabled = await getIsExperimentalModeEnabled();
-      const SDK = isExperimentalModeEnabled ? SorobanSdk : StellarSdk;
-      const sourceKeys = SDK.Keypair.fromSecret(privateKey);
+      const sourceKeys = StellarSdk.Keypair.fromSecret(privateKey);
 
       const blob = blobQueue.pop();
       const response = blob
@@ -960,11 +959,12 @@ export const popupMessageListener = (request: Request, sessionStore: Store) => {
 
     if (privateKey.length) {
       const sourceKeys = SorobanSdk.Keypair.fromSecret(privateKey);
-
       const authEntry = authEntryQueue.pop();
 
       const response = authEntry
-        ? await sourceKeys.sign(SorobanSdk.hash(Buffer.from(authEntry.entry, "base64")))
+        ? await sourceKeys.sign(
+            SorobanSdk.hash(Buffer.from(authEntry.entry, "base64")),
+          )
         : null;
 
       const entryResponse = responseQueue.pop();
@@ -988,8 +988,8 @@ export const popupMessageListener = (request: Request, sessionStore: Store) => {
 
   const signFreighterTransaction = async () => {
     const { transactionXDR, network } = request;
-    const isExperimentalModeEnabled = await getIsExperimentalModeEnabled();
-    const SDK = isExperimentalModeEnabled ? SorobanSdk : StellarSdk;
+    const isSorobanSupported = await getIsSorobanSupported();
+    const SDK = isSorobanSupported ? SorobanSdk : StellarSdk;
     const transaction = SDK.TransactionBuilder.fromXDR(transactionXDR, network);
 
     const privateKey = privateKeySelector(sessionStore.getState());

--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -10,6 +10,7 @@ import { signTransaction, rejectTransaction } from "popup/ducks/access";
 import {
   settingsNetworkDetailsSelector,
   settingsExperimentalModeSelector,
+  settingsSorobanSupportedSelector,
 } from "popup/ducks/settings";
 
 import { ShowOverlayStatus } from "popup/ducks/transactionSubmission";
@@ -64,6 +65,7 @@ export const SignTransaction = () => {
   const isExperimentalModeEnabled = useSelector(
     settingsExperimentalModeSelector,
   );
+  const isSorobanSuported = useSelector(settingsSorobanSupportedSelector);
   const { networkName, networkPassphrase } = useSelector(
     settingsNetworkDetailsSelector,
   );
@@ -86,7 +88,7 @@ export const SignTransaction = () => {
   But in this case, we will need the hostFn prototype associated with Soroban tx operations.
   */
 
-  const SDK = isExperimentalModeEnabled ? SorobanSdk : StellarSdk;
+  const SDK = isSorobanSuported ? SorobanSdk : StellarSdk;
   const transaction = SDK.TransactionBuilder.fromXDR(
     transactionXdr,
     networkPassphrase,


### PR DESCRIPTION
Bug reported in Discord, details - https://discord.com/channels/897514728459468821/1162044192135065681
Ticket: https://stellarorg.atlassian.net/browse/WAL-1153

When Soroban became available on Testnet, we didn't migrate a few existing checks for `isExperimentalMode` enabled. This used to be ok since Experimental Mode was always on when a user was using Freighter on Futurenet, which at the time was the only network that supported Soroban. Now that Testnet supports Soroban, we need to check for Soroban support(has an rpc url) instead of experimental mode to know which sdk to use.

Changes-
Adds a background getter for `isSorobanSupported`.
Swaps all `isExperimentalMode` checks that related to Soroban with `isSorobanSupported` checks.