### PR TITLE
[FIX] HistoryItem/TransactionDetail load glitch

### DIFF
--- a/extension/src/popup/components/account/AssetDetail/index.tsx
+++ b/extension/src/popup/components/account/AssetDetail/index.tsx
@@ -47,6 +47,7 @@ import StellarLogo from "popup/assets/stellar-logo.png";
 
 import "./styles.scss";
 import { formatAmount } from "popup/helpers/formatters";
+import { Loading } from "popup/components/Loading";
 
 interface AssetDetailProps {
   assetOperations: HorizonOperation[];
@@ -126,7 +127,7 @@ export const AssetDetail = ({
 
   if (assetIssuer && !assetDomain && !isSorobanAsset) {
     // if we have an asset issuer, wait until we have the asset domain before continuing
-    return null;
+    return <Loading />;
   }
 
   return isDetailViewShowing ? (

--- a/extension/src/popup/components/account/AssetDetail/index.tsx
+++ b/extension/src/popup/components/account/AssetDetail/index.tsx
@@ -117,7 +117,7 @@ export const AssetDetail = ({
     defaultDetailViewProps,
   );
 
-  const { assetDomain } = useAssetDomain({
+  const { assetDomain, error: assetError } = useAssetDomain({
     assetIssuer,
   });
 
@@ -125,7 +125,7 @@ export const AssetDetail = ({
     return null;
   }
 
-  if (assetIssuer && !assetDomain && !isSorobanAsset) {
+  if (assetIssuer && !assetDomain && !assetError && !isSorobanAsset) {
     // if we have an asset issuer, wait until we have the asset domain before continuing
     return <Loading />;
   }

--- a/extension/src/popup/components/accountHistory/TransactionDetail/index.tsx
+++ b/extension/src/popup/components/accountHistory/TransactionDetail/index.tsx
@@ -6,6 +6,7 @@ import { Button } from "@stellar/design-system";
 import { KeyIdenticon } from "popup/components/identicons/KeyIdenticon";
 import { SubviewHeader } from "popup/components/SubviewHeader";
 import { AssetNetworkInfo } from "popup/components/accountHistory/AssetNetworkInfo";
+import { Loading } from "popup/components/Loading";
 import { View } from "popup/basics/layout/View";
 
 import { emitMetric } from "helpers/metrics";
@@ -72,12 +73,15 @@ export const TransactionDetail = ({
 
   const { t } = useTranslation();
 
-  const { assetDomain } = useAssetDomain({
+  const { assetDomain, error: assetError } = useAssetDomain({
     assetIssuer,
   });
   const networkDetails = useSelector(settingsNetworkDetailsSelector);
+  const showContent = assetIssuer && !assetDomain && !assetError;
 
-  return assetIssuer && !assetDomain ? null : (
+  return showContent ? (
+    <Loading />
+  ) : (
     <React.Fragment>
       <SubviewHeader
         customBackAction={() => setIsDetailViewShowing(false)}

--- a/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
@@ -420,7 +420,7 @@ export const SubmitFail = () => {
             <img src={IconFail} alt="Icon Fail" />
           </div>
           <div className="SubmitResult__error-code">
-            {errDetails.status ? `${errDetails.status}:` : ""}{" "}
+            {errDetails.status ? `Status ${errDetails.status}:` : ""}{" "}
             {errDetails.opError}
           </div>
         </div>

--- a/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
@@ -336,12 +336,7 @@ export const SubmitFail = () => {
           "Destination account does not accept this asset",
         );
         errorDetails.errorBlock = (
-          <Notification
-            variant="error"
-            title={t(
-              "The destination account does not accept the asset you’re sending",
-            )}
-          >
+          <Notification variant="error" title="">
             <div>
               {t(
                 "The destination account does not accept the asset you’re sending. The destination account must opt to accept this asset before receiving it.",

--- a/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
@@ -336,10 +336,15 @@ export const SubmitFail = () => {
           "Destination account does not accept this asset",
         );
         errorDetails.errorBlock = (
-          <Notification variant="error" title="">
+          <Notification
+            variant="error"
+            title={t(
+              "The destination account does not accept the asset you’re sending",
+            )}
+          >
             <div>
               {t(
-                "The destination account does not accept the asset you’re sending. The destination account must opt to accept this asset before receiving it.",
+                "The destination account must opt to accept this asset before receiving it.",
               )}{" "}
               <Link
                 isUnderline

--- a/extension/src/popup/ducks/transactionSubmission.ts
+++ b/extension/src/popup/ducks/transactionSubmission.ts
@@ -608,7 +608,6 @@ const transactionSubmissionSlice = createSlice({
     resetSubmission: () => initialState,
     resetAccountBalanceStatus: (state) => {
       state.accountBalanceStatus = initialState.accountBalanceStatus;
-      state.accountBalances = initialState.accountBalances;
     },
     resetDestinationAmount: (state) => {
       state.transactionData.destinationAmount =

--- a/extension/src/popup/helpers/useAssetDomain.ts
+++ b/extension/src/popup/helpers/useAssetDomain.ts
@@ -7,11 +7,13 @@ import { isSorobanIssuer } from "./account";
 
 interface UseAssetDomain {
   assetIssuer?: string;
+  error?: string;
 }
 
 export const useAssetDomain = ({ assetIssuer = "" }: UseAssetDomain) => {
   const networkDetails = useSelector(settingsNetworkDetailsSelector);
   const [networkDomain, setNetworkDomain] = useState("");
+  const [error, setError] = useState("");
 
   useEffect(() => {
     const fetchAssetDomain = async () => {
@@ -25,6 +27,7 @@ export const useAssetDomain = ({ assetIssuer = "" }: UseAssetDomain) => {
         assetDomain = account.home_domain || "";
       } catch (e) {
         console.error(e);
+        setError(e as string);
       }
       setNetworkDomain(assetDomain || " ");
     };
@@ -36,5 +39,6 @@ export const useAssetDomain = ({ assetIssuer = "" }: UseAssetDomain) => {
 
   return {
     assetDomain: networkDomain,
+    error,
   };
 };

--- a/extension/src/popup/locales/en/translation.json
+++ b/extension/src/popup/locales/en/translation.json
@@ -423,9 +423,7 @@
   "The asset creator can revoke your access to this asset at anytime": "The asset creator can revoke your access to this asset at anytime",
   "The asset is not part of Stellar Expert's top 50 assets list": "The asset is not part of Stellar Expert's top 50 assets list",
   "The destination account can receive a different asset, the received amount is defined by the available conversion rates": "The destination account can receive a different asset, the received amount is defined by the available conversion rates",
-  "The destination account does not accept the asset you’re sending": {
-    " The destination account must opt to accept this asset before receiving it": "The destination account does not accept the asset you’re sending. The destination account must opt to accept this asset before receiving it."
-  },
+  "The destination account does not accept the asset you’re sending": "The destination account does not accept the asset you’re sending",
   "The destination account doesn’t exist": "The destination account doesn’t exist.",
   "The destination account receives the same asset and amount sent": "The destination account receives the same asset and amount sent",
   "The final amount is approximate and may change": "The final amount is approximate and may change",

--- a/extension/src/popup/locales/en/translation.json
+++ b/extension/src/popup/locales/en/translation.json
@@ -425,6 +425,7 @@
   "The destination account can receive a different asset, the received amount is defined by the available conversion rates": "The destination account can receive a different asset, the received amount is defined by the available conversion rates",
   "The destination account does not accept the asset you’re sending": "The destination account does not accept the asset you’re sending",
   "The destination account doesn’t exist": "The destination account doesn’t exist.",
+  "The destination account must opt to accept this asset before receiving it": "The destination account must opt to accept this asset before receiving it.",
   "The destination account receives the same asset and amount sent": "The destination account receives the same asset and amount sent",
   "The final amount is approximate and may change": "The final amount is approximate and may change",
   "The transaction you’re trying to sign is on": "The transaction you’re trying to sign is on",

--- a/extension/src/popup/locales/pt/translation.json
+++ b/extension/src/popup/locales/pt/translation.json
@@ -423,9 +423,7 @@
   "The asset creator can revoke your access to this asset at anytime": "The asset creator can revoke your access to this asset at anytime",
   "The asset is not part of Stellar Expert's top 50 assets list": "The asset is not part of Stellar Expert's top 50 assets list",
   "The destination account can receive a different asset, the received amount is defined by the available conversion rates": "The destination account can receive a different asset, the received amount is defined by the available conversion rates",
-  "The destination account does not accept the asset you’re sending": {
-    " The destination account must opt to accept this asset before receiving it": "The destination account does not accept the asset you’re sending. The destination account must opt to accept this asset before receiving it."
-  },
+  "The destination account does not accept the asset you’re sending": "The destination account does not accept the asset you’re sending",
   "The destination account doesn’t exist": "The destination account doesn’t exist.",
   "The destination account receives the same asset and amount sent": "The destination account receives the same asset and amount sent",
   "The final amount is approximate and may change": "The final amount is approximate and may change",

--- a/extension/src/popup/locales/pt/translation.json
+++ b/extension/src/popup/locales/pt/translation.json
@@ -425,6 +425,7 @@
   "The destination account can receive a different asset, the received amount is defined by the available conversion rates": "The destination account can receive a different asset, the received amount is defined by the available conversion rates",
   "The destination account does not accept the asset you’re sending": "The destination account does not accept the asset you’re sending",
   "The destination account doesn’t exist": "The destination account doesn’t exist.",
+  "The destination account must opt to accept this asset before receiving it": "The destination account must opt to accept this asset before receiving it.",
   "The destination account receives the same asset and amount sent": "The destination account receives the same asset and amount sent",
   "The final amount is approximate and may change": "The final amount is approximate and may change",
   "The transaction you’re trying to sign is on": "The transaction you’re trying to sign is on",

--- a/extension/src/popup/views/__tests__/Account.test.tsx
+++ b/extension/src/popup/views/__tests__/Account.test.tsx
@@ -66,7 +66,7 @@ jest
   .mockImplementation(() => Promise.resolve(mockHistoryOperations.operations));
 
 jest.spyOn(UseAssetDomain, "useAssetDomain").mockImplementation(() => {
-  return { assetDomain: "centre.io" };
+  return { assetDomain: "centre.io", error: "" };
 });
 
 describe("Account view", () => {


### PR DESCRIPTION
What
Adds missing loading states in TransactionDetail & HistoryItem to avoid the layout shift.

Why
In both of these spots, we rendered null for a loading state which caused a layout shift as the nav moved up where the missing space is.