### PR TITLE
fixes router loading window by adding full height

### DIFF
--- a/extension/src/popup/Router.tsx
+++ b/extension/src/popup/Router.tsx
@@ -247,7 +247,11 @@ export const Router = () => {
     applicationState === APPLICATION_STATE.APPLICATION_LOADING ||
     !networkDetails.network
   ) {
-    return <Loading />;
+    return (
+      <div className="RouterLoading">
+        <Loading />
+      </div>
+    );
   }
 
   return (

--- a/extension/src/popup/styles/global.scss
+++ b/extension/src/popup/styles/global.scss
@@ -95,6 +95,12 @@ a {
   }
 }
 
+.RouterLoading {
+  .View__content {
+    height: 100vh;
+  }
+}
+
 // TODO: fix in SDS
 .sds-theme-light p,
 .sds-theme-light ul,


### PR DESCRIPTION
Adds a full height container around our router loader to avoid the container getting cut off when rendered top level in the router.