### PR TITLE
[FIX] Account loading glitch

### DIFF
--- a/extension/src/popup/components/account/AccountHeader/index.tsx
+++ b/extension/src/popup/components/account/AccountHeader/index.tsx
@@ -29,6 +29,7 @@ interface AccountHeaderProps {
   allAccounts: Account[];
   currentAccountName: string;
   publicKey: string;
+  setLoading: (isLoading: boolean) => void;
 }
 
 export const AccountHeader = ({
@@ -36,6 +37,7 @@ export const AccountHeader = ({
   allAccounts,
   currentAccountName,
   publicKey,
+  setLoading,
 }: AccountHeaderProps) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -93,6 +95,7 @@ export const AccountHeader = ({
             allAccounts={allAccounts}
             publicKey={publicKey}
             setIsDropdownOpen={setIsDropdownOpen}
+            setLoading={setLoading}
           />
           <div className="AccountList__footer">
             <hr className="AccountHeader__list-divider" />

--- a/extension/src/popup/components/account/AccountList/index.tsx
+++ b/extension/src/popup/components/account/AccountList/index.tsx
@@ -31,6 +31,7 @@ interface AccountListItemProps {
   setIsDropdownOpen: (isDropdownOpen: boolean) => void;
   imported: boolean;
   hardwareWalletType?: WalletType;
+  setLoading?: (isLoading: boolean) => void;
 }
 
 export const AccountListItem = ({
@@ -40,6 +41,7 @@ export const AccountListItem = ({
   setIsDropdownOpen,
   imported,
   hardwareWalletType = WalletType.NONE,
+  setLoading,
 }: AccountListItemProps) => (
   <li
     className="AccountList__item"
@@ -52,6 +54,7 @@ export const AccountListItem = ({
       active={isSelected}
       publicKey={accountPublicKey}
       setIsDropdownOpen={setIsDropdownOpen}
+      setLoading={setLoading}
     >
       <OptionTag imported={imported} hardwareWalletType={hardwareWalletType} />
     </AccountListIdenticon>
@@ -65,12 +68,14 @@ interface AccounsListProps {
   allAccounts: Account[];
   publicKey: string;
   setIsDropdownOpen: (isDropdownOpen: boolean) => void;
+  setLoading?: (isLoading: boolean) => void;
 }
 
 export const AccountList = ({
   allAccounts,
   publicKey,
   setIsDropdownOpen,
+  setLoading,
 }: AccounsListProps) => (
   <div className="AccountList__accountsWrapper View__inset--scroll-shadows">
     {allAccounts.map(
@@ -91,6 +96,7 @@ export const AccountList = ({
             imported={imported}
             hardwareWalletType={hardwareWalletType}
             key={`${accountPublicKey}-${accountName}`}
+            setLoading={setLoading}
           />
         );
       },

--- a/extension/src/popup/components/identicons/AccountListIdenticon/index.tsx
+++ b/extension/src/popup/components/identicons/AccountListIdenticon/index.tsx
@@ -16,6 +16,7 @@ interface KeyIdenticonProps {
   publicKey: string;
   displayKey?: boolean;
   setIsDropdownOpen?: (IsDropdownOpen: boolean) => void;
+  setLoading?: (isLoading: boolean) => void;
 }
 
 export const AccountListIdenticon = ({
@@ -25,11 +26,18 @@ export const AccountListIdenticon = ({
   publicKey = "",
   displayKey = false,
   setIsDropdownOpen,
+  setLoading,
 }: KeyIdenticonProps) => {
   const dispatch = useDispatch();
   const shortPublicKey = truncatedPublicKey(publicKey);
 
   const handleMakeAccountActive = () => {
+    console.log(setLoading, "has set loading");
+    if (setLoading) {
+      console.log("set to true");
+      setLoading(true);
+    }
+
     if (setIsDropdownOpen) {
       setIsDropdownOpen(false);
     }

--- a/extension/src/popup/components/identicons/AccountListIdenticon/index.tsx
+++ b/extension/src/popup/components/identicons/AccountListIdenticon/index.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from "react-redux";
 
 import { truncatedPublicKey } from "helpers/stellar";
 import { makeAccountActive } from "popup/ducks/accountServices";
+import { resetAccountBalanceStatus } from "popup/ducks/transactionSubmission";
 
 import { IdenticonImg } from "../IdenticonImg";
 
@@ -29,11 +30,13 @@ export const AccountListIdenticon = ({
   const shortPublicKey = truncatedPublicKey(publicKey);
 
   const handleMakeAccountActive = () => {
-    if (!active) {
-      dispatch(makeAccountActive(publicKey));
-    }
     if (setIsDropdownOpen) {
       setIsDropdownOpen(false);
+    }
+
+    if (!active) {
+      dispatch(makeAccountActive(publicKey));
+      dispatch(resetAccountBalanceStatus());
     }
   };
 

--- a/extension/src/popup/components/identicons/AccountListIdenticon/index.tsx
+++ b/extension/src/popup/components/identicons/AccountListIdenticon/index.tsx
@@ -32,9 +32,7 @@ export const AccountListIdenticon = ({
   const shortPublicKey = truncatedPublicKey(publicKey);
 
   const handleMakeAccountActive = () => {
-    console.log(setLoading, "has set loading");
     if (setLoading) {
-      console.log("set to true");
       setLoading(true);
     }
 

--- a/extension/src/popup/ducks/transactionSubmission.ts
+++ b/extension/src/popup/ducks/transactionSubmission.ts
@@ -608,6 +608,7 @@ const transactionSubmissionSlice = createSlice({
     resetSubmission: () => initialState,
     resetAccountBalanceStatus: (state) => {
       state.accountBalanceStatus = initialState.accountBalanceStatus;
+      state.accountBalances = initialState.accountBalances;
     },
     resetDestinationAmount: (state) => {
       state.transactionData.destinationAmount =
@@ -723,6 +724,7 @@ const transactionSubmissionSlice = createSlice({
     });
     builder.addCase(getAccountBalances.pending, (state) => {
       state.accountBalanceStatus = ActionStatus.PENDING;
+      state.accountBalances = initialState.accountBalances;
     });
     builder.addCase(getAccountBalances.rejected, (state, action) => {
       state.error = action.payload;

--- a/extension/src/popup/views/Account/index.tsx
+++ b/extension/src/popup/views/Account/index.tsx
@@ -85,13 +85,16 @@ export const Account = () => {
   const [sortedBalances, setSortedBalances] = useState([] as AssetType[]);
   const [assetOperations, setAssetOperations] = useState({} as AssetOperations);
   const [selectedAsset, setSelectedAsset] = useState("");
+  const [isLoading, setLoading] = useState(true);
 
   const sorobanClient = useContext(SorobanContext);
 
   const { balances, isFunded } = accountBalances;
+
   useEffect(() => {
     // reset to avoid any residual data eg switching between send and swap or
     // previous stale sends
+    setLoading(true);
     dispatch(resetSubmission());
     dispatch(
       getAccountBalances({
@@ -158,10 +161,18 @@ export const Account = () => {
   }, [publicKey, networkDetails, balances, sortedBalances]);
 
   const hasError = accountBalanceStatus === ActionStatus.ERROR;
-  const isLoading =
-    accountBalanceStatus === ActionStatus.PENDING ||
-    accountBalanceStatus === ActionStatus.IDLE ||
-    accountStatus === ActionStatus.PENDING;
+
+  useEffect(() => {
+    if (
+      !(
+        accountBalanceStatus === ActionStatus.PENDING ||
+        accountBalanceStatus === ActionStatus.IDLE ||
+        accountStatus === ActionStatus.PENDING
+      )
+    ) {
+      setLoading(false);
+    }
+  }, [accountBalanceStatus, accountStatus]);
 
   return selectedAsset ? (
     <AssetDetail
@@ -273,7 +284,7 @@ export const Account = () => {
                   />
                 </div>
               )}
-              {!isFunded && !hasError && (
+              {balances !== null && !isFunded && !hasError && (
                 <NotFundedMessage
                   canUseFriendbot={!!networkDetails.friendbotUrl}
                   setIsAccountFriendbotFunded={setIsAccountFriendbotFunded}

--- a/extension/src/popup/views/Account/index.tsx
+++ b/extension/src/popup/views/Account/index.tsx
@@ -195,6 +195,7 @@ export const Account = () => {
             allAccounts={allAccounts}
             currentAccountName={currentAccountName}
             publicKey={publicKey}
+            setLoading={setLoading}
           />
           <View.Content
             hasNoTopPadding
@@ -284,7 +285,7 @@ export const Account = () => {
                   />
                 </div>
               )}
-              {balances !== null && !isFunded && !hasError && (
+              {!isFunded && !hasError && (
                 <NotFundedMessage
                   canUseFriendbot={!!networkDetails.friendbotUrl}
                   setIsAccountFriendbotFunded={setIsAccountFriendbotFunded}


### PR DESCRIPTION
What
Resets account balances any time the account balance status is reset
Moves isLoading to a useState var in Account
Adds a check for `balances` before showing not funded message

Why
When switching accounts, you would experience a flicker of the last state due to a mismatch in the rendering lifecycle and data fetching lifecycle.