### PR TITLE
[TESTS] Fix expectation for getTokenInvocationArgs-related tests

### DIFF
--- a/extension/src/popup/views/__tests__/SignTransaction.test.tsx
+++ b/extension/src/popup/views/__tests__/SignTransaction.test.tsx
@@ -220,7 +220,7 @@ describe("SignTransactions", () => {
     ).toBeTruthy();
     expect(
       opDetails.includes(
-        `Contract ID${Stellar.truncatedPublicKey(args?.contractId)}`,
+        `Contract ID${Stellar.truncatedPublicKey(args?.contractId!)}`,
       ),
     ).toBeTruthy();
     expect(opDetails.includes(`Function Name${args?.fnName}`)).toBeTruthy();
@@ -271,7 +271,7 @@ describe("SignTransactions", () => {
     ).toBeTruthy();
     expect(
       opDetails.includes(
-        `Contract ID${Stellar.truncatedPublicKey(args?.contractId)}`,
+        `Contract ID${Stellar.truncatedPublicKey(args?.contractId!)}`,
       ),
     ).toBeTruthy();
     expect(opDetails.includes(`Function Name${args?.fnName}`)).toBeTruthy();

--- a/extension/src/popup/views/__tests__/SignTransaction.test.tsx
+++ b/extension/src/popup/views/__tests__/SignTransaction.test.tsx
@@ -213,21 +213,17 @@ describe("SignTransactions", () => {
       .getAllByTestId("OperationKeyVal")
       .map((node) => node.textContent);
 
-    expect(opDetails.includes(`Amount:${args?.amount.toString()}`));
     expect(
       opDetails.includes(
-        `Contract ID:${Stellar.truncatedPublicKey(args?.contractId!)}`,
+        `Parameters${args?.from.toString()}${args?.to.toString()}${args?.amount.toString()}`,
       ),
-    );
+    ).toBeTruthy();
     expect(
       opDetails.includes(
-        `Destination:${Stellar.truncatedPublicKey(args?.to!)}`,
+        `Contract ID${Stellar.truncatedPublicKey(args?.contractId)}`,
       ),
-    );
-    expect(
-      opDetails.includes(`Source:${Stellar.truncatedPublicKey(args?.from!)}`),
-    );
-    expect(opDetails.includes(`Function Name:${args?.fnName}`));
+    ).toBeTruthy();
+    expect(opDetails.includes(`Function Name${args?.fnName}`)).toBeTruthy();
   });
 
   it("displays mint parameters for Soroban mint operations", async () => {
@@ -262,26 +258,23 @@ describe("SignTransactions", () => {
     );
 
     userEvent.click(screen.getByTestId("Tab-Details"));
+
     const args = getTokenInvocationArgs(op);
     const opDetails = screen
       .getAllByTestId("OperationKeyVal")
       .map((node) => node.textContent);
 
-    expect(opDetails.includes(`Amount:${args?.amount.toString()}`));
     expect(
       opDetails.includes(
-        `Contract ID:${Stellar.truncatedPublicKey(args?.contractId!)}`,
+        `Parameters${args?.to.toString()}${args?.amount.toString()}`,
       ),
-    );
+    ).toBeTruthy();
     expect(
       opDetails.includes(
-        `Destination:${Stellar.truncatedPublicKey(args?.to!)}`,
+        `Contract ID${Stellar.truncatedPublicKey(args?.contractId)}`,
       ),
-    );
-    expect(
-      opDetails.includes(`Source:${Stellar.truncatedPublicKey(args?.from!)}`),
-    );
-    expect(opDetails.includes(`Function Name:${args?.fnName}`));
+    ).toBeTruthy();
+    expect(opDetails.includes(`Function Name${args?.fnName}`)).toBeTruthy();
   });
 
   it("memo: doesn't render memo if there is no memo", async () => {


### PR DESCRIPTION
Both `getTokenInvocationArgs`-related tests from this PR were calling `expect()` without any real comparison so that the test would always succeed regardless of the expected output.

This PR fixes that by adding a `toBeTruthy()` matching function to `expect(...).toBeTruthy()` and _consequently_ also fixes the expected matching content of the `opDetails` array which currently has the format below:
```
opDetails:  [
  'Invocation TypeInvoke Contract',
  'Contract IDCAPE…7UI2',
  'Function Nametransfer',
  'ParametersGCGORBD5DB4JDIKVIA536CJE3EWMWZ6KBUBWZWRQM7Y3NHFRCLOKYVALGDUBMXMABE7UOZSGYJ5ONE7UYAEHKK3JOX7HZQGNZ7NYTZPPP4AJ2GQJ5'
]
```

Note: all the other tests from this file are correctly calling `expect().someMatchingFunction()` so only those 2 tests were missing it.