### PR TITLE
[BUG] Handle not ok case in subscriptions

### DIFF
--- a/extension/src/background/helpers/account.ts
+++ b/extension/src/background/helpers/account.ts
@@ -196,18 +196,24 @@ export const subscribeAccount = async (publicKey: string) => {
         network: networkDetails.network,
       }),
     };
-    await fetch(`${INDEXER_URL}/subscription/account`, options);
+    const res = await fetch(`${INDEXER_URL}/subscription/account`, options);
     const subsByKeyId = {
       ...hasAccountSubByKeyId,
       [keyId]: true,
     };
-    await localStore.setItem(HAS_ACCOUNT_SUBSCRIPTION, subsByKeyId);
+
+    if (res.ok) {
+      await localStore.setItem(HAS_ACCOUNT_SUBSCRIPTION, subsByKeyId);
+    } else {
+      const resJson = await res.json();
+      throw new Error(resJson);
+    }
   } catch (e) {
     console.error(e);
-    captureException(
-      `Failed to subscribe account with Mercury - ${JSON.stringify(e)}`,
-    );
-    throw new Error("Error subscribing account");
+    // Turn on when Mercury is enabled
+    // captureException(
+    //   `Failed to subscribe account with Mercury - ${JSON.stringify(e)}`,
+    // );
   }
 
   return { publicKey };
@@ -230,13 +236,20 @@ export const subscribeTokenBalance = async (
         network: networkDetails.network,
       }),
     };
-    await fetch(`${INDEXER_URL}/subscription/token-balance`, options);
+    const res = await fetch(
+      `${INDEXER_URL}/subscription/token-balance`,
+      options,
+    );
+
+    if (!res.ok) {
+      const resJson = await res.json();
+      throw new Error(resJson);
+    }
   } catch (e) {
     console.error(e);
     captureException(
       `Failed to subscribe token balance - ${JSON.stringify(e)}`,
     );
-    throw new Error(`Error subscribing to token: ${contractId}`);
   }
 };
 
@@ -252,13 +265,17 @@ export const subscribeTokenHistory = async (
       },
       body: JSON.stringify({ pub_key: publicKey, contract_id: contractId }),
     };
-    await fetch(`${INDEXER_URL}/subscription/token`, options);
+    const res = await fetch(`${INDEXER_URL}/subscription/token`, options);
+
+    if (!res.ok) {
+      const resJson = await res.json();
+      throw new Error(resJson);
+    }
   } catch (e) {
     console.error(e);
     captureException(
       `Failed to subscribe token history - ${JSON.stringify(e)}`,
     );
-    throw new Error(`Error subscribing to token: ${contractId}`);
   }
 };
 

--- a/extension/src/background/helpers/dataStorage.ts
+++ b/extension/src/background/helpers/dataStorage.ts
@@ -246,6 +246,16 @@ const migrateSorobanRpcUrlNetwork = async () => {
   }
 };
 
+export const resetAccountSubscriptions = async () => {
+  const localStore = dataStorageAccess(browserLocalStorage);
+  const storageVersion = (await localStore.getItem(STORAGE_VERSION)) as string;
+
+  if (!storageVersion || semver.eq(storageVersion, "4.0.2")) {
+    // once account is unlocked, setup Mercury account subscription if !HAS_ACCOUNT_SUBSCRIPTION
+    await localStore.setItem(HAS_ACCOUNT_SUBSCRIPTION, {});
+  }
+};
+
 export const versionedMigration = async () => {
   // sequentially call migrations in order to enforce smooth schema upgrades
 
@@ -254,6 +264,7 @@ export const versionedMigration = async () => {
   await migrateToAccountSubscriptions();
   await migrateMainnetSorobanRpcUrlNetworkDetails();
   await migrateSorobanRpcUrlNetwork();
+  await resetAccountSubscriptions();
 };
 
 // Updates storage version


### PR DESCRIPTION
What?
Handles the !res.ok() case when subscribing to an account and/or token details.
Resets the HAS_ACCOUNT_SUBSCRIPTION storage object.
Commented out the Sentry log for these failures as we expect this to fail when Mercury is off.

Why?
I was looking into our Sentry logs and realized that we should expect to see a ton of [these logs](https://github.com/stellar/freighter/blob/master/extension/src/background/helpers/account.ts#L207) because we try to subscribe to accounts/token details even when mercury is not enabled, but we saw none of those logs.
The reason is because the 400 thrown response in this case, when using fetch, does not throw but instead returns the field ok as false. Since we were not checking this, when any user hit this error we ignored it and then set their account to true in HAS_ACCOUNT_SUBSCRIPTION incorrectly.

Since Mercury is not "on" yet, this doesn't affect any users but needs to be resolved before turning it on. Resetting the accounts is necessary in this case since many accounts are likely marked as having subs when they do not.

Todo
Should we add the useMercury flag from the backend to the feature-flags route? Right now, I don't think we have a way for the UI to know when to try to subscribe or not, we could expose the flag from the backend in order to use that to skip these calls when Mercury is disabled.