### PR TITLE
[FIX] Formats token amount in transfer summary

### DIFF
--- a/extension/src/popup/views/AccountHistory/index.tsx
+++ b/extension/src/popup/views/AccountHistory/index.tsx
@@ -8,7 +8,7 @@ import {
   getAccountHistoryStandalone,
   getIndexerAccountHistory,
 } from "@shared/api/internal";
-import { ActionStatus, HorizonOperation } from "@shared/api/types";
+import { ActionStatus } from "@shared/api/types";
 import { SorobanTokenInterface } from "@shared/constants/soroban/token";
 
 import { publicKeySelector } from "popup/ducks/accountServices";
@@ -16,7 +16,6 @@ import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
 import { transactionSubmissionSelector } from "popup/ducks/transactionSubmission";
 import {
   getIsPayment,
-  getIsSupportedSorobanOp,
   getIsSwap,
   getStellarExpertUrl,
 } from "popup/helpers/account";
@@ -86,21 +85,15 @@ export const AccountHistory = () => {
     accountBalanceStatus === ActionStatus.PENDING;
 
   useEffect(() => {
-    const isSupportedSorobanAccountItem = (operation: HorizonOperation) =>
-      getIsSupportedSorobanOp(operation, networkDetails);
-
     const createSegments = (
       operations: Horizon.ServerApi.OperationRecord[],
     ) => {
-      const _operations = operations.filter(
-        (op) => op.type_i !== 24 || isSupportedSorobanAccountItem(op),
-      );
       const segments = {
         [SELECTOR_OPTIONS.ALL]: [] as HistoryItemOperation[],
         [SELECTOR_OPTIONS.SENT]: [] as HistoryItemOperation[],
         [SELECTOR_OPTIONS.RECEIVED]: [] as HistoryItemOperation[],
       };
-      _operations.forEach((operation) => {
+      operations.forEach((operation) => {
         const isPayment = getIsPayment(operation.type);
         const isSorobanXfer =
           getAttrsFromSorobanHorizonOp(operation, networkDetails)?.fnName ===

--- a/extension/src/popup/views/ReviewAuth/index.tsx
+++ b/extension/src/popup/views/ReviewAuth/index.tsx
@@ -228,6 +228,7 @@ const TransferSummary = ({
   };
   tokenDetails: TokenDetails;
 }) => {
+  const hasTokenDetails = tokenDetails.symbol && tokenDetails.decimals;
   const isNative = tokenDetails.symbol === "native";
   const symbol = isNative ? "XLM" : tokenDetails.symbol;
   return (
@@ -252,22 +253,37 @@ const TransferSummary = ({
           <p>Amount</p>
         </div>
         <div className="SummaryBlock__Title">
-          <p>
-            {formatTokenAmount(
-              new BigNumber(transfer.amount),
-              tokenDetails.decimals,
-            )}{" "}
-            {symbol}
-          </p>
-          {isNative ? (
-            <div className="AccountAssets__asset--logo AccountAssets__asset--soroban-token">
-              <img src={StellarLogo} alt="Stellar icon" />
-            </div>
+          {hasTokenDetails ? (
+            <>
+              <p>
+                {formatTokenAmount(
+                  new BigNumber(transfer.amount),
+                  tokenDetails.decimals,
+                )}{" "}
+                {symbol}
+              </p>
+              {isNative ? (
+                <div className="AccountAssets__asset--logo AccountAssets__asset--soroban-token">
+                  <img src={StellarLogo} alt="Stellar icon" />
+                </div>
+              ) : (
+                <SorobanTokenIcon />
+              )}
+            </>
           ) : (
-            <SorobanTokenIcon />
+            <>
+              <p>{transfer.amount}</p>
+            </>
           )}
         </div>
       </div>
+      {!hasTokenDetails && (
+        <div className="SummaryBlock">
+          <p className="MissingDetailWarning">
+            Failed to fetch token details, showing raw amount.
+          </p>
+        </div>
+      )}
     </div>
   );
 };

--- a/extension/src/popup/views/ReviewAuth/styles.scss
+++ b/extension/src/popup/views/ReviewAuth/styles.scss
@@ -95,6 +95,12 @@
           display: flex;
           justify-content: space-between;
 
+          .MissingDetailWarning {
+            width: 100%;
+            font-style: italic;
+            font-size: 0.75rem;
+          }
+
           &__Title {
             display: flex;
             align-items: center;


### PR DESCRIPTION
What
Adds formatting using decimals to the amount value in the transfer summary, also special cases xlm to show "XLM" as symbol and show the stellar icon instead of the generic soroban one.
Removes transfer/mint constraint on history items to allow showing all soroban ops in history.
Adds fallback to raw value in transfer summary

Why
Display value should be formatted using decimals when possible
We should now show all soroban ops in history

Example of missing token details fallback -
<img width="393" alt="Screenshot 2024-03-14 at 11 17 37 AM" src="https://github.com/stellar/freighter/assets/6886006/f50ce116-cdd6-4d93-adb3-90cfe093d4c9">
