### PR TITLE
[FIX] adds layout styles to form container to avoid button overflow in footer

### DIFF
--- a/extension/src/popup/components/manageAssets/AddAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/AddAsset/index.tsx
@@ -80,7 +80,7 @@ export const AddAsset = () => {
   return (
     <Formik initialValues={initialValues} onSubmit={handleSubmit}>
       {({ dirty, errors, isSubmitting, isValid, touched }) => (
-        <Form>
+        <Form className="FormContainer">
           <React.Fragment>
             <SubviewHeader title={t("Add Another Asset")} />
             <View.Content>

--- a/extension/src/popup/components/manageAssets/AddAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/AddAsset/index.tsx
@@ -80,7 +80,7 @@ export const AddAsset = () => {
   return (
     <Formik initialValues={initialValues} onSubmit={handleSubmit}>
       {({ dirty, errors, isSubmitting, isValid, touched }) => (
-        <Form className="FormContainer">
+        <Form className="AddAsset__FormContainer">
           <React.Fragment>
             <SubviewHeader title={t("Add Another Asset")} />
             <View.Content>

--- a/extension/src/popup/components/manageAssets/AddAsset/styles.scss
+++ b/extension/src/popup/components/manageAssets/AddAsset/styles.scss
@@ -25,3 +25,10 @@
     }
   }
 }
+
+.FormContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  overflow: hidden;
+}

--- a/extension/src/popup/components/manageAssets/AddAsset/styles.scss
+++ b/extension/src/popup/components/manageAssets/AddAsset/styles.scss
@@ -13,6 +13,13 @@
     text-transform: uppercase;
   }
 
+  &__FormContainer {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    overflow: hidden;
+  }
+
   &__results {
     flex-grow: 1;
     height: var(--AddAsset--results-height);
@@ -24,11 +31,4 @@
       );
     }
   }
-}
-
-.FormContainer {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  overflow: hidden;
 }


### PR DESCRIPTION
What
Adds some layout styles to the "manually add asset" form container

Why
To avoid the button in the footer overflowing

Before
<img width="403" alt="Screenshot 2024-03-14 at 12 08 28 PM" src="https://github.com/stellar/freighter/assets/6886006/a969f0ff-0873-402d-a6f8-399b28a360a0">


After
<img width="393" alt="Screenshot 2024-03-14 at 12 11 25 PM" src="https://github.com/stellar/freighter/assets/6886006/85c79adb-3a70-4c7b-a0a4-db561c17671e">
