### PR TITLE
[FEATURE] send token from detail

### DIFF
--- a/extension/src/popup/components/account/AssetDetail/index.tsx
+++ b/extension/src/popup/components/account/AssetDetail/index.tsx
@@ -17,7 +17,7 @@ import {
 } from "popup/helpers/account";
 import { useAssetDomain } from "popup/helpers/useAssetDomain";
 import { navigateTo } from "popup/helpers/navigate";
-import { formatTokenAmount } from "popup/helpers/soroban";
+import { formatTokenAmount, isContractId } from "popup/helpers/soroban";
 import { getAssetFromCanonical } from "helpers/stellar";
 import { ROUTES } from "popup/constants/routes";
 
@@ -39,14 +39,15 @@ import { View } from "popup/basics/layout/View";
 import {
   saveAsset,
   saveDestinationAsset,
+  saveIsToken,
   transactionSubmissionSelector,
 } from "popup/ducks/transactionSubmission";
 import { AppDispatch } from "popup/App";
 import { useIsOwnedScamAsset } from "popup/helpers/useIsOwnedScamAsset";
 import StellarLogo from "popup/assets/stellar-logo.png";
+import { formatAmount } from "popup/helpers/formatters";
 
 import "./styles.scss";
-import { formatAmount } from "popup/helpers/formatters";
 
 interface AssetDetailProps {
   assetOperations: HorizonOperation[];
@@ -120,6 +121,8 @@ export const AssetDetail = ({
     assetIssuer,
   });
 
+  const isContract = isContractId(assetIssuer);
+
   if (!assetOperations && !isSorobanAsset) {
     return null;
   }
@@ -183,17 +186,19 @@ export const AssetDetail = ({
           <div className="AssetDetail__actions">
             {balance?.total && new BigNumber(balance?.total).toNumber() > 0 ? (
               <>
-                {/* Hide send for Soroban until send work is ready for Soroban tokens */}
-                {!isSorobanAsset && (
-                  <PillButton
-                    onClick={() => {
-                      dispatch(saveAsset(selectedAsset));
-                      navigateTo(ROUTES.sendPayment);
-                    }}
-                  >
-                    {t("SEND")}
-                  </PillButton>
-                )}
+                <PillButton
+                  onClick={() => {
+                    dispatch(saveAsset(selectedAsset));
+                    if (isContract) {
+                      dispatch(saveIsToken(true));
+                    } else {
+                      dispatch(saveIsToken(false));
+                    }
+                    navigateTo(ROUTES.sendPayment);
+                  }}
+                >
+                  {t("SEND")}
+                </PillButton>
                 {!isSorobanAsset && (
                   <PillButton
                     onClick={() => {


### PR DESCRIPTION
What
Removes restriction on send from asset detail for Soroban tokens.

Why
We support sending Soroban tokens as a feature and were missing the path to do it from asset detail.