### PR TITLE
[FIX] flips title boolean in NetworkForm to show correct title

### DIFF
--- a/extension/src/popup/components/manageNetwork/NetworkForm/index.tsx
+++ b/extension/src/popup/components/manageNetwork/NetworkForm/index.tsx
@@ -274,7 +274,7 @@ export const NetworkForm = ({ isEditing }: NetworkFormProps) => {
   return (
     <React.Fragment>
       <SubviewHeader
-        title={isEditing ? t("Add Custom Network") : t("Network Details")}
+        title={!isEditing ? t("Add Custom Network") : t("Network Details")}
       />
       <Formik
         onSubmit={handleSubmit}


### PR DESCRIPTION
What
Flips the boolean that controls the title in order to show it correctly

Why
The flipped boolean was causing the wrong title to be rendered