### PR TITLE
before we close the sign transaction window, complete metrics upload

### DIFF
--- a/extension/src/helpers/metrics.ts
+++ b/extension/src/helpers/metrics.ts
@@ -147,7 +147,7 @@ const getUserId = () => {
  * @param {object?} body An optional object containing event metadata
  * @returns {void}
  */
-export const emitMetric = (name: string, body?: any) => {
+export const emitMetric = async (name: string, body?: any) => {
   const isDataSharingAllowed = settingsDataSharingSelector(store.getState());
   if (!isDataSharingAllowed) {
     return;
@@ -169,5 +169,5 @@ export const emitMetric = (name: string, body?: any) => {
     secret_key_account_funded: metricsData.importedFunded,
     /* eslint-enable */
   });
-  uploadMetrics();
+  await uploadMetrics();
 };

--- a/extension/src/popup/helpers/useSetupSigningFlow.ts
+++ b/extension/src/popup/helpers/useSetupSigningFlow.ts
@@ -55,7 +55,6 @@ export function useSetupSigningFlow(
   };
 
   const signAndClose = async () => {
-    emitMetric(METRIC_NAMES.approveSign);
     if (isHardwareWallet) {
       dispatch(
         startHwSign({ transactionXDR: transactionXdr, shouldSubmit: false }),
@@ -63,6 +62,7 @@ export function useSetupSigningFlow(
       setStartedHwSign(true);
     } else {
       await dispatch(signFn());
+      await emitMetric(METRIC_NAMES.approveSign);
       window.close();
     }
   };


### PR DESCRIPTION

https://github.com/stellar/freighter/assets/6789586/8b119640-3291-4cf0-8f7a-083a9f565290

A hypothesis for why we're seeing so many Amplitude errors in Sentry is that the popup is closing before the call can be completed. We seem to be getting a good deal more errors for SignTransaction. This may be because we were emitting a metric, signing/transmitting the tx, and then closing the window. The latter 2 steps happen very quickly. Maybe too quickly for the metric emit to complete.

I was able to simulate this by throttling my network to a slow speed and observing that at slow network speeds, I was pretty reliably generating a Sentry error because the Amplitude request was always still in process when the window closed. 

The change above shows what happens at a slow network speed now. The window waits to complete any metric emission before closing. This is at a throttled speed, so the delay is pretty pronounced. On a normal speed, it's almost completely unnoticeable.

Let's see if this reduces the amount of Sentry errors we get. We will still have the problem of Amplitude requests being cut off if someone quickly closes the popup. But this will hopefully a) reduce some noise and b) lend more credence to our hypothesis