### PR TITLE
splits dotenv so prod can use systemvars from CI

### DIFF
--- a/extension/webpack.common.js
+++ b/extension/webpack.common.js
@@ -5,7 +5,6 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const path = require("path");
 const webpack = require("webpack");
-const Dotenv = require("dotenv-webpack");
 
 const { DEFAULT_STATS } = require("../config/webpack");
 
@@ -143,7 +142,6 @@ const commonConfig = (
     new webpack.ProvidePlugin({
       process: "process/browser",
     }),
-    new Dotenv(),
   ],
   stats: DEFAULT_STATS,
 });

--- a/extension/webpack.dev.js
+++ b/extension/webpack.dev.js
@@ -1,6 +1,7 @@
 const { merge } = require("webpack-merge");
 const webpack = require("webpack");
 const path = require("path");
+const Dotenv = require("dotenv-webpack");
 
 const { BUILD_PATH, commonConfig } = require("./webpack.common.js");
 
@@ -20,6 +21,7 @@ const devConfig = {
       /webextension-polyfill/,
       path.resolve(__dirname, "../config/shims/webextension-polyfill.ts"),
     ),
+    new Dotenv(),
   ],
 };
 

--- a/extension/webpack.extension.js
+++ b/extension/webpack.extension.js
@@ -2,6 +2,7 @@ const { merge } = require("webpack-merge");
 const webpack = require("webpack");
 const I18nextWebpackPlugin = require("i18next-scanner-webpack");
 const { commonConfig } = require("./webpack.common.js");
+const Dotenv = require("dotenv-webpack");
 
 const LOCALES = ["en", "pt"];
 
@@ -47,6 +48,7 @@ const prodConfig = (
           }),
         ]
       : []),
+    new Dotenv({ systemvars: true }),
   ],
   // This if to fine tune logged output. Since this is an extension, not a
   // webapp, we don't face the same bundle size constraints of the web.


### PR DESCRIPTION
This allows our prod build, which gets used in CI, to use system vars for the indexer URL