### PR TITLE
[FIX] incorrect query and network config for standalone

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -299,12 +299,14 @@ export const confirmPassword = async (
 
 export const getAccountIndexerBalances = async (
   publicKey: string,
-  network: NETWORKS,
+  networkDetails: NetworkDetails,
 ): Promise<AccountBalancesInterface> => {
   try {
-    const contractIds = await getTokenIds(network);
+    const contractIds = await getTokenIds(networkDetails.network as NETWORKS);
     const url = new URL(`${INDEXER_URL}/account-balances/${publicKey}`);
-    url.searchParams.append("network", network);
+    url.searchParams.append("network", networkDetails.network);
+    url.searchParams.append("horizon_url", networkDetails.networkUrl);
+    url.searchParams.append("soroban_url", networkDetails.sorobanRpcUrl!);
     for (const id of contractIds) {
       url.searchParams.append("contract_ids", id);
     }
@@ -385,7 +387,7 @@ export const getIndexerAccountHistory = async ({
 }) => {
   try {
     const url = new URL(
-      `${INDEXER_URL}/account-history/${publicKey}?network=${networkDetails.network}&soroban_rpc_url=${networkDetails.sorobanRpcUrl}`,
+      `${INDEXER_URL}/account-history/${publicKey}?network=${networkDetails.network}&soroban_url=${networkDetails.sorobanRpcUrl}&horizon_url=${networkDetails.networkUrl}`,
     );
     const response = await fetch(url.href);
     const data = (await response.json()) as HorizonOperation;

--- a/extension/src/helpers/stellar.ts
+++ b/extension/src/helpers/stellar.ts
@@ -158,7 +158,7 @@ export const isActiveNetwork = (
   networkB: NetworkDetails,
 ) => isEqual(networkA, networkB);
 
-export const CUSTOM_NETWORK = "CUSTOM";
+export const CUSTOM_NETWORK = "STANDALONE";
 
 export const isCustomNetwork = (networkDetails: NetworkDetails) => {
   const { network } = networkDetails;

--- a/extension/src/popup/components/accountHistory/HistoryItem/index.tsx
+++ b/extension/src/popup/components/accountHistory/HistoryItem/index.tsx
@@ -238,7 +238,7 @@ export const HistoryItem = ({
 
             try {
               const response = await fetch(
-                `${INDEXER_URL}/token-details/${attrs.contractId}?pub_key=${publicKey}&network=${networkDetails.network}&soroban_rpc_url=${networkDetails.sorobanRpcUrl}`,
+                `${INDEXER_URL}/token-details/${attrs.contractId}?pub_key=${publicKey}&horizon_url=${networkDetails.network}&soroban_url=${networkDetails.sorobanRpcUrl}`,
               );
               const tokenDetails = await response.json();
 

--- a/extension/src/popup/components/signTransaction/Operations/index.tsx
+++ b/extension/src/popup/components/signTransaction/Operations/index.tsx
@@ -356,7 +356,7 @@ export const Operations = ({
     if (!contractId) return;
     const fetchContractDecimals = async () => {
       const response = await fetch(
-        `${INDEXER_URL}/token-details/${contractId}?pub_key=${publicKey}&network=${networkDetails.network}&soroban_rpc_url=${networkDetails.sorobanRpcUrl}`,
+        `${INDEXER_URL}/token-details/${contractId}?pub_key=${publicKey}&horizon_url=${networkDetails.network}&soroban_url=${networkDetails.sorobanRpcUrl}`,
       );
       const tokenDetails = await response.json();
       setDecimals(tokenDetails.decimals);

--- a/extension/src/popup/ducks/transactionSubmission.ts
+++ b/extension/src/popup/ducks/transactionSubmission.ts
@@ -290,7 +290,7 @@ export const getAccountBalances = createAsyncThunk<
   try {
     const balances = await internalgetAccountIndexerBalances(
       publicKey,
-      networkDetails.network as NETWORKS,
+      networkDetails,
     );
     storeBalanceMetricData(publicKey, balances.isFunded || false);
     return balances;
@@ -305,10 +305,7 @@ export const getDestinationBalances = createAsyncThunk<
   { rejectValue: ErrorMessage }
 >("getDestinationBalances", async ({ publicKey, networkDetails }, thunkApi) => {
   try {
-    return await internalgetAccountIndexerBalances(
-      publicKey,
-      networkDetails.network as NETWORKS,
-    );
+    return await internalgetAccountIndexerBalances(publicKey, networkDetails);
   } catch (e) {
     return thunkApi.rejectWithValue({ errorMessage: e });
   }

--- a/extension/src/popup/views/IntegrationTest.tsx
+++ b/extension/src/popup/views/IntegrationTest.tsx
@@ -202,7 +202,7 @@ export const IntegrationTest = () => {
 
       res = await getAccountIndexerBalances(
         testPublicKey,
-        TESTNET_NETWORK_DETAILS.network as NETWORKS,
+        TESTNET_NETWORK_DETAILS,
       );
       runAsserts("getAccountBalances", () => {
         assertEq(Object.keys(res.balances).length > 0, true);


### PR DESCRIPTION
This fixes https://stellarorg.atlassian.net/browse/WAL-1228 along with https://github.com/stellar/freighter-backend/pull/17

Updates custom network identifier to be `STANDALONE` which matches the sdk value used in the backend.
Corrects or adds the missing query params to pass rpc urls for custom networks.