### PR TITLE
Constrain token payment

### DIFF
--- a/extension/src/popup/App.tsx
+++ b/extension/src/popup/App.tsx
@@ -8,6 +8,7 @@ import { metricsMiddleware } from "helpers/metrics";
 import { reducer as auth } from "popup/ducks/accountServices";
 import { reducer as settings } from "popup/ducks/settings";
 import { reducer as transactionSubmission } from "popup/ducks/transactionSubmission";
+import { reducer as tokenPaymentSimulation } from "popup/ducks/token-payment";
 
 import { Loading } from "popup/components/Loading";
 import { ErrorTracking } from "popup/components/ErrorTracking";
@@ -20,6 +21,7 @@ const rootReducer = combineReducers({
   auth,
   settings,
   transactionSubmission,
+  tokenPaymentSimulation,
 });
 export type AppState = ReturnType<typeof rootReducer>;
 export const store = configureStore({

--- a/extension/src/popup/__testHelpers__/index.tsx
+++ b/extension/src/popup/__testHelpers__/index.tsx
@@ -16,11 +16,13 @@ import {
   reducer as transactionSubmission,
   initialState as transactionSubmissionInitialState,
 } from "popup/ducks/transactionSubmission";
+import { reducer as tokenPaymentSimulation } from "popup/ducks/token-payment";
 
 const rootReducer = combineReducers({
   auth,
   settings,
   transactionSubmission,
+  tokenPaymentSimulation,
 });
 
 const { Router } = jest.requireActual("react-router-dom");

--- a/extension/src/popup/components/sendPayment/SendSettings/Settings/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendSettings/Settings/index.tsx
@@ -1,0 +1,290 @@
+import React, { useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { Formik, Form, Field, FieldProps } from "formik";
+import { Icon, Textarea, Link, Button } from "@stellar/design-system";
+import { useTranslation } from "react-i18next";
+
+import { navigateTo } from "popup/helpers/navigate";
+import { useNetworkFees } from "popup/helpers/useNetworkFees";
+import { useIsSwap } from "popup/helpers/useIsSwap";
+import { isMuxedAccount } from "helpers/stellar";
+import { ROUTES } from "popup/constants/routes";
+import { SubviewHeader } from "popup/components/SubviewHeader";
+import { FormRows } from "popup/basics/Forms";
+import { View } from "popup/basics/layout/View";
+import {
+  saveMemo,
+  transactionDataSelector,
+  isPathPaymentSelector,
+  saveTransactionFee,
+  saveSimulation,
+  transactionSubmissionSelector,
+} from "popup/ducks/transactionSubmission";
+import { simulateTokenPayment } from "popup/ducks/token-payment";
+
+import { InfoTooltip } from "popup/basics/InfoTooltip";
+import { publicKeySelector } from "popup/ducks/accountServices";
+import { parseTokenAmount } from "popup/helpers/soroban";
+import "../../styles.scss";
+import { Balances, TokenBalance } from "@shared/api/types";
+import { getNetworkDetails } from "background/helpers/account";
+import { AppDispatch } from "popup/App";
+
+export const Settings = ({
+  previous,
+  next,
+}: {
+  previous: ROUTES;
+  next: ROUTES;
+}) => {
+  const { t } = useTranslation();
+  const dispatch: AppDispatch = useDispatch();
+  const {
+    asset,
+    amount,
+    destination,
+    transactionFee,
+    memo,
+    allowedSlippage,
+    isToken,
+  } = useSelector(transactionDataSelector);
+  const isPathPayment = useSelector(isPathPaymentSelector);
+  const publicKey = useSelector(publicKeySelector);
+  const { accountBalances } = useSelector(transactionSubmissionSelector);
+  const isSwap = useIsSwap();
+  const { recommendedFee } = useNetworkFees();
+
+  // use default transaction fee if unset
+  useEffect(() => {
+    if (!transactionFee) {
+      dispatch(saveTransactionFee(recommendedFee));
+    }
+  }, [dispatch, recommendedFee, transactionFee]);
+
+  const handleTxFeeNav = () =>
+    navigateTo(isSwap ? ROUTES.swapSettingsFee : ROUTES.sendPaymentSettingsFee);
+
+  const handleSlippageNav = () =>
+    navigateTo(
+      isSwap ? ROUTES.swapSettingsSlippage : ROUTES.sendPaymentSettingsSlippage,
+    );
+
+  // dont show memo for regular sends to Muxed, or for swaps
+  const showMemo = !isSwap && !isMuxedAccount(destination);
+  const showSlippage = isPathPayment || isSwap;
+
+  async function goToReview() {
+    if (isToken) {
+      const assetAddress = asset.split(":")[1];
+      const balances =
+        accountBalances.balances || ({} as NonNullable<Balances>);
+      const assetBalance = balances[asset] as TokenBalance;
+
+      if (!assetBalance) {
+        throw new Error("Asset Balance not available");
+      }
+
+      const parsedAmount = parseTokenAmount(
+        amount,
+        Number(assetBalance.decimals),
+      );
+
+      const params = {
+        publicKey,
+        destination,
+        amount: parsedAmount.toNumber(),
+      };
+
+      const networkDetails = await getNetworkDetails();
+      const simulation = await dispatch(
+        simulateTokenPayment({
+          address: assetAddress,
+          publicKey,
+          memo,
+          params,
+          networkUrl: networkDetails.sorobanRpcUrl!,
+          networkPassphrase: networkDetails.networkPassphrase,
+        }),
+      );
+
+      if (simulateTokenPayment.fulfilled.match(simulation)) {
+        dispatch(saveSimulation(simulation.payload));
+        navigateTo(next);
+      }
+      return;
+    }
+    navigateTo(next);
+  }
+
+  return (
+    <View data-testid="send-settings-view">
+      <SubviewHeader
+        title={`${isSwap ? t("Swap") : t("Send")} ${t("Settings")}`}
+        customBackAction={() => navigateTo(previous)}
+      />
+      <Formik
+        initialValues={{ memo }}
+        onSubmit={(values) => {
+          dispatch(saveMemo(values.memo));
+        }}
+      >
+        {({ submitForm }) => (
+          <Form className="View__contentAndFooterWrapper">
+            <View.Content>
+              <FormRows>
+                {!isToken ? (
+                  <div className="SendSettings__row">
+                    <div className="SendSettings__row__left">
+                      <InfoTooltip
+                        infoText={
+                          <span>
+                            {t("Maximum network transaction fee to be paid")}{" "}
+                            <Link
+                              variant="secondary"
+                              href="https://developers.stellar.org/docs/glossary/fees/#base-fee"
+                              rel="noreferrer"
+                              target="_blank"
+                            >
+                              {t("Learn more")}
+                            </Link>
+                          </span>
+                        }
+                        placement="bottom"
+                      >
+                        <span
+                          className="SendSettings__row__title SendSettings__clickable"
+                          onClick={() => {
+                            submitForm();
+                            handleTxFeeNav();
+                          }}
+                        >
+                          {t("Transaction fee")}
+                        </span>
+                      </InfoTooltip>
+                    </div>
+                    <div
+                      className="SendSettings__row__right SendSettings__clickable"
+                      onClick={() => {
+                        submitForm();
+                        handleTxFeeNav();
+                      }}
+                    >
+                      <span data-testid="SendSettingsTransactionFee">
+                        {transactionFee} XLM
+                      </span>
+                      <div>
+                        <Icon.ChevronRight />
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+
+                {showSlippage && (
+                  <div className="SendSettings__row">
+                    <div className="SendSettings__row__left">
+                      <InfoTooltip
+                        infoText={
+                          <span>
+                            {t(
+                              "Allowed downward variation in the destination amount",
+                            )}{" "}
+                            <Link
+                              variant="secondary"
+                              href="https://www.freighter.app/faq"
+                              rel="noreferrer"
+                              target="_blank"
+                            >
+                              {t("Learn more")}
+                            </Link>
+                          </span>
+                        }
+                        placement="bottom"
+                      >
+                        <span
+                          className="SendSettings__row__title SendSettings__clickable"
+                          onClick={() => {
+                            submitForm();
+                            handleSlippageNav();
+                          }}
+                        >
+                          {t("Allowed slippage")}
+                        </span>
+                      </InfoTooltip>
+                    </div>
+                    <div
+                      className="SendSettings__row__right SendSettings__clickable"
+                      onClick={() => {
+                        submitForm();
+                        handleSlippageNav();
+                      }}
+                    >
+                      <span data-testid="SendSettingsAllowedSlippage">
+                        {allowedSlippage}%
+                      </span>
+                      <div>
+                        <Icon.ChevronRight />
+                      </div>
+                    </div>
+                  </div>
+                )}
+                {showMemo && (
+                  <>
+                    <div className="SendSettings__row">
+                      <div className="SendSettings__row__left">
+                        <InfoTooltip
+                          infoText={
+                            <span>
+                              {t("Include a custom memo to this transaction")}{" "}
+                              <Link
+                                variant="secondary"
+                                href="https://developers.stellar.org/docs/glossary/transactions/#memo"
+                                rel="noreferrer"
+                                target="_blank"
+                              >
+                                {t("Learn more")}
+                              </Link>
+                            </span>
+                          }
+                          placement="bottom"
+                        >
+                          <span className="SendSettings__row__title">
+                            {t("Memo")}
+                          </span>
+                        </InfoTooltip>
+                      </div>
+                      <div className="SendSettings__row__right">
+                        <span></span>
+                      </div>
+                    </div>
+                    <Field name="memo">
+                      {({ field }: FieldProps) => (
+                        <Textarea
+                          fieldSize="md"
+                          id="mnemonic-input"
+                          placeholder={t("Memo (optional)")}
+                          {...field}
+                        />
+                      )}
+                    </Field>
+                  </>
+                )}
+              </FormRows>
+            </View.Content>
+            <View.Footer>
+              <Button
+                size="md"
+                isFullWidth
+                onClick={goToReview}
+                type="submit"
+                variant="secondary"
+                data-testid="send-settings-btn-continue"
+              >
+                {t("Review")} {isSwap ? t("Swap") : t("Send")}
+              </Button>
+            </View.Footer>
+          </Form>
+        )}
+      </Formik>
+    </View>
+  );
+};

--- a/extension/src/popup/components/sendPayment/SendSettings/SettingsFail/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendSettings/SettingsFail/index.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Button } from "@stellar/design-system";
+import { useTranslation } from "react-i18next";
+
+import { navigateTo } from "popup/helpers/navigate";
+import { ROUTES } from "popup/constants/routes";
+import { View } from "popup/basics/layout/View";
+import IconFail from "popup/assets/icon-fail.svg";
+
+import "./styles.scss";
+import { emitMetric } from "helpers/metrics";
+import { METRIC_NAMES } from "popup/constants/metricsNames";
+import {
+  resetSimulation,
+  tokenSimulationSelector,
+} from "popup/ducks/token-payment";
+
+export const SettingsFail = () => {
+  const dispatch = useDispatch();
+  const { error } = useSelector(tokenSimulationSelector);
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    emitMetric(METRIC_NAMES.simuilateTokenPaymentError, { error });
+  }, [error]);
+
+  return (
+    <View>
+      <View.AppHeader pageTitle={t("Error")} />
+      <View.Content>
+        <div className="SettingsFail__content">
+          <div className="SettingsFail__amount">Simulation Rejected</div>
+          <div className="SettingsFail__icon SettingsFail__fail">
+            <img src={IconFail} alt="Icon Fail" />
+          </div>
+          <div className="SettingsFail__error-code"></div>
+        </div>
+        <div className="SettingsFail__error-block">{error?.errorMessage}</div>
+      </View.Content>
+      <View.Footer>
+        <Button
+          isFullWidth
+          variant="secondary"
+          size="md"
+          onClick={() => {
+            dispatch(resetSimulation());
+            navigateTo(ROUTES.account);
+          }}
+        >
+          {t("Got it")}
+        </Button>
+      </View.Footer>
+    </View>
+  );
+};

--- a/extension/src/popup/components/sendPayment/SendSettings/SettingsFail/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendSettings/SettingsFail/index.tsx
@@ -8,13 +8,13 @@ import { ROUTES } from "popup/constants/routes";
 import { View } from "popup/basics/layout/View";
 import IconFail from "popup/assets/icon-fail.svg";
 
-import "./styles.scss";
 import { emitMetric } from "helpers/metrics";
 import { METRIC_NAMES } from "popup/constants/metricsNames";
 import {
   resetSimulation,
   tokenSimulationSelector,
 } from "popup/ducks/token-payment";
+import "./styles.scss";
 
 export const SettingsFail = () => {
   const dispatch = useDispatch();

--- a/extension/src/popup/components/sendPayment/SendSettings/SettingsFail/styles.scss
+++ b/extension/src/popup/components/sendPayment/SendSettings/SettingsFail/styles.scss
@@ -1,0 +1,112 @@
+.SettingsFail {
+  &__content {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+  }
+
+  &__header {
+    font-size: 0.875rem;
+    line-height: 1.375rem;
+    margin-bottom: 0.25rem;
+  }
+
+  &__amount {
+    font-size: 1.5rem;
+    line-height: 2.25rem;
+    color: var(--color-gray-90);
+    margin-bottom: 1.5rem;
+    text-align: center;
+  }
+
+  &__icon {
+    margin-bottom: 1.5rem;
+
+    svg {
+      height: 40px;
+      width: 40px;
+      stroke-width: 1.5px;
+    }
+  }
+
+  &__success {
+    svg {
+      fill: var(--color-green-60);
+    }
+  }
+
+  &__fail {
+    svg {
+      fill: var(--color-red-60);
+    }
+  }
+
+  &__identicon {
+    display: flex;
+    align-items: center;
+    border: 1px solid var(--color-gray-10);
+    border-radius: 100px;
+    padding: 0.25rem 0.5rem;
+
+    %identiconImg {
+      border-radius: 1rem;
+      width: 0.875rem;
+      height: 0.875rem;
+      margin-right: 0.5rem;
+    }
+
+    span {
+      color: var(--color-gray-90);
+      font-size: 0.875rem;
+      line-height: 1.375rem;
+    }
+  }
+
+  &__suggest-remove-tl {
+    .remove-tl-contents {
+      display: flex;
+      flex-direction: column;
+
+      p {
+        font-size: 14px;
+        margin: 0;
+        line-height: 1.375rem;
+      }
+
+      button {
+        font-size: 14px;
+        font-weight: bold;
+        border: 0;
+        padding: 0;
+        text-align: initial;
+        margin-top: 10px;
+        background-color: transparent;
+        text-decoration: underline;
+        cursor: pointer;
+      }
+    }
+  }
+
+  &__button-rows {
+    &__success {
+      display: flex;
+      column-gap: 1rem;
+      button {
+        flex: 1;
+      }
+    }
+  }
+
+  &__error-code {
+    font-size: 0.75rem;
+    line-height: 1.25rem;
+  }
+
+  &__error-block {
+    margin-top: auto;
+    font-size: 0.875rem;
+  }
+}

--- a/extension/src/popup/components/sendPayment/SendSettings/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendSettings/index.tsx
@@ -1,33 +1,13 @@
-import React, { useEffect } from "react";
-import { useSelector, useDispatch } from "react-redux";
-import { Formik, Form, Field, FieldProps } from "formik";
-import { Icon, Textarea, Link, Button } from "@stellar/design-system";
-import { useTranslation } from "react-i18next";
+import React from "react";
+import { useSelector } from "react-redux";
 
-import { navigateTo } from "popup/helpers/navigate";
-import { useNetworkFees } from "popup/helpers/useNetworkFees";
-import { useIsSwap } from "popup/helpers/useIsSwap";
-import { isMuxedAccount } from "helpers/stellar";
+import { ActionStatus } from "@shared/api/types";
+
+import { tokenSimulationStatusSelector } from "popup/ducks/token-payment";
 import { ROUTES } from "popup/constants/routes";
-import { SubviewHeader } from "popup/components/SubviewHeader";
-import { FormRows } from "popup/basics/Forms";
-import { View } from "popup/basics/layout/View";
-import {
-  saveMemo,
-  transactionDataSelector,
-  isPathPaymentSelector,
-  saveTransactionFee,
-  saveSimulation,
-  transactionSubmissionSelector,
-} from "popup/ducks/transactionSubmission";
 
-import { InfoTooltip } from "popup/basics/InfoTooltip";
-import { publicKeySelector } from "popup/ducks/accountServices";
-import { parseTokenAmount } from "popup/helpers/soroban";
-import "../styles.scss";
-import { Balances, TokenBalance } from "@shared/api/types";
-import { getNetworkDetails } from "background/helpers/account";
-import { INDEXER_URL } from "@shared/constants/mercury";
+import { Settings } from "./Settings";
+import { SettingsFail } from "./SettingsFail";
 
 export const SendSettings = ({
   previous,
@@ -36,281 +16,19 @@ export const SendSettings = ({
   previous: ROUTES;
   next: ROUTES;
 }) => {
-  const { t } = useTranslation();
-  const dispatch = useDispatch();
-  const {
-    asset,
-    amount,
-    destination,
-    transactionFee,
-    memo,
-    allowedSlippage,
-    isToken,
-  } = useSelector(transactionDataSelector);
-  const isPathPayment = useSelector(isPathPaymentSelector);
-  const publicKey = useSelector(publicKeySelector);
-  const { accountBalances } = useSelector(transactionSubmissionSelector);
-  const isSwap = useIsSwap();
-  const { recommendedFee } = useNetworkFees();
+  const simStatus = useSelector(tokenSimulationStatusSelector);
 
-  // use default transaction fee if unset
-  useEffect(() => {
-    if (!transactionFee) {
-      dispatch(saveTransactionFee(recommendedFee));
+  const render = () => {
+    switch (simStatus) {
+      case ActionStatus.IDLE:
+      case ActionStatus.PENDING:
+        return <Settings previous={previous} next={next} />;
+      case ActionStatus.ERROR:
+        return <SettingsFail />;
+      default:
+        return <Settings previous={previous} next={next} />;
     }
-  }, [dispatch, recommendedFee, transactionFee]);
+  };
 
-  const handleTxFeeNav = () =>
-    navigateTo(isSwap ? ROUTES.swapSettingsFee : ROUTES.sendPaymentSettingsFee);
-
-  const handleSlippageNav = () =>
-    navigateTo(
-      isSwap ? ROUTES.swapSettingsSlippage : ROUTES.sendPaymentSettingsSlippage,
-    );
-
-  // dont show memo for regular sends to Muxed, or for swaps
-  const showMemo = !isSwap && !isMuxedAccount(destination);
-  const showSlippage = isPathPayment || isSwap;
-
-  async function goToReview() {
-    if (isToken) {
-      const assetAddress = asset.split(":")[1];
-      const balances =
-        accountBalances.balances || ({} as NonNullable<Balances>);
-      const assetBalance = balances[asset] as TokenBalance;
-
-      if (!assetBalance) {
-        throw new Error("Asset Balance not available");
-      }
-
-      const parsedAmount = parseTokenAmount(
-        amount,
-        Number(assetBalance.decimals),
-      );
-
-      const params = {
-        publicKey,
-        destination,
-        amount: parsedAmount.toNumber(),
-      };
-
-      try {
-        const networkDetails = await getNetworkDetails();
-        const options = {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            address: assetAddress,
-            pub_key: publicKey,
-            memo,
-            params,
-            network_url: networkDetails.sorobanRpcUrl,
-            network_passphrase: networkDetails.networkPassphrase,
-          }),
-        };
-        const response = await fetch(
-          `${INDEXER_URL}/simulate-token-transfer`,
-          options,
-        );
-        if (!response.ok) {
-          throw new Error("failed to simluate token transfer");
-        }
-        const {
-          preparedTransaction,
-          simulationResponse,
-        } = await response.json();
-
-        if (preparedTransaction) {
-          dispatch(
-            saveSimulation({
-              response: simulationResponse,
-              preparedTransaction,
-            }),
-          );
-          navigateTo(next);
-          return;
-        }
-        throw new Error(`Failed to simluate transaction`);
-      } catch (error) {
-        throw new Error(
-          `Failed to simluate transaction: ${JSON.stringify(error)}`,
-        );
-      }
-    }
-    navigateTo(next);
-  }
-
-  return (
-    <View data-testid="send-settings-view">
-      <SubviewHeader
-        title={`${isSwap ? t("Swap") : t("Send")} ${t("Settings")}`}
-        customBackAction={() => navigateTo(previous)}
-      />
-      <Formik
-        initialValues={{ memo }}
-        onSubmit={(values) => {
-          dispatch(saveMemo(values.memo));
-        }}
-      >
-        {({ submitForm }) => (
-          <Form className="View__contentAndFooterWrapper">
-            <View.Content>
-              <FormRows>
-                {!isToken ? (
-                  <div className="SendSettings__row">
-                    <div className="SendSettings__row__left">
-                      <InfoTooltip
-                        infoText={
-                          <span>
-                            {t("Maximum network transaction fee to be paid")}{" "}
-                            <Link
-                              variant="secondary"
-                              href="https://developers.stellar.org/docs/glossary/fees/#base-fee"
-                              rel="noreferrer"
-                              target="_blank"
-                            >
-                              {t("Learn more")}
-                            </Link>
-                          </span>
-                        }
-                        placement="bottom"
-                      >
-                        <span
-                          className="SendSettings__row__title SendSettings__clickable"
-                          onClick={() => {
-                            submitForm();
-                            handleTxFeeNav();
-                          }}
-                        >
-                          {t("Transaction fee")}
-                        </span>
-                      </InfoTooltip>
-                    </div>
-                    <div
-                      className="SendSettings__row__right SendSettings__clickable"
-                      onClick={() => {
-                        submitForm();
-                        handleTxFeeNav();
-                      }}
-                    >
-                      <span data-testid="SendSettingsTransactionFee">
-                        {transactionFee} XLM
-                      </span>
-                      <div>
-                        <Icon.ChevronRight />
-                      </div>
-                    </div>
-                  </div>
-                ) : null}
-
-                {showSlippage && (
-                  <div className="SendSettings__row">
-                    <div className="SendSettings__row__left">
-                      <InfoTooltip
-                        infoText={
-                          <span>
-                            {t(
-                              "Allowed downward variation in the destination amount",
-                            )}{" "}
-                            <Link
-                              variant="secondary"
-                              href="https://www.freighter.app/faq"
-                              rel="noreferrer"
-                              target="_blank"
-                            >
-                              {t("Learn more")}
-                            </Link>
-                          </span>
-                        }
-                        placement="bottom"
-                      >
-                        <span
-                          className="SendSettings__row__title SendSettings__clickable"
-                          onClick={() => {
-                            submitForm();
-                            handleSlippageNav();
-                          }}
-                        >
-                          {t("Allowed slippage")}
-                        </span>
-                      </InfoTooltip>
-                    </div>
-                    <div
-                      className="SendSettings__row__right SendSettings__clickable"
-                      onClick={() => {
-                        submitForm();
-                        handleSlippageNav();
-                      }}
-                    >
-                      <span data-testid="SendSettingsAllowedSlippage">
-                        {allowedSlippage}%
-                      </span>
-                      <div>
-                        <Icon.ChevronRight />
-                      </div>
-                    </div>
-                  </div>
-                )}
-                {showMemo && (
-                  <>
-                    <div className="SendSettings__row">
-                      <div className="SendSettings__row__left">
-                        <InfoTooltip
-                          infoText={
-                            <span>
-                              {t("Include a custom memo to this transaction")}{" "}
-                              <Link
-                                variant="secondary"
-                                href="https://developers.stellar.org/docs/glossary/transactions/#memo"
-                                rel="noreferrer"
-                                target="_blank"
-                              >
-                                {t("Learn more")}
-                              </Link>
-                            </span>
-                          }
-                          placement="bottom"
-                        >
-                          <span className="SendSettings__row__title">
-                            {t("Memo")}
-                          </span>
-                        </InfoTooltip>
-                      </div>
-                      <div className="SendSettings__row__right">
-                        <span></span>
-                      </div>
-                    </div>
-                    <Field name="memo">
-                      {({ field }: FieldProps) => (
-                        <Textarea
-                          fieldSize="md"
-                          id="mnemonic-input"
-                          placeholder={t("Memo (optional)")}
-                          {...field}
-                        />
-                      )}
-                    </Field>
-                  </>
-                )}
-              </FormRows>
-            </View.Content>
-            <View.Footer>
-              <Button
-                size="md"
-                isFullWidth
-                onClick={goToReview}
-                type="submit"
-                variant="secondary"
-                data-testid="send-settings-btn-continue"
-              >
-                {t("Review")} {isSwap ? t("Swap") : t("Send")}
-              </Button>
-            </View.Footer>
-          </Form>
-        )}
-      </Formik>
-    </View>
-  );
+  return render();
 };

--- a/extension/src/popup/constants/metricsNames.ts
+++ b/extension/src/popup/constants/metricsNames.ts
@@ -58,6 +58,7 @@ export const METRIC_NAMES = {
   sendPaymentSuccess: "send payment: payment success",
   sendPaymentPathPaymentSuccess: "send payment: path payment success",
   sendPaymentError: "send payment: error",
+  simuilateTokenPaymentError: "failed to simulate token payment",
 
   viewSwap: "loaded screen: swap",
   swapAmount: "loaded screen: swap amount",

--- a/extension/src/popup/ducks/token-payment.ts
+++ b/extension/src/popup/ducks/token-payment.ts
@@ -1,4 +1,4 @@
-import { createAsyncThunk } from "@reduxjs/toolkit";
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { ActionStatus, ErrorMessage } from "@shared/api/types";
 import { INDEXER_URL } from "@shared/constants/mercury";
 import { SorobanRpc } from "stellar-sdk";
@@ -10,15 +10,15 @@ export const simulateTokenPayment = createAsyncThunk<
   },
   {
     address: string;
-    pub_key: string;
+    publicKey: string;
     memo: string;
     params: {
       publicKey: string;
       destination: string;
       amount: number;
     };
-    network_url: string;
-    network_passphrase: string;
+    networkUrl: string;
+    networkPassphrase: string;
   },
   {
     rejectValue: ErrorMessage;
@@ -30,14 +30,21 @@ export const simulateTokenPayment = createAsyncThunk<
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(args),
+      body: JSON.stringify({
+        address: args.address,
+        pub_key: args.publicKey,
+        memo: args.memo,
+        params: args.params,
+        network_url: args.networkUrl,
+        network_passphrase: args.networkPassphrase,
+      }),
     };
     const res = await fetch(`${INDEXER_URL}/simulate-token-transfer`, options);
     const response = await res.json();
 
     if (!res.ok) {
       return thunkApi.rejectWithValue({
-        errorMessage: response,
+        errorMessage: response.message,
       });
     }
     return response;
@@ -50,13 +57,55 @@ export const simulateTokenPayment = createAsyncThunk<
 });
 
 interface InitialState {
-  preparedTransaction: string | null;
-  simulationTransaction: SorobanRpc.Api.SimulateTransactionSuccessResponse | null;
+  error: ErrorMessage | undefined;
+  simulation: {
+    preparedTransaction: string | null;
+    simulationTransaction: SorobanRpc.Api.SimulateTransactionSuccessResponse | null;
+  };
   simStatus: ActionStatus;
 }
 
 export const initialState: InitialState = {
-  preparedTransaction: null,
-  simulationTransaction: null,
+  error: undefined,
+  simulation: {
+    preparedTransaction: null,
+    simulationTransaction: null,
+  },
   simStatus: ActionStatus.IDLE,
 };
+
+const tokenPaymentsSimulationSlice = createSlice({
+  name: "tokenPaymentSimulation",
+  initialState,
+  reducers: {
+    resetSimulation: () => initialState,
+  },
+  extraReducers: (builder) => {
+    builder.addCase(simulateTokenPayment.pending, (state) => {
+      state.simStatus = ActionStatus.PENDING;
+    });
+    builder.addCase(simulateTokenPayment.rejected, (state, action) => {
+      state.simStatus = ActionStatus.ERROR;
+      state.error = action.payload;
+    });
+    builder.addCase(simulateTokenPayment.fulfilled, (state, action) => {
+      state.simStatus = ActionStatus.SUCCESS;
+      state.simulation = action.payload;
+    });
+  },
+});
+
+export const { resetSimulation } = tokenPaymentsSimulationSlice.actions;
+export const { reducer } = tokenPaymentsSimulationSlice;
+
+export const tokenSimulationSelector = (state: {
+  tokenPaymentSimulation: InitialState;
+}) => state.tokenPaymentSimulation;
+
+export const tokenSimulationStatusSelector = (state: {
+  tokenPaymentSimulation: InitialState;
+}) => state.tokenPaymentSimulation.simStatus;
+
+export const tokenSimulationErrorSelector = (state: {
+  tokenPaymentSimulation: InitialState;
+}) => state.tokenPaymentSimulation.error;

--- a/extension/src/popup/ducks/token-payment.ts
+++ b/extension/src/popup/ducks/token-payment.ts
@@ -1,0 +1,62 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import { ActionStatus, ErrorMessage } from "@shared/api/types";
+import { INDEXER_URL } from "@shared/constants/mercury";
+import { SorobanRpc } from "stellar-sdk";
+
+export const simulateTokenPayment = createAsyncThunk<
+  {
+    preparedTransaction: string;
+    simulationTransaction: SorobanRpc.Api.SimulateTransactionSuccessResponse;
+  },
+  {
+    address: string;
+    pub_key: string;
+    memo: string;
+    params: {
+      publicKey: string;
+      destination: string;
+      amount: number;
+    };
+    network_url: string;
+    network_passphrase: string;
+  },
+  {
+    rejectValue: ErrorMessage;
+  }
+>("simulateTokenPayment", async (args, thunkApi) => {
+  try {
+    const options = {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(args),
+    };
+    const res = await fetch(`${INDEXER_URL}/simulate-token-transfer`, options);
+    const response = await res.json();
+
+    if (!res.ok) {
+      return thunkApi.rejectWithValue({
+        errorMessage: response,
+      });
+    }
+    return response;
+  } catch (e) {
+    return thunkApi.rejectWithValue({
+      errorMessage: e.message || e,
+      response: e.response?.data,
+    });
+  }
+});
+
+interface InitialState {
+  preparedTransaction: string | null;
+  simulationTransaction: SorobanRpc.Api.SimulateTransactionSuccessResponse | null;
+  simStatus: ActionStatus;
+}
+
+export const initialState: InitialState = {
+  preparedTransaction: null,
+  simulationTransaction: null,
+  simStatus: ActionStatus.IDLE,
+};


### PR DESCRIPTION
This makes SendSettings work more like ConfirmSettings.
Moves the token-simulation action from the view to a new redux slice.
Uses new failure screen for any simulation rejections.