### PR TITLE
[CHORE] removes the rpc urls passed to the backend

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -442,8 +442,6 @@ export const getAccountIndexerBalances = async (
   const contractIds = await getTokenIds(networkDetails.network as NETWORKS);
   const url = new URL(`${INDEXER_URL}/account-balances/${publicKey}`);
   url.searchParams.append("network", networkDetails.network);
-  url.searchParams.append("horizon_url", networkDetails.networkUrl);
-  url.searchParams.append("soroban_url", networkDetails.sorobanRpcUrl!);
   for (const id of contractIds) {
     url.searchParams.append("contract_ids", id);
   }
@@ -669,7 +667,7 @@ export const getIndexerAccountHistory = async ({
 }) => {
   try {
     const url = new URL(
-      `${INDEXER_URL}/account-history/${publicKey}?network=${networkDetails.network}&soroban_url=${networkDetails.sorobanRpcUrl}&horizon_url=${networkDetails.networkUrl}`,
+      `${INDEXER_URL}/account-history/${publicKey}?network=${networkDetails.network}`,
     );
     const response = await fetch(url.href);
 

--- a/extension/src/popup/components/WarningMessages/index.tsx
+++ b/extension/src/popup/components/WarningMessages/index.tsx
@@ -969,8 +969,8 @@ const WarningMessageTokenDetails = ({
 
   const tokenDetailsUrl = React.useCallback(
     (contractId: string) =>
-      `${INDEXER_URL}/token-details/${contractId}?pub_key=${publicKey}&network=${networkDetails.network}&soroban_url=${networkDetails.sorobanRpcUrl}`,
-    [publicKey, networkDetails.network, networkDetails.sorobanRpcUrl],
+      `${INDEXER_URL}/token-details/${contractId}?pub_key=${publicKey}&network=${networkDetails.network}`,
+    [publicKey, networkDetails.network],
   );
   React.useEffect(() => {
     async function getTokenDetails() {

--- a/extension/src/popup/components/accountHistory/HistoryItem/index.tsx
+++ b/extension/src/popup/components/accountHistory/HistoryItem/index.tsx
@@ -304,7 +304,7 @@ export const HistoryItem = ({
                 setIsLoading(false);
               } else {
                 const response = await fetch(
-                  `${INDEXER_URL}/token-details/${attrs.contractId}?pub_key=${publicKey}&network=${networkDetails.network}&soroban_url=${networkDetails.sorobanRpcUrl}`,
+                  `${INDEXER_URL}/token-details/${attrs.contractId}?pub_key=${publicKey}&network=${networkDetails.network}`,
                 );
 
                 if (!response.ok) {

--- a/extension/src/popup/components/manageAssets/AddToken/index.tsx
+++ b/extension/src/popup/components/manageAssets/AddToken/index.tsx
@@ -170,10 +170,6 @@ export const AddToken = () => {
           );
           tokenUrl.searchParams.append("network", networkDetails.network);
           tokenUrl.searchParams.append("pub_key", publicKey);
-          tokenUrl.searchParams.append(
-            "soroban_url",
-            networkDetails.sorobanRpcUrl!,
-          );
 
           const res = await fetch(tokenUrl.href);
           const resJson = await res.json();


### PR DESCRIPTION
What?
Removes horizon/rpc URLs from the calls to the API.

Why?
They are no longer needed since we moved the standalone case back to client side only.