### PR TITLE
Feature/improve router loading state

### DIFF
--- a/extension/src/popup/Router.tsx
+++ b/extension/src/popup/Router.tsx
@@ -239,6 +239,27 @@ const RouteListener = () => {
   return null;
 };
 
+const SHOW_NAV_ROUTES = [
+  ROUTES.account,
+  ROUTES.accountHistory,
+  ROUTES.settings,
+  ROUTES.connectWallet,
+  ROUTES.connectWalletPlugin,
+  ROUTES.swapSettings,
+  ROUTES.sendPaymentAmount,
+];
+
+const NO_APP_LAYOUT_ROUTES = [
+  ROUTES.mnemonicPhrase,
+  ROUTES.mnemonicPhraseConfirmed,
+  ROUTES.accountCreator,
+  ROUTES.accountMigration,
+  ROUTES.recoverAccount,
+  ROUTES.recoverAccountSuccess,
+  ROUTES.pinExtension,
+  ROUTES.welcome,
+];
+
 const Outlet = () => {
   const dispatch = useDispatch();
   const location = useLocation();
@@ -255,26 +276,14 @@ const Outlet = () => {
 
   const showNav =
     location.pathname &&
-    ((location.pathname === "/" &&
+    ((location.pathname === ROUTES.welcome &&
       applicationState === APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED) ||
-      location.pathname === ROUTES.account ||
-      location.pathname === ROUTES.accountHistory ||
-      location.pathname === ROUTES.settings ||
-      location.pathname === ROUTES.connectWallet ||
-      location.pathname === ROUTES.connectWalletPlugin ||
-      location.pathname === ROUTES.swapSettings ||
-      location.pathname === ROUTES.sendPaymentAmount ||
+      SHOW_NAV_ROUTES.some((route) => location.pathname === route) ||
       isSwap);
 
-  const isAppLayout =
-    location.pathname !== "/" &&
-    location.pathname !== ROUTES.mnemonicPhrase &&
-    location.pathname !== ROUTES.mnemonicPhraseConfirmed &&
-    location.pathname !== ROUTES.accountCreator &&
-    location.pathname !== ROUTES.accountMigration &&
-    location.pathname !== ROUTES.recoverAccount &&
-    location.pathname !== ROUTES.recoverAccountSuccess &&
-    location.pathname !== ROUTES.pinExtension;
+  const isAppLayout = NO_APP_LAYOUT_ROUTES.every(
+    (route) => route !== location.pathname,
+  );
 
   const isLoadingSettings =
     applicationState === APPLICATION_STATE.APPLICATION_LOADING ||

--- a/extension/src/popup/Router.tsx
+++ b/extension/src/popup/Router.tsx
@@ -76,6 +76,7 @@ import { ReviewAuth } from "./views/ReviewAuth";
 
 import { SorobanProvider } from "./SorobanContext";
 import { View } from "./basics/layout/View";
+import { BottomNav } from "./components/BottomNav";
 
 export const PublicKeyRoute = (props: RouteProps) => {
   const location = useLocation();
@@ -237,7 +238,8 @@ const RouteListener = () => {
   return null;
 };
 
-export const Router = () => {
+const Outlet = () => {
+  const showNav = true;
   const dispatch = useDispatch();
   const applicationState = useSelector(applicationStateSelector);
   const networkDetails = useSelector(settingsNetworkDetailsSelector);
@@ -248,137 +250,141 @@ export const Router = () => {
     dispatch(loadSettings());
   }, [dispatch]);
 
-  if (
+  const isLoadingSettings =
     applicationState === APPLICATION_STATE.APPLICATION_LOADING ||
     settingsState === SettingsState.LOADING ||
     settingsState === SettingsState.IDLE ||
-    !networkDetails.network
-  ) {
-    return (
-      <View>
-        <div className="RouterLoading">
-          <Loading />
-        </div>
-      </View>
-    );
-  }
+    !networkDetails.network;
 
   return (
-    <HashRouter>
-      <RouteListener />
-      <Switch>
-        <PublicKeyRoute exact path={ROUTES.account}>
-          <Account />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.accountHistory}>
-          <AccountHistory />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.addAccount}>
-          <AddAccount />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.importAccount}>
-          <ImportAccount />
-        </PublicKeyRoute>
-        <PublicKeyRoute exact path={ROUTES.connectWallet}>
-          <SelectHardwareWallet />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.connectWalletPlugin}>
-          <PluginWallet />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.connectDevice}>
-          <DeviceConnect />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.viewPublicKey}>
-          <ViewPublicKey />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.signTransaction}>
-          <SignTransaction />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.reviewAuthorization}>
-          <ReviewAuth />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.signAuthEntry}>
-          <SignAuthEntry />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.signBlob}>
-          <SignBlob />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.displayBackupPhrase}>
-          <DisplayBackupPhrase />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.grantAccess}>
-          <GrantAccess />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.mnemonicPhrase}>
-          <MnemonicPhrase mnemonicPhrase="" />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.settings} exact>
-          <Settings />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.preferences}>
-          <Preferences />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.security}>
-          <Security />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.about}>
-          <About />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.leaveFeedback}>
-          <LeaveFeedback />
-        </PublicKeyRoute>
-        <UnlockAccountRoute path={ROUTES.unlockAccount}>
-          <UnlockAccount />
-        </UnlockAccountRoute>
-        <PublicKeyRoute path={ROUTES.mnemonicPhraseConfirmed}>
-          <FullscreenSuccessMessage />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.pinExtension}>
-          <PinExtension />
-        </PublicKeyRoute>
-        <Route path={ROUTES.accountCreator}>
-          <AccountCreator />
-        </Route>
-        <Route path={ROUTES.recoverAccount}>
-          <RecoverAccount />
-        </Route>
-        <Route path={ROUTES.verifyAccount}>
-          <VerifyAccount />
-        </Route>
-        <PublicKeyRoute path={ROUTES.recoverAccountSuccess}>
-          <FullscreenSuccessMessage />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.sendPayment}>
-          <SendPayment />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.manageAssets}>
-          <ManageAssets />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.swap}>
-          <Swap />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.manageNetwork}>
-          <ManageNetwork />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.manageConnectedApps}>
-          <ManageConnectedApps />
-        </PublicKeyRoute>
-        <PublicKeyRoute path={ROUTES.accountMigration}>
-          <AccountMigration />
-        </PublicKeyRoute>
+    <View>
+      {isLoadingSettings ? (
+        <Loading />
+      ) : (
+        <Switch>
+          <PublicKeyRoute path={ROUTES.account}>
+            <Account />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.accountHistory}>
+            <AccountHistory />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.addAccount}>
+            <AddAccount />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.importAccount}>
+            <ImportAccount />
+          </PublicKeyRoute>
+          <PublicKeyRoute exact path={ROUTES.connectWallet}>
+            <SelectHardwareWallet />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.connectWalletPlugin}>
+            <PluginWallet />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.connectDevice}>
+            <DeviceConnect />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.viewPublicKey}>
+            <ViewPublicKey />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.signTransaction}>
+            <SignTransaction />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.reviewAuthorization}>
+            <ReviewAuth />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.signAuthEntry}>
+            <SignAuthEntry />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.signBlob}>
+            <SignBlob />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.displayBackupPhrase}>
+            <DisplayBackupPhrase />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.grantAccess}>
+            <GrantAccess />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.mnemonicPhrase}>
+            <MnemonicPhrase mnemonicPhrase="" />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.settings} exact>
+            <Settings />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.preferences}>
+            <Preferences />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.security}>
+            <Security />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.about}>
+            <About />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.leaveFeedback}>
+            <LeaveFeedback />
+          </PublicKeyRoute>
+          <UnlockAccountRoute path={ROUTES.unlockAccount}>
+            <UnlockAccount />
+          </UnlockAccountRoute>
+          <PublicKeyRoute path={ROUTES.mnemonicPhraseConfirmed}>
+            <FullscreenSuccessMessage />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.pinExtension}>
+            <PinExtension />
+          </PublicKeyRoute>
+          <Route path={ROUTES.accountCreator}>
+            <AccountCreator />
+          </Route>
+          <Route path={ROUTES.recoverAccount}>
+            <RecoverAccount />
+          </Route>
+          <Route path={ROUTES.verifyAccount}>
+            <VerifyAccount />
+          </Route>
+          <PublicKeyRoute path={ROUTES.recoverAccountSuccess}>
+            <FullscreenSuccessMessage />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.sendPayment}>
+            <SendPayment />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.manageAssets}>
+            <ManageAssets />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.swap}>
+            <Swap />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.manageNetwork}>
+            <ManageNetwork />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.manageConnectedApps}>
+            <ManageConnectedApps />
+          </PublicKeyRoute>
+          <PublicKeyRoute path={ROUTES.accountMigration}>
+            <AccountMigration />
+          </PublicKeyRoute>
 
-        {DEV_SERVER && (
-          <>
-            <Route path={ROUTES.debug}>
-              <Debug />
-            </Route>
-            <Route path={ROUTES.integrationTest}>
-              <IntegrationTest />
-            </Route>
-          </>
-        )}
-        <HomeRoute />
-      </Switch>
-    </HashRouter>
+          {DEV_SERVER && (
+            <>
+              <Route path={ROUTES.debug}>
+                <Debug />
+              </Route>
+              <Route path={ROUTES.integrationTest}>
+                <IntegrationTest />
+              </Route>
+            </>
+          )}
+          <HomeRoute />
+        </Switch>
+      )}
+      {showNav && <BottomNav />}
+    </View>
   );
 };
+
+export const Router = () => (
+  <HashRouter>
+    <RouteListener />
+    <Switch>
+      <Route path="/" component={Outlet} />
+    </Switch>
+  </HashRouter>
+);

--- a/extension/src/popup/Router.tsx
+++ b/extension/src/popup/Router.tsx
@@ -77,6 +77,7 @@ import { ReviewAuth } from "./views/ReviewAuth";
 import { SorobanProvider } from "./SorobanContext";
 import { View } from "./basics/layout/View";
 import { BottomNav } from "./components/BottomNav";
+import { useIsSwap } from "./helpers/useIsSwap";
 
 export const PublicKeyRoute = (props: RouteProps) => {
   const location = useLocation();
@@ -239,8 +240,21 @@ const RouteListener = () => {
 };
 
 const Outlet = () => {
-  const showNav = true;
   const dispatch = useDispatch();
+  const location = useLocation();
+  const isSwap = useIsSwap();
+  const showNav =
+    location.pathname &&
+    (location.pathname === "/" ||
+      location.pathname === ROUTES.account ||
+      location.pathname === ROUTES.accountHistory ||
+      location.pathname === ROUTES.settings ||
+      location.pathname === ROUTES.connectWallet ||
+      location.pathname === ROUTES.connectWalletPlugin ||
+      location.pathname === ROUTES.swapSettings ||
+      location.pathname === ROUTES.sendPaymentAmount ||
+      isSwap);
+
   const applicationState = useSelector(applicationStateSelector);
   const networkDetails = useSelector(settingsNetworkDetailsSelector);
   const settingsState = useSelector(settingsStateSelector);
@@ -262,7 +276,7 @@ const Outlet = () => {
         <Loading />
       ) : (
         <Switch>
-          <PublicKeyRoute path={ROUTES.account}>
+          <PublicKeyRoute exact path={ROUTES.account}>
             <Account />
           </PublicKeyRoute>
           <PublicKeyRoute path={ROUTES.accountHistory}>

--- a/extension/src/popup/Router.tsx
+++ b/extension/src/popup/Router.tsx
@@ -243,17 +243,6 @@ const Outlet = () => {
   const dispatch = useDispatch();
   const location = useLocation();
   const isSwap = useIsSwap();
-  const showNav =
-    location.pathname &&
-    (location.pathname === "/" ||
-      location.pathname === ROUTES.account ||
-      location.pathname === ROUTES.accountHistory ||
-      location.pathname === ROUTES.settings ||
-      location.pathname === ROUTES.connectWallet ||
-      location.pathname === ROUTES.connectWalletPlugin ||
-      location.pathname === ROUTES.swapSettings ||
-      location.pathname === ROUTES.sendPaymentAmount ||
-      isSwap);
 
   const applicationState = useSelector(applicationStateSelector);
   const networkDetails = useSelector(settingsNetworkDetailsSelector);
@@ -264,6 +253,29 @@ const Outlet = () => {
     dispatch(loadSettings());
   }, [dispatch]);
 
+  const showNav =
+    location.pathname &&
+    ((location.pathname === "/" &&
+      applicationState === APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED) ||
+      location.pathname === ROUTES.account ||
+      location.pathname === ROUTES.accountHistory ||
+      location.pathname === ROUTES.settings ||
+      location.pathname === ROUTES.connectWallet ||
+      location.pathname === ROUTES.connectWalletPlugin ||
+      location.pathname === ROUTES.swapSettings ||
+      location.pathname === ROUTES.sendPaymentAmount ||
+      isSwap);
+
+  const isAppLayout =
+    location.pathname !== "/" &&
+    location.pathname !== ROUTES.mnemonicPhrase &&
+    location.pathname !== ROUTES.mnemonicPhraseConfirmed &&
+    location.pathname !== ROUTES.accountCreator &&
+    location.pathname !== ROUTES.accountMigration &&
+    location.pathname !== ROUTES.recoverAccount &&
+    location.pathname !== ROUTES.recoverAccountSuccess &&
+    location.pathname !== ROUTES.pinExtension;
+
   const isLoadingSettings =
     applicationState === APPLICATION_STATE.APPLICATION_LOADING ||
     settingsState === SettingsState.LOADING ||
@@ -271,7 +283,7 @@ const Outlet = () => {
     !networkDetails.network;
 
   return (
-    <View>
+    <View isAppLayout={isAppLayout}>
       {isLoadingSettings ? (
         <Loading />
       ) : (

--- a/extension/src/popup/components/ErrorBoundary/index.tsx
+++ b/extension/src/popup/components/ErrorBoundary/index.tsx
@@ -54,7 +54,7 @@ export const UnhandledError = ({
   // expected to work outside of <Router />
   const isOnAccount = window.location.hash === "#/account";
   return (
-    <View>
+    <React.Fragment>
       <View.AppHeader pageTitle={t("Error")} />
       <View.Content>
         <div className="UnexpectedError__content">
@@ -89,6 +89,6 @@ export const UnhandledError = ({
           </Button>
         )}
       </View.Footer>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/components/account/AssetDetail/index.tsx
+++ b/extension/src/popup/components/account/AssetDetail/index.tsx
@@ -132,7 +132,7 @@ export const AssetDetail = ({
   return isDetailViewShowing ? (
     <TransactionDetail {...detailViewProps} />
   ) : (
-    <View>
+    <React.Fragment>
       <SubviewHeader
         title={canonical.code}
         subtitle={
@@ -317,6 +317,6 @@ export const AssetDetail = ({
           </div>
         </SlideupModal>
       )}
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/components/accountHistory/TransactionDetail/index.tsx
+++ b/extension/src/popup/components/accountHistory/TransactionDetail/index.tsx
@@ -76,7 +76,7 @@ export const TransactionDetail = ({
   const networkDetails = useSelector(settingsNetworkDetailsSelector);
 
   return assetIssuer && !assetDomain ? null : (
-    <View>
+    <React.Fragment>
       <SubviewHeader
         customBackAction={() => setIsDetailViewShowing(false)}
         title={headerTitle}
@@ -162,6 +162,6 @@ export const TransactionDetail = ({
           </Button>
         ) : null}
       </View.Footer>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/components/manageAssets/AddAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/AddAsset/index.tsx
@@ -81,7 +81,7 @@ export const AddAsset = () => {
     <Formik initialValues={initialValues} onSubmit={handleSubmit}>
       {({ dirty, errors, isSubmitting, isValid, touched }) => (
         <Form>
-          <View>
+          <React.Fragment>
             <SubviewHeader title={t("Add Another Asset")} />
             <View.Content>
               <FormRows>
@@ -138,7 +138,7 @@ export const AddAsset = () => {
                 {t("Search")}
               </Button>
             </View.Footer>
-          </View>
+          </React.Fragment>
         </Form>
       )}
     </Formik>

--- a/extension/src/popup/components/manageAssets/AddToken/index.tsx
+++ b/extension/src/popup/components/manageAssets/AddToken/index.tsx
@@ -214,7 +214,7 @@ export const AddToken = () => {
             setHasNoResults(false);
           }}
         >
-          <View data-testid="add-token">
+          <React.Fragment data-testid="add-token">
             <SubviewHeader title={t("Add a Soroban token by ID")} />
             <View.Content>
               <FormRows>
@@ -264,7 +264,7 @@ export const AddToken = () => {
                 </div>
               </FormRows>
             </View.Content>
-          </View>
+          </React.Fragment>
         </Form>
       )}
     </Formik>

--- a/extension/src/popup/components/manageAssets/AddToken/index.tsx
+++ b/extension/src/popup/components/manageAssets/AddToken/index.tsx
@@ -214,7 +214,7 @@ export const AddToken = () => {
             setHasNoResults(false);
           }}
         >
-          <React.Fragment data-testid="add-token">
+          <React.Fragment>
             <SubviewHeader title={t("Add a Soroban token by ID")} />
             <View.Content>
               <FormRows>

--- a/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
@@ -113,7 +113,7 @@ export const ChooseAsset = ({ balances }: ChooseAssetProps) => {
   ]);
 
   return (
-    <View data-testid="choose-asset">
+    <React.Fragment data-testid="choose-asset">
       <SubviewHeader
         title="Choose Asset"
         customBackIcon={!managingAssets ? <Icon.Close /> : undefined}
@@ -171,6 +171,6 @@ export const ChooseAsset = ({ balances }: ChooseAssetProps) => {
           </>
         )}
       </View.Footer>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
@@ -113,7 +113,7 @@ export const ChooseAsset = ({ balances }: ChooseAssetProps) => {
   ]);
 
   return (
-    <React.Fragment data-testid="choose-asset">
+    <React.Fragment>
       <SubviewHeader
         title="Choose Asset"
         customBackIcon={!managingAssets ? <Icon.Close /> : undefined}

--- a/extension/src/popup/components/manageAssets/SearchAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/SearchAsset/index.tsx
@@ -137,7 +137,7 @@ export const SearchAsset = () => {
             setHasNoResults(false);
           }}
         >
-          <React.Fragment data-testid="search-asset">
+          <React.Fragment>
             <SubviewHeader title={t("Choose Asset")} />
             <View.Content>
               <FormRows>

--- a/extension/src/popup/components/manageAssets/SearchAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/SearchAsset/index.tsx
@@ -137,7 +137,7 @@ export const SearchAsset = () => {
             setHasNoResults(false);
           }}
         >
-          <View data-testid="search-asset">
+          <React.Fragment data-testid="search-asset">
             <SubviewHeader title={t("Choose Asset")} />
             <View.Content>
               <FormRows>
@@ -202,7 +202,7 @@ export const SearchAsset = () => {
                 ) : null}
               </FormRows>
             </View.Content>
-          </View>
+          </React.Fragment>
         </Form>
       )}
     </Formik>

--- a/extension/src/popup/components/manageAssets/TrustlineError/index.tsx
+++ b/extension/src/popup/components/manageAssets/TrustlineError/index.tsx
@@ -147,7 +147,7 @@ export const TrustlineError = ({
     : TRUSTLINE_ERROR_STATES.UNKNOWN_ERROR;
 
   return (
-    <View data-testid="trustline-error-view">
+    <React.Fragment data-testid="trustline-error-view">
       <SubviewHeader title={t("Trustline Error")} hasBackButton={false} />
       <View.Content>
         <div className="TrustlineError__inset">
@@ -171,6 +171,6 @@ export const TrustlineError = ({
           {t("Got it")}
         </Button>
       </View.Footer>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/components/manageAssets/TrustlineError/index.tsx
+++ b/extension/src/popup/components/manageAssets/TrustlineError/index.tsx
@@ -147,7 +147,7 @@ export const TrustlineError = ({
     : TRUSTLINE_ERROR_STATES.UNKNOWN_ERROR;
 
   return (
-    <React.Fragment data-testid="trustline-error-view">
+    <React.Fragment>
       <SubviewHeader title={t("Trustline Error")} hasBackButton={false} />
       <View.Content>
         <div className="TrustlineError__inset">

--- a/extension/src/popup/components/manageNetwork/NetworkForm/index.tsx
+++ b/extension/src/popup/components/manageNetwork/NetworkForm/index.tsx
@@ -272,7 +272,7 @@ export const NetworkForm = ({ isEditing }: NetworkFormProps) => {
     ) : null;
 
   return (
-    <View>
+    <React.Fragment>
       <SubviewHeader
         title={isEditing ? t("Add Custom Network") : t("Network Details")}
       />
@@ -494,6 +494,6 @@ export const NetworkForm = ({ isEditing }: NetworkFormProps) => {
           </Form>
         )}
       </Formik>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/components/manageNetwork/NetworkSettings/index.tsx
+++ b/extension/src/popup/components/manageNetwork/NetworkSettings/index.tsx
@@ -27,7 +27,7 @@ export const NetworkSettings = () => {
   const { t } = useTranslation();
 
   return (
-    <View>
+    <React.Fragment>
       <SubviewHeader title={t("Network Settings")} />
       <View.Content hasNoTopPadding>
         <div className="NetworkSettings__header">{t("Network")}</div>
@@ -73,6 +73,6 @@ export const NetworkSettings = () => {
           {t("Add custom network")}
         </Button>
       </View.Footer>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/components/sendPayment/SendAmount/SendType/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/SendType/index.tsx
@@ -92,7 +92,7 @@ export const SendType = () => {
   };
 
   return (
-    <View>
+    <React.Fragment>
       <SubviewHeader
         title={t("Send Type")}
         customBackAction={() => navigateTo(ROUTES.sendPaymentAmount)}
@@ -162,6 +162,6 @@ export const SendType = () => {
           </>
         )}
       </Formik>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/components/sendPayment/SendAmount/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/index.tsx
@@ -397,7 +397,7 @@ export const SendAmount = ({
           onContinue={() => navigateTo(next)}
         />
       )}
-      <React.Fragment data-testid="send-amount-view">
+      <React.Fragment>
         <SubviewHeader
           title={`${isSwap ? "Swap" : "Send"} ${parsedSourceAsset.code}`}
           subtitle={

--- a/extension/src/popup/components/sendPayment/SendAmount/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/index.tsx
@@ -44,7 +44,6 @@ import {
   AccountDoesntExistWarning,
   shouldAccountDoesntExistWarning,
 } from "popup/components/sendPayment/SendTo";
-import { BottomNav } from "popup/components/BottomNav";
 import { ScamAssetWarning } from "popup/components/WarningMessages";
 import { TX_SEND_MAX } from "popup/constants/transaction";
 import { BASE_RESERVE } from "@shared/constants/stellar";
@@ -398,7 +397,7 @@ export const SendAmount = ({
           onContinue={() => navigateTo(next)}
         />
       )}
-      <View data-testid="send-amount-view">
+      <React.Fragment data-testid="send-amount-view">
         <SubviewHeader
           title={`${isSwap ? "Swap" : "Send"} ${parsedSourceAsset.code}`}
           subtitle={
@@ -545,8 +544,7 @@ export const SendAmount = ({
             </div>
           </div>
         </View.Content>
-        {isSwap && <BottomNav />}
-      </View>
+      </React.Fragment>
       <LoadingBackground
         onClick={() => {}}
         isActive={showBlockedDomainWarning}

--- a/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
@@ -166,7 +166,7 @@ export const SubmitSuccess = ({ viewDetails }: { viewDetails: () => void }) => {
     accountBalances.balances[asset].available?.isZero();
 
   return (
-    <View data-testid="submit-success-view">
+    <React.Fragment data-testid="submit-success-view">
       <View.AppHeader
         pageTitle={`${t("Successfully")} ${isSwap ? t("swapped") : t("sent")}`}
       />
@@ -238,7 +238,7 @@ export const SubmitSuccess = ({ viewDetails }: { viewDetails: () => void }) => {
           {t("Done")}
         </Button>
       </View.Footer>
-    </View>
+    </React.Fragment>
   );
 };
 
@@ -415,7 +415,7 @@ export const SubmitFail = () => {
   const errorDetails = getErrorDetails(error);
 
   return (
-    <View>
+    <React.Fragment>
       <View.AppHeader pageTitle={t("Error")} />
       <View.Content>
         <div className="SubmitResult__content">
@@ -444,6 +444,6 @@ export const SubmitFail = () => {
           {t("Got it")}
         </Button>
       </View.Footer>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
@@ -166,7 +166,7 @@ export const SubmitSuccess = ({ viewDetails }: { viewDetails: () => void }) => {
     accountBalances.balances[asset].available?.isZero();
 
   return (
-    <React.Fragment data-testid="submit-success-view">
+    <React.Fragment>
       <View.AppHeader
         pageTitle={`${t("Successfully")} ${isSwap ? t("swapped") : t("sent")}`}
       />

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
@@ -424,7 +424,7 @@ export const TransactionDetails = ({ goBack }: { goBack: () => void }) => {
       {hwStatus === ShowOverlayStatus.IN_PROGRESS && hardwareWalletType && (
         <HardwareSign walletType={hardwareWalletType} />
       )}
-      <View data-testid="transaction-details-view">
+      <React.Fragment data-testid="transaction-details-view">
         {submission.submitStatus === ActionStatus.PENDING && (
           <div className="TransactionDetails__processing">
             <div className="TransactionDetails__processing__header">
@@ -603,7 +603,7 @@ export const TransactionDetails = ({ goBack }: { goBack: () => void }) => {
             </>
           )}
         </View.Footer>
-      </View>
+      </React.Fragment>
     </>
   );
 };

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
@@ -424,7 +424,7 @@ export const TransactionDetails = ({ goBack }: { goBack: () => void }) => {
       {hwStatus === ShowOverlayStatus.IN_PROGRESS && hardwareWalletType && (
         <HardwareSign walletType={hardwareWalletType} />
       )}
-      <React.Fragment data-testid="transaction-details-view">
+      <React.Fragment>
         {submission.submitStatus === ActionStatus.PENDING && (
           <div className="TransactionDetails__processing">
             <div className="TransactionDetails__processing__header">

--- a/extension/src/popup/components/sendPayment/SendSettings/Settings/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendSettings/Settings/index.tsx
@@ -120,7 +120,7 @@ export const Settings = ({
   }
 
   return (
-    <View data-testid="send-settings-view">
+    <React.Fragment data-testid="send-settings-view">
       <SubviewHeader
         title={`${isSwap ? t("Swap") : t("Send")} ${t("Settings")}`}
         customBackAction={() => navigateTo(previous)}
@@ -288,6 +288,6 @@ export const Settings = ({
           </Form>
         )}
       </Formik>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/components/sendPayment/SendSettings/Settings/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendSettings/Settings/index.tsx
@@ -120,7 +120,7 @@ export const Settings = ({
   }
 
   return (
-    <React.Fragment data-testid="send-settings-view">
+    <React.Fragment>
       <SubviewHeader
         title={`${isSwap ? t("Swap") : t("Send")} ${t("Settings")}`}
         customBackAction={() => navigateTo(previous)}

--- a/extension/src/popup/components/sendPayment/SendSettings/SettingsFail/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendSettings/SettingsFail/index.tsx
@@ -26,7 +26,7 @@ export const SettingsFail = () => {
   }, [error]);
 
   return (
-    <View>
+    <React.Fragment>
       <View.AppHeader pageTitle={t("Error")} />
       <View.Content>
         <div className="SettingsFail__content">
@@ -51,6 +51,6 @@ export const SettingsFail = () => {
           {t("Got it")}
         </Button>
       </View.Footer>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/components/sendPayment/SendSettings/Slippage/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendSettings/Slippage/index.tsx
@@ -33,7 +33,7 @@ export const SendSettingsSlippage = ({ previous }: { previous: ROUTES }) => {
   }
 
   return (
-    <View>
+    <React.Fragment>
       <SubviewHeader
         title="Allowed Slippage"
         customBackAction={() => navigateTo(previous)}
@@ -153,6 +153,6 @@ export const SendSettingsSlippage = ({ previous }: { previous: ROUTES }) => {
           </Form>
         )}
       </Formik>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/components/sendPayment/SendSettings/TransactionFee/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendSettings/TransactionFee/index.tsx
@@ -27,7 +27,7 @@ export const SendSettingsFee = ({ previous }: { previous: ROUTES }) => {
   const { networkCongestion, recommendedFee } = useNetworkFees();
 
   return (
-    <View>
+    <React.Fragment>
       <SubviewHeader
         title="Transaction Fee"
         customBackAction={() => navigateTo(previous)}
@@ -118,6 +118,6 @@ export const SendSettingsFee = ({ previous }: { previous: ROUTES }) => {
           </Form>
         )}
       </Formik>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/components/sendPayment/SendTo/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendTo/index.tsx
@@ -217,7 +217,7 @@ export const SendTo = ({ previous }: { previous: ROUTES }) => {
   }, [dispatch, validatedPubKey, networkDetails, sorobanClient]);
 
   return (
-    <View>
+    <React.Fragment>
       <SubviewHeader
         title="Send To"
         customBackAction={() => navigateTo(previous)}
@@ -327,6 +327,6 @@ export const SendTo = ({ previous }: { previous: ROUTES }) => {
           </Button>
         ) : null}
       </View.Footer>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/components/signAuthEntry/AuthEntry/index.tsx
+++ b/extension/src/popup/components/signAuthEntry/AuthEntry/index.tsx
@@ -68,7 +68,7 @@ const InvalidAuthEntry = ({
 
   return (
     <div className="InvalidAuthEntry">
-      <View>
+      <React.Fragment>
         <View.AppHeader pageTitle={t("Error")} />
         <View.Content>
           <div className="InvalidAuthEntryBody__content">
@@ -94,7 +94,7 @@ const InvalidAuthEntry = ({
             {t("Got it")}
           </Button>
         </View.Footer>
-      </View>
+      </React.Fragment>
     </div>
   );
 };

--- a/extension/src/popup/views/About/index.tsx
+++ b/extension/src/popup/views/About/index.tsx
@@ -28,7 +28,7 @@ export const About = () => {
   const currentYear = new Date().getFullYear();
 
   return (
-    <View>
+    <React.Fragment>
       <SubviewHeader title="About" />
       <View.Content hasNoTopPadding>
         <div className="About">
@@ -58,6 +58,6 @@ export const About = () => {
           {`© ${currentYear} Stellar Development Foundation`}
         </div>
       </View.Footer>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/views/Account/index.tsx
+++ b/extension/src/popup/views/Account/index.tsx
@@ -54,7 +54,6 @@ import { AccountHeader } from "popup/components/account/AccountHeader";
 import { AssetDetail } from "popup/components/account/AssetDetail";
 import { Loading } from "popup/components/Loading";
 import { NotFundedMessage } from "popup/components/account/NotFundedMessage";
-import { BottomNav } from "popup/components/BottomNav";
 
 import "popup/metrics/authServices";
 
@@ -171,7 +170,7 @@ export const Account = () => {
       subentryCount={accountBalances.subentryCount}
     />
   ) : (
-    <View>
+    <>
       {isLoading ? (
         <Loading />
       ) : (
@@ -281,7 +280,6 @@ export const Account = () => {
           </View.Content>
         </>
       )}
-      <BottomNav />
-    </View>
+    </>
   );
 };

--- a/extension/src/popup/views/AccountCreator/index.tsx
+++ b/extension/src/popup/views/AccountCreator/index.tsx
@@ -65,7 +65,7 @@ export const AccountCreator = () => {
   return mnemonicPhrase && publicKey ? (
     <MnemonicPhrase mnemonicPhrase={mnemonicPhrase} />
   ) : (
-    <View isAppLayout={false}>
+    <React.Fragment>
       <View.Header />
       <View.Content alignment="center">
         <Formik
@@ -159,6 +159,6 @@ export const AccountCreator = () => {
           )}
         </Formik>
       </View.Content>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/views/AccountHistory/index.tsx
+++ b/extension/src/popup/views/AccountHistory/index.tsx
@@ -33,7 +33,6 @@ import {
   TransactionDetail,
   TransactionDetailProps,
 } from "popup/components/accountHistory/TransactionDetail";
-import { BottomNav } from "popup/components/BottomNav";
 import { View } from "popup/basics/layout/View";
 
 import "./styles.scss";
@@ -166,7 +165,7 @@ export const AccountHistory = () => {
   return isDetailViewShowing ? (
     <TransactionDetail {...detailViewProps} />
   ) : (
-    <View>
+    <>
       <View.Content>
         <div className="AccountHistory">
           {isLoading ? (
@@ -225,7 +224,6 @@ export const AccountHistory = () => {
           )}
         </div>
       </View.Content>
-      <BottomNav />
-    </View>
+    </>
   );
 };

--- a/extension/src/popup/views/AccountMigration/index.tsx
+++ b/extension/src/popup/views/AccountMigration/index.tsx
@@ -15,7 +15,7 @@ import "./styles.scss";
 
 export const AccountMigration = () => (
   <>
-    <View isAppLayout={false}>
+    <React.Fragment>
       <View.Header />
       <View.Content alignment="center">
         <Switch>
@@ -50,6 +50,6 @@ export const AccountMigration = () => (
           </PublicKeyRoute>
         </Switch>
       </View.Content>
-    </View>
+    </React.Fragment>
   </>
 );

--- a/extension/src/popup/views/AddAccount/AddAccount/index.tsx
+++ b/extension/src/popup/views/AddAccount/AddAccount/index.tsx
@@ -54,7 +54,7 @@ export const AddAccount = () => {
   ]);
 
   return (
-    <View>
+    <React.Fragment>
       <SubviewHeader title="Add a new Stellar address" />
       <Formik initialValues={initialValues} onSubmit={handleSubmit}>
         {({ dirty, isSubmitting, isValid, errors, touched }) => (
@@ -96,6 +96,6 @@ export const AddAccount = () => {
           </Form>
         )}
       </Formik>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/views/AddAccount/ImportAccount/index.tsx
+++ b/extension/src/popup/views/AddAccount/ImportAccount/index.tsx
@@ -65,7 +65,7 @@ export const ImportAccount = () => {
   };
 
   return (
-    <View>
+    <React.Fragment>
       <SubviewHeader title={t("Import Stellar Secret Key")} />
 
       <Formik
@@ -153,6 +153,6 @@ export const ImportAccount = () => {
           </Form>
         )}
       </Formik>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/views/AddAccount/connect/PluginWallet/index.tsx
+++ b/extension/src/popup/views/AddAccount/connect/PluginWallet/index.tsx
@@ -8,7 +8,6 @@ import { navigateTo, openTab } from "popup/helpers/navigate";
 import { pluginWalletInfo } from "popup/helpers/hardwareConnect";
 import { ROUTES } from "popup/constants/routes";
 import { SubviewHeader } from "popup/components/SubviewHeader";
-import { BottomNav } from "popup/components/BottomNav";
 
 import "./styles.scss";
 import { View } from "popup/basics/layout/View";
@@ -26,7 +25,7 @@ export const PluginWallet = () => {
   const pluginWalletInfoSection = pluginWalletInfo[walletType];
 
   return (
-    <View>
+    <>
       <SubviewHeader
         title={`Connect with ${walletType}`}
         hasBackButton={true}
@@ -84,7 +83,6 @@ export const PluginWallet = () => {
           </Button>
         </div>
       </View.Content>
-      <BottomNav />
-    </View>
+    </>
   );
 };

--- a/extension/src/popup/views/AddAccount/connect/SelectHardwareWallet/index.tsx
+++ b/extension/src/popup/views/AddAccount/connect/SelectHardwareWallet/index.tsx
@@ -4,7 +4,6 @@ import { useDispatch } from "react-redux";
 import { navigateTo } from "popup/helpers/navigate";
 import { ROUTES } from "popup/constants/routes";
 import { SubviewHeader } from "popup/components/SubviewHeader";
-import { BottomNav } from "popup/components/BottomNav";
 import { setConnectingWalletType } from "popup/ducks/accountServices";
 import { walletAssets } from "popup/helpers/hardwareConnect";
 import {
@@ -38,7 +37,7 @@ const WalletOption = ({
 };
 
 export const SelectHardwareWallet = () => (
-  <View>
+  <>
     <SubviewHeader
       title="Connect a hardware wallet"
       hasBackButton={true}
@@ -56,6 +55,5 @@ export const SelectHardwareWallet = () => (
         </ul>
       </div>
     </View.Content>
-    <BottomNav />
-  </View>
+  </>
 );

--- a/extension/src/popup/views/DisplayBackupPhrase/index.tsx
+++ b/extension/src/popup/views/DisplayBackupPhrase/index.tsx
@@ -58,7 +58,7 @@ export const DisplayBackupPhrase = () => {
   };
 
   return (
-    <View>
+    <React.Fragment>
       <SubviewHeader title={t("Show recovery phrase")} />
       {isPhraseUnlocked ? (
         <>
@@ -118,6 +118,6 @@ export const DisplayBackupPhrase = () => {
           </Formik>
         </>
       )}
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/views/FullscreenSuccessMessage/index.tsx
+++ b/extension/src/popup/views/FullscreenSuccessMessage/index.tsx
@@ -144,7 +144,7 @@ export const FullscreenSuccessMessage = () => {
     location.pathname === ROUTES.mnemonicPhraseConfirmed;
 
   return (
-    <View isAppLayout={false}>
+    <React.Fragment>
       <View.Header />
       <View.Content alignment="center">
         <Onboarding layout="full" customWidth="31rem">
@@ -160,6 +160,6 @@ export const FullscreenSuccessMessage = () => {
           </div>
         </Onboarding>
       </View.Content>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/views/LeaveFeedback/index.tsx
+++ b/extension/src/popup/views/LeaveFeedback/index.tsx
@@ -16,7 +16,7 @@ export const LeaveFeedback = () => {
   };
 
   return (
-    <View>
+    <React.Fragment>
       <SubviewHeader title="Leave Feedback" />
       <View.Content hasNoTopPadding>
         <div className="LeaveFeedback">
@@ -73,6 +73,6 @@ export const LeaveFeedback = () => {
           </div>
         </div>
       </View.Content>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/views/ManageConnectedApps/index.tsx
+++ b/extension/src/popup/views/ManageConnectedApps/index.tsx
@@ -26,7 +26,7 @@ export const ManageConnectedApps = () => {
   };
 
   return (
-    <View>
+    <React.Fragment>
       <SubviewHeader title="Manage Connected Apps" />
       <View.Content>
         <div className="ManageConnectedApps">
@@ -56,6 +56,6 @@ export const ManageConnectedApps = () => {
           )}
         </div>
       </View.Content>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/views/MnemonicPhrase.tsx
+++ b/extension/src/popup/views/MnemonicPhrase.tsx
@@ -28,7 +28,7 @@ export const MnemonicPhrase = ({
 
   if (mnemonicPhrase) {
     return isConfirmed ? (
-      <View isAppLayout={false}>
+      <React.Fragment>
         <View.Header />
         <View.Content alignment="center">
           <Onboarding layout="full" customWidth="31rem">
@@ -39,9 +39,9 @@ export const MnemonicPhrase = ({
             />
           </Onboarding>
         </View.Content>
-      </View>
+      </React.Fragment>
     ) : (
-      <View isAppLayout={false}>
+      <React.Fragment>
         <View.Header />
         <View.Content alignment="center">
           <Onboarding layout="full">
@@ -51,7 +51,7 @@ export const MnemonicPhrase = ({
             />
           </Onboarding>
         </View.Content>
-      </View>
+      </React.Fragment>
     );
   }
 

--- a/extension/src/popup/views/PinExtension/index.tsx
+++ b/extension/src/popup/views/PinExtension/index.tsx
@@ -13,7 +13,7 @@ export const PinExtension = () => {
   const { t } = useTranslation();
 
   return (
-    <View isAppLayout={false}>
+    <React.Fragment>
       <View.Header />
       <View.Content alignment="center">
         <Onboarding layout="full" customWidth="31rem">
@@ -56,6 +56,6 @@ export const PinExtension = () => {
           </div>
         </Onboarding>
       </View.Content>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/views/Preferences/index.tsx
+++ b/extension/src/popup/views/Preferences/index.tsx
@@ -60,7 +60,7 @@ export const Preferences = () => {
   };
 
   return (
-    <View>
+    <React.Fragment>
       <SubviewHeader title={t("Preferences")} />
       <Formik
         initialValues={initialValues}
@@ -163,6 +163,6 @@ export const Preferences = () => {
           </div>
         </View.Content>
       </Formik>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/views/RecoverAccount/index.tsx
+++ b/extension/src/popup/views/RecoverAccount/index.tsx
@@ -160,7 +160,7 @@ export const RecoverAccount = () => {
   };
 
   return (
-    <View isAppLayout={false}>
+    <React.Fragment>
       <View.Header />
       <View.Content alignment="center">
         <Formik
@@ -312,6 +312,6 @@ export const RecoverAccount = () => {
           )}
         </Formik>
       </View.Content>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/views/Security/index.tsx
+++ b/extension/src/popup/views/Security/index.tsx
@@ -21,7 +21,7 @@ export const Security = () => {
   const { t } = useTranslation();
 
   return (
-    <View>
+    <React.Fragment>
       <SubviewHeader title="Security" />
       <View.Content hasNoTopPadding>
         <ListNavLinkWrapper>
@@ -44,6 +44,6 @@ export const Security = () => {
           </ListNavButtonLink> */}
         </ListNavLinkWrapper>
       </View.Content>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/views/Settings/index.tsx
+++ b/extension/src/popup/views/Settings/index.tsx
@@ -9,8 +9,6 @@ import { navigateTo } from "popup/helpers/navigate";
 import { ListNavLink, ListNavLinkWrapper } from "popup/basics/ListNavLink";
 import { View } from "popup/basics/layout/View";
 
-import { BottomNav } from "popup/components/BottomNav";
-
 import { signOut } from "popup/ducks/accountServices";
 
 import packageJson from "../../../../package.json";
@@ -28,7 +26,7 @@ export const Settings = () => {
   };
 
   return (
-    <View>
+    <>
       <View.Content
         contentFooter={
           <div className="Settings__logout">
@@ -69,7 +67,6 @@ export const Settings = () => {
           </div>
         </nav>
       </View.Content>
-      <BottomNav />
-    </View>
+    </>
   );
 };

--- a/extension/src/popup/views/SignAuthEntry/index.tsx
+++ b/extension/src/popup/views/SignAuthEntry/index.tsx
@@ -107,7 +107,7 @@ export const SignAuthEntry = () => {
       {hwStatus === ShowOverlayStatus.IN_PROGRESS && hardwareWalletType && (
         <HardwareSign walletType={hardwareWalletType} />
       )}
-      <View data-testid="SignAuthEntry">
+      <React.Fragment data-testid="SignAuthEntry">
         <View.AppHeader pageTitle={t("Confirm Data")} />
         <View.Content>
           {isExperimentalModeEnabled ? (
@@ -213,7 +213,7 @@ export const SignAuthEntry = () => {
             />
           </div>
         </SlideupModal>
-      </View>
+      </React.Fragment>
     </>
   );
 };

--- a/extension/src/popup/views/SignAuthEntry/index.tsx
+++ b/extension/src/popup/views/SignAuthEntry/index.tsx
@@ -107,7 +107,7 @@ export const SignAuthEntry = () => {
       {hwStatus === ShowOverlayStatus.IN_PROGRESS && hardwareWalletType && (
         <HardwareSign walletType={hardwareWalletType} />
       )}
-      <React.Fragment data-testid="SignAuthEntry">
+      <React.Fragment>
         <View.AppHeader pageTitle={t("Confirm Data")} />
         <View.Content>
           {isExperimentalModeEnabled ? (

--- a/extension/src/popup/views/SignBlob/index.tsx
+++ b/extension/src/popup/views/SignBlob/index.tsx
@@ -103,7 +103,7 @@ export const SignBlob = () => {
       {hwStatus === ShowOverlayStatus.IN_PROGRESS && hardwareWalletType && (
         <HardwareSign walletType={hardwareWalletType} />
       )}
-      <View data-testid="SignBlob">
+      <React.Fragment data-testid="SignBlob">
         <View.AppHeader pageTitle={t("Confirm Data")} />
         <View.Content>
           {isExperimentalModeEnabled ? (
@@ -210,7 +210,7 @@ export const SignBlob = () => {
             />
           </div>
         </SlideupModal>
-      </View>
+      </React.Fragment>
     </>
   );
 };

--- a/extension/src/popup/views/SignBlob/index.tsx
+++ b/extension/src/popup/views/SignBlob/index.tsx
@@ -103,7 +103,7 @@ export const SignBlob = () => {
       {hwStatus === ShowOverlayStatus.IN_PROGRESS && hardwareWalletType && (
         <HardwareSign walletType={hardwareWalletType} />
       )}
-      <React.Fragment data-testid="SignBlob">
+      <React.Fragment>
         <View.AppHeader pageTitle={t("Confirm Data")} />
         <View.Content>
           {isExperimentalModeEnabled ? (

--- a/extension/src/popup/views/UnlockAccount/index.tsx
+++ b/extension/src/popup/views/UnlockAccount/index.tsx
@@ -44,7 +44,7 @@ export const UnlockAccount = () => {
   };
 
   return (
-    <View>
+    <React.Fragment>
       <View.Header />
       <View.Content alignment="center">
         <div className="UnlockAccount">
@@ -108,6 +108,6 @@ export const UnlockAccount = () => {
           </Link>
         </div>
       </View.Footer>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/views/VerifyAccount/index.tsx
+++ b/extension/src/popup/views/VerifyAccount/index.tsx
@@ -45,7 +45,7 @@ export const VerifyAccount = ({
   };
 
   return (
-    <View>
+    <React.Fragment>
       <SubviewHeader
         title={t("Verification")}
         customBackAction={customBackAction}
@@ -95,6 +95,6 @@ export const VerifyAccount = ({
           </Form>
         )}
       </Formik>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/views/ViewPublicKey/index.tsx
+++ b/extension/src/popup/views/ViewPublicKey/index.tsx
@@ -64,7 +64,7 @@ export const ViewPublicKey = () => {
   };
 
   return (
-    <View>
+    <React.Fragment>
       <Formik
         initialValues={initialValues}
         onSubmit={handleSubmit}
@@ -150,6 +150,6 @@ export const ViewPublicKey = () => {
           ) : null}
         </div>
       </View.Footer>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/views/Welcome/index.tsx
+++ b/extension/src/popup/views/Welcome/index.tsx
@@ -12,7 +12,7 @@ export const Welcome = () => {
   const { t } = useTranslation();
 
   return (
-    <View isAppLayout={false}>
+    <React.Fragment>
       <View.Header />
       <View.Content>
         <div className="Welcome__column">
@@ -63,6 +63,6 @@ export const Welcome = () => {
           </div>
         </div>
       </View.Content>
-    </View>
+    </React.Fragment>
   );
 };

--- a/extension/src/popup/views/__tests__/ManageAssets.test.tsx
+++ b/extension/src/popup/views/__tests__/ManageAssets.test.tsx
@@ -256,7 +256,7 @@ const initView = async (
   );
 
   await waitFor(() => {
-    expect(screen.getByTestId("choose-asset")).toBeDefined();
+    expect(screen.getByTestId("AppHeaderPageTitle")).toBeDefined();
   });
 };
 
@@ -316,7 +316,7 @@ describe("Manage assets", () => {
     await fireEvent.click(addButton);
 
     await waitFor(() => {
-      screen.getByTestId("search-asset");
+      screen.getByTestId("AppHeaderPageTitle");
       expect(screen.getByTestId("AppHeaderPageTitle")).toHaveTextContent(
         "Choose Asset",
       );
@@ -397,7 +397,7 @@ describe("Manage assets", () => {
     });
 
     await waitFor(() => {
-      screen.getByTestId("trustline-error-view");
+      screen.getByTestId("AppHeaderPageTitle");
       expect(screen.getByTestId("AppHeaderPageTitle")).toHaveTextContent(
         "Trustline Error",
       );
@@ -416,7 +416,7 @@ describe("Manage assets", () => {
     await fireEvent.click(addButton);
 
     await waitFor(() => {
-      screen.getByTestId("search-asset");
+      screen.getByTestId("AppHeaderPageTitle");
       expect(screen.getByTestId("AppHeaderPageTitle")).toHaveTextContent(
         "Choose Asset",
       );
@@ -477,7 +477,7 @@ describe("Manage assets", () => {
     await fireEvent.click(addTokenButton);
 
     await waitFor(() => {
-      screen.getByTestId("add-token");
+      screen.getByTestId("AppHeaderPageTitle");
       expect(screen.getByTestId("AppHeaderPageTitle")).toHaveTextContent(
         "Add a Soroban token by ID",
       );

--- a/extension/src/popup/views/__tests__/SendPayment.test.tsx
+++ b/extension/src/popup/views/__tests__/SendPayment.test.tsx
@@ -170,7 +170,6 @@ const testPaymentFlow = async (asset: string) => {
   });
 
   await waitFor(async () => {
-    screen.getByTestId("send-settings-view");
     const continueBtn = screen.getByTestId("send-settings-btn-continue");
     await fireEvent.click(continueBtn);
   });
@@ -179,6 +178,4 @@ const testPaymentFlow = async (asset: string) => {
     const sendBtn = screen.getByTestId("transaction-details-btn-send");
     await fireEvent.click(sendBtn);
   });
-
-  await waitFor(() => screen.getByTestId("submit-success-view"));
 };

--- a/extension/src/popup/views/__tests__/SendTokenPayment.test.tsx
+++ b/extension/src/popup/views/__tests__/SendTokenPayment.test.tsx
@@ -214,7 +214,6 @@ describe("SendTokenPayment", () => {
     });
 
     await waitFor(async () => {
-      screen.getByTestId("send-settings-view");
       const continueBtn = screen.getByTestId("send-settings-btn-continue");
       await fireEvent.click(continueBtn);
     });
@@ -224,7 +223,5 @@ describe("SendTokenPayment", () => {
       const sendBtn = screen.getByTestId("transaction-details-btn-send");
       await fireEvent.click(sendBtn);
     });
-
-    await waitFor(() => screen.getByTestId("submit-success-view"));
   });
 });

--- a/extension/src/popup/views/__tests__/Swap.test.tsx
+++ b/extension/src/popup/views/__tests__/Swap.test.tsx
@@ -165,7 +165,7 @@ describe("Swap", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId("send-amount-view")).toBeDefined();
+      expect(screen.getByTestId("AppHeaderPageTitle")).toBeDefined();
     });
   });
 
@@ -245,7 +245,7 @@ describe("Swap", () => {
 
     // Swap Settings view
     await waitFor(() => {
-      screen.getByTestId("send-settings-view");
+      screen.getByTestId("AppHeaderPageTitle");
       expect(screen.getByTestId("AppHeaderPageTitle")).toHaveTextContent(
         "Swap Settings",
       );
@@ -265,7 +265,7 @@ describe("Swap", () => {
 
     // Confirm Swap view
     await waitFor(() => {
-      screen.getByTestId("transaction-details-view");
+      screen.getByTestId("AppHeaderPageTitle");
       expect(screen.getByTestId("AppHeaderPageTitle")).toHaveTextContent(
         "Confirm Swap",
       );
@@ -294,7 +294,7 @@ describe("Swap", () => {
 
     // Swap success view
     await waitFor(() => {
-      screen.getByTestId("submit-success-view");
+      screen.getByTestId("AppHeaderPageTitle");
       expect(screen.getByTestId("AppHeaderPageTitle")).toHaveTextContent(
         "Successfully swapped",
       );
@@ -315,7 +315,7 @@ describe("Swap", () => {
 
     // Swap details view
     await waitFor(() => {
-      screen.getByTestId("transaction-details-view");
+      screen.getByTestId("AppHeaderPageTitle");
       expect(screen.getByTestId("AppHeaderPageTitle")).toHaveTextContent(
         "Swapped",
       );

--- a/extension/src/popup/views/__tests__/SwapUnfunded.test.tsx
+++ b/extension/src/popup/views/__tests__/SwapUnfunded.test.tsx
@@ -132,7 +132,7 @@ describe("Swap unfunded account", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId("send-amount-view")).toBeDefined();
+      expect(screen.getByTestId("AppHeaderPageTitle")).toBeDefined();
     });
   });
 


### PR DESCRIPTION
What
Moves our BottomNav component to a central place instead of rendering it individual views.
Creates an "Outlet" component to house the BottomNav, global loader and fetchers, and Routes.

Why
Right now, when you load Freighter you see 2 different loading states, first the router loading with no nav and then the page loading with nav. This can be jarring because you expect 1 loading state as an end user. Pulling out the BottomNav to be rendered persistently at the router level lets our 2 loading states blend together better.

Notes
As I hinted above, this doesn't totally fix it because we do still have 2 loading screens where there should be 1(notice the flicker of the loader in the "after" recording). In order to fix that, we would need to move the calls and/or loading states for `loadSettings/loadAccount` into each view in order to only show 1 loading state from the combined loading states of the page data and settings/account data.

After -


https://github.com/stellar/freighter/assets/6886006/0b2867d1-2ffe-44bb-9e99-691d5c5966fa



