### PR TITLE
[Soroban] getTokenInvocationArgs amount should be bigint or number

### DIFF
--- a/@shared/constants/soroban/token.ts
+++ b/@shared/constants/soroban/token.ts
@@ -4,6 +4,17 @@ export enum SorobanTokenInterface {
   mint = "mint",
 }
 
+export type ArgsForTokenInvocation = {
+  from: string;
+  to: string;
+  amount: bigint | number;
+};
+
+export type TokenInvocationArgs = ArgsForTokenInvocation & {
+  fnName: SorobanTokenInterface;
+  contractId: string;
+};
+
 // TODO: can we generate this at build time using the cli TS generator? Also should we?
 export interface SorobanToken {
   // only currently holds fields we care about

--- a/extension/src/popup/helpers/soroban.ts
+++ b/extension/src/popup/helpers/soroban.ts
@@ -19,7 +19,11 @@ import {
   SorobanBalance,
 } from "@shared/api/types";
 import { NetworkDetails } from "@shared/constants/stellar";
-import { SorobanTokenInterface } from "@shared/constants/soroban/token";
+import {
+  ArgsForTokenInvocation,
+  SorobanTokenInterface,
+  TokenInvocationArgs,
+} from "@shared/constants/soroban/token";
 
 export const SOROBAN_OPERATION_TYPES = [
   "invoke_host_function",
@@ -109,8 +113,8 @@ export const parseTokenAmount = (value: string, decimals: number) => {
 export const getArgsForTokenInvocation = (
   fnName: string,
   args: xdr.ScVal[],
-) => {
-  let amount: BigNumber;
+): ArgsForTokenInvocation => {
+  let amount: bigint | number;
   let from = "";
   let to = "";
 
@@ -131,7 +135,7 @@ export const getArgsForTokenInvocation = (
       amount = scValToNative(args[1]);
       break;
     default:
-      amount = new BigNumber(0);
+      amount = BigInt(0);
   }
 
   return { from, to, amount };
@@ -142,12 +146,12 @@ const isSorobanOp = (operation: HorizonOperation) =>
 
 export const getTokenInvocationArgs = (
   hostFn: Operation.InvokeHostFunction,
-) => {
+): TokenInvocationArgs | null => {
   if (!hostFn?.func?.invokeContract) {
     return null;
   }
 
-  let invokedContract;
+  let invokedContract: xdr.InvokeContractArgs;
 
   try {
     invokedContract = hostFn.func.invokeContract();
@@ -168,7 +172,7 @@ export const getTokenInvocationArgs = (
     return null;
   }
 
-  let opArgs;
+  let opArgs: ArgsForTokenInvocation;
 
   try {
     opArgs = getArgsForTokenInvocation(fnName, args);

--- a/extension/src/popup/views/__tests__/SignTransaction.test.tsx
+++ b/extension/src/popup/views/__tests__/SignTransaction.test.tsx
@@ -220,10 +220,11 @@ describe("SignTransactions", () => {
     ).toBeTruthy();
     expect(
       opDetails.includes(
-        `Contract ID${Stellar.truncatedPublicKey(args?.contractId!)}`,
+        `Contract ID${Stellar.truncatedPublicKey(args?.contractId || "")}`,
       ),
     ).toBeTruthy();
     expect(opDetails.includes(`Function Name${args?.fnName}`)).toBeTruthy();
+    expect(args?.amount === BigInt(5)).toBeTruthy();
   });
 
   it("displays mint parameters for Soroban mint operations", async () => {
@@ -271,10 +272,11 @@ describe("SignTransactions", () => {
     ).toBeTruthy();
     expect(
       opDetails.includes(
-        `Contract ID${Stellar.truncatedPublicKey(args?.contractId!)}`,
+        `Contract ID${Stellar.truncatedPublicKey(args?.contractId || "")}`,
       ),
     ).toBeTruthy();
     expect(opDetails.includes(`Function Name${args?.fnName}`)).toBeTruthy();
+    expect(args?.amount === BigInt(5)).toBeTruthy();
   });
 
   it("memo: doesn't render memo if there is no memo", async () => {


### PR DESCRIPTION
stellar-base's [scValToNative](https://github.com/stellar/js-stellar-base/blob/master/src/scval.js#L284) function can return `number` or `bigint`, but never `BigNumber`. This PR fixes the returned `amount` type of `getTokenInvocationArgs` to be compliant with that.