### PR TITLE
clean up UI for showing "destination acct doesn't exist" warning

### DIFF
--- a/extension/src/popup/components/sendPayment/SendTo/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendTo/index.tsx
@@ -41,6 +41,7 @@ import {
 import { SorobanContext } from "popup/SorobanContext";
 
 import "../styles.scss";
+import { ActionStatus } from "@shared/api/types";
 
 const baseReserve = new BigNumber(1);
 
@@ -102,7 +103,9 @@ export const SendTo = ({ previous }: { previous: ROUTES }) => {
     transactionDataSelector,
   );
   const networkDetails = useSelector(settingsNetworkDetailsSelector);
-  const { destinationBalances } = useSelector(transactionSubmissionSelector);
+  const { destinationBalances, destinationAccountBalanceStatus } = useSelector(
+    transactionSubmissionSelector,
+  );
 
   const [recentAddresses, setRecentAddresses] = useState<string[]>([]);
   const [validatedPubKey, setValidatedPubKey] = useState("");
@@ -287,24 +290,29 @@ export const SendTo = ({ previous }: { previous: ROUTES }) => {
                 <div>
                   {formik.isValid ? (
                     <>
-                      {!destinationBalances.isFunded && (
-                        <AccountDoesntExistWarning />
-                      )}
-                      {isFederationAddress(formik.values.destination) && (
+                      {destinationAccountBalanceStatus ===
+                      ActionStatus.SUCCESS ? (
                         <>
-                          <div className="SendTo__subheading">
-                            {t("FEDERATION ADDRESS")}
-                          </div>
-                          <div className="SendTo__subsection-copy">
-                            {formik.values.destination}
+                          {!destinationBalances.isFunded && (
+                            <AccountDoesntExistWarning />
+                          )}
+                          {isFederationAddress(formik.values.destination) && (
+                            <>
+                              <div className="SendTo__subheading">
+                                {t("FEDERATION ADDRESS")}
+                              </div>
+                              <div className="SendTo__subsection-copy">
+                                {formik.values.destination}
+                              </div>
+                            </>
+                          )}
+                          <div className="SendTo__subheading">Address</div>
+                          <div className="SendTo__subheading-identicon">
+                            <IdenticonImg publicKey={validatedPubKey} />
+                            <span>{truncatedPublicKey(validatedPubKey)}</span>
                           </div>
                         </>
-                      )}
-                      <div className="SendTo__subheading">Address</div>
-                      <div className="SendTo__subheading-identicon">
-                        <IdenticonImg publicKey={validatedPubKey} />
-                        <span>{truncatedPublicKey(validatedPubKey)}</span>
-                      </div>
+                      ) : null}
                     </>
                   ) : (
                     <InvalidAddressWarning />

--- a/extension/src/popup/ducks/transactionSubmission.ts
+++ b/extension/src/popup/ducks/transactionSubmission.ts
@@ -517,6 +517,7 @@ export enum AssetSelectType {
 interface InitialState {
   submitStatus: ActionStatus;
   accountBalanceStatus: ActionStatus;
+  destinationAccountBalanceStatus: ActionStatus;
   hardwareWalletData: HardwareWalletData;
   response:
     | Horizon.HorizonApi.TransactionResponse
@@ -545,6 +546,7 @@ interface InitialState {
 export const initialState: InitialState = {
   submitStatus: ActionStatus.IDLE,
   accountBalanceStatus: ActionStatus.IDLE,
+  destinationAccountBalanceStatus: ActionStatus.IDLE,
   response: null,
   error: undefined,
   transactionData: {
@@ -580,7 +582,7 @@ export const initialState: InitialState = {
   destinationBalances: {
     tokensWithNoBalance: [],
     balances: null,
-    isFunded: false,
+    isFunded: true,
     subentryCount: 0,
   },
   assetIcons: {},
@@ -728,6 +730,7 @@ const transactionSubmissionSlice = createSlice({
     });
     builder.addCase(getDestinationBalances.fulfilled, (state, action) => {
       state.destinationBalances = action.payload;
+      state.destinationAccountBalanceStatus = ActionStatus.SUCCESS;
     });
     builder.addCase(getAssetIcons.fulfilled, (state, action) => {
       const assetIcons = action.payload || {};


### PR DESCRIPTION
Fixing some UI jumpiness where the "destination acct doesn't exist" was showing for a split second while we were looking up the account to determine if it actually was funded or not
<img width="360" alt="Screenshot 2024-03-14 at 12 09 49 PM" src="https://github.com/stellar/freighter/assets/6789586/e22a3d4e-9ee4-4965-8dd9-0a37107495a3">
<img width="359" alt="Screenshot 2024-03-14 at 12 09 37 PM" src="https://github.com/stellar/freighter/assets/6789586/df4e141d-bb09-4a9c-827e-b274c835ef22">
