### PR TITLE
enabling mainnet access to Soroban

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -11,6 +11,7 @@ import {
   MigratableAccount,
   MigratedAccount,
   Settings,
+  IndexerSettings,
 } from "./types";
 import {
   MAINNET_NETWORK_DETAILS,
@@ -922,7 +923,7 @@ export const editCustomNetwork = async ({
   return response;
 };
 
-export const loadSettings = (): Promise<Settings> =>
+export const loadSettings = (): Promise<Settings & IndexerSettings> =>
   sendMessageToBackground({
     type: SERVICE_TYPES.LOAD_SETTINGS,
   });

--- a/@shared/api/types.ts
+++ b/@shared/api/types.ts
@@ -50,6 +50,7 @@ export interface Response {
   isSafetyValidationEnabled: boolean;
   isValidatingSafeAssetsEnabled: boolean;
   isExperimentalModeEnabled: boolean;
+  isSorobanPublicEnabled: boolean;
   networkDetails: NetworkDetails;
   sorobanRpcUrl: string;
   networksList: NetworkDetails[];
@@ -137,6 +138,10 @@ export interface Preferences {
   networksList: NetworkDetails[];
   error: string;
   isExperimentalModeEnabled: boolean;
+}
+
+export interface IndexerSettings {
+  isSorobanPublicEnabled: boolean;
 }
 
 export type Settings = {

--- a/@shared/constants/stellar.ts
+++ b/@shared/constants/stellar.ts
@@ -24,6 +24,8 @@ export enum FRIENDBOT_URLS {
 }
 
 export const SOROBAN_RPC_URLS: { [key in NETWORKS]?: string } = {
+  [NETWORKS.PUBLIC]:
+    "http://soroban-rpc-pubnet-prd.soroban-rpc-pubnet-prd.svc.cluster.local:8000",
   [NETWORKS.TESTNET]: "https://soroban-testnet.stellar.org/",
   [NETWORKS.FUTURENET]: "https://rpc-futurenet.stellar.org/",
 };
@@ -42,6 +44,7 @@ export const MAINNET_NETWORK_DETAILS: NetworkDetails = {
   networkName: NETWORK_NAMES.PUBNET,
   networkUrl: NETWORK_URLS.PUBLIC,
   networkPassphrase: Networks.PUBLIC,
+  sorobanRpcUrl: SOROBAN_RPC_URLS.PUBLIC,
 };
 
 export const TESTNET_NETWORK_DETAILS: NetworkDetails = {

--- a/extension/src/background/helpers/account.ts
+++ b/extension/src/background/helpers/account.ts
@@ -126,11 +126,6 @@ export const getNetworksList = async () => {
   return networksList;
 };
 
-export const getIsSorobanSupported = async () => {
-  const networkDetails = await getNetworkDetails();
-  return !!networkDetails.sorobanRpcUrl;
-};
-
 export const subscribeAccount = async (publicKey: string) => {
   // if pub key already has a subscription setup, skip this
   const keyId = await localStore.getItem(KEY_ID);

--- a/extension/src/background/messageListener/popupMessageListener.ts
+++ b/extension/src/background/messageListener/popupMessageListener.ts
@@ -13,6 +13,7 @@ import browser from "webextension-polyfill";
 import { fromMnemonic, generateMnemonic } from "stellar-hd-wallet";
 import { BigNumber } from "bignumber.js";
 
+import { INDEXER_URL } from "@shared/constants/mercury";
 import { SERVICE_TYPES } from "@shared/constants/services";
 import { APPLICATION_STATE } from "@shared/constants/applicationState";
 import { WalletType } from "@shared/constants/hardwareWallet";
@@ -1213,6 +1214,15 @@ export const popupMessageListener = (request: Request, sessionStore: Store) => {
     const isDataSharingAllowed =
       (await localStore.getItem(DATA_SHARING_ID)) ?? true;
 
+    let resJson = { useSorobanPublic: false };
+
+    try {
+      const res = await fetch(`${INDEXER_URL}/feature-flags`);
+      resJson = await res.json();
+    } catch (e) {
+      console.error(e);
+    }
+
     return {
       allowList: await getAllowList(),
       isDataSharingAllowed,
@@ -1222,6 +1232,7 @@ export const popupMessageListener = (request: Request, sessionStore: Store) => {
       isExperimentalModeEnabled: await getIsExperimentalModeEnabled(),
       networkDetails: await getNetworkDetails(),
       networksList: await getNetworksList(),
+      isSorobanPublicEnabled: resJson.useSorobanPublic,
     };
   };
 

--- a/extension/src/popup/views/AccountHistory/index.tsx
+++ b/extension/src/popup/views/AccountHistory/index.tsx
@@ -9,10 +9,7 @@ import { ActionStatus, HorizonOperation } from "@shared/api/types";
 import { SorobanTokenInterface } from "@shared/constants/soroban/token";
 
 import { publicKeySelector } from "popup/ducks/accountServices";
-import {
-  settingsNetworkDetailsSelector,
-  settingsSorobanSupportedSelector,
-} from "popup/ducks/settings";
+import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
 import { transactionSubmissionSelector } from "popup/ducks/transactionSubmission";
 import {
   getIsPayment,
@@ -62,7 +59,6 @@ export const AccountHistory = () => {
   const { accountBalances, accountBalanceStatus } = useSelector(
     transactionSubmissionSelector,
   );
-  const isSorobanSuported = useSelector(settingsSorobanSupportedSelector);
 
   const [selectedSegment, setSelectedSegment] = useState(SELECTOR_OPTIONS.ALL);
   const [historySegments, setHistorySegments] = useState(
@@ -90,15 +86,10 @@ export const AccountHistory = () => {
     const isSupportedSorobanAccountItem = (operation: HorizonOperation) =>
       getIsSupportedSorobanOp(operation, networkDetails);
 
-    const createSegments = (
-      operations: HorizonOperation[],
-      showSorobanTxs = false,
-    ) => {
-      const _operations = showSorobanTxs
-        ? operations.filter(
-            (op) => op.type_i !== 24 || isSupportedSorobanAccountItem(op),
-          )
-        : operations.filter((op) => op.type_i !== 24);
+    const createSegments = (operations: HorizonOperation[]) => {
+      const _operations = operations.filter(
+        (op) => op.type_i !== 24 || isSupportedSorobanAccountItem(op),
+      );
       const segments = {
         [SELECTOR_OPTIONS.ALL]: [] as HistoryItemOperation[],
         [SELECTOR_OPTIONS.SENT]: [] as HistoryItemOperation[],
@@ -145,9 +136,7 @@ export const AccountHistory = () => {
           publicKey,
           networkDetails,
         });
-        setHistorySegments(
-          createSegments(operations, isSorobanSuported as boolean),
-        );
+        setHistorySegments(createSegments(operations));
       } catch (e) {
         console.error(e);
       }
@@ -160,7 +149,7 @@ export const AccountHistory = () => {
     };
 
     getData();
-  }, [publicKey, networkDetails, isSorobanSuported, dispatch]);
+  }, [publicKey, networkDetails, dispatch]);
 
   return isDetailViewShowing ? (
     <TransactionDetail {...detailViewProps} />


### PR DESCRIPTION
* This looks for freighter-backend API to allow Mainnet Soroban access
* On Mainnet, the API gates adding a soroban token and sending a token payment. Viewing Soroban account history and signing a Soroban XDR are still permitted
* All other networks have Soroban enabled by default