### PR TITLE
Feature/improve api error states

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -669,22 +669,17 @@ export const getIndexerAccountHistory = async ({
   publicKey: string;
   networkDetails: NetworkDetails;
 }): Promise<Horizon.ServerApi.OperationRecord[]> => {
-  try {
-    const url = new URL(
-      `${INDEXER_URL}/account-history/${publicKey}?network=${networkDetails.network}`,
-    );
-    const response = await fetch(url.href);
+  const url = new URL(
+    `${INDEXER_URL}/account-history/${publicKey}?network=${networkDetails.network}`,
+  );
+  const response = await fetch(url.href);
 
-    const data = await response.json();
-    if (!response.ok) {
-      throw new Error(data);
-    }
-
-    return data;
-  } catch (e) {
-    console.error(e);
-    return [];
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data);
   }
+
+  return data;
 };
 
 export const getAssetIcons = async ({

--- a/extension/src/popup/components/account/AccountHeader/index.tsx
+++ b/extension/src/popup/components/account/AccountHeader/index.tsx
@@ -25,7 +25,6 @@ import IconCube from "popup/assets/icon-cube.svg";
 import "./styles.scss";
 
 interface AccountHeaderProps {
-  // accountDropDownRef: React.RefObject<HTMLDivElement>;
   allAccounts: Account[];
   currentAccountName: string;
   publicKey: string;
@@ -33,7 +32,6 @@ interface AccountHeaderProps {
 }
 
 export const AccountHeader = ({
-  // accountDropDownRef,
   allAccounts,
   currentAccountName,
   publicKey,

--- a/extension/src/popup/locales/en/translation.json
+++ b/extension/src/popup/locales/en/translation.json
@@ -158,6 +158,7 @@
   "Executable Wasm Hash": "Executable Wasm Hash",
   "Extend To": "Extend To",
   "Failed to fetch your account balances": "Failed to fetch your account balances.",
+  "Failed to fetch your account history": "Failed to fetch your account history.",
   "FEDERATION ADDRESS": "FEDERATION ADDRESS",
   "Fee": "Fee",
   "Fees can vary depending on the network congestion": {
@@ -510,6 +511,7 @@
     " Please review the transaction and try again": "Your account balance is not sufficient for this transaction. Please review the transaction and try again."
   },
   "Your account balances could not be fetched at this time": "Your account balances could not be fetched at this time.",
+  "Your account history could not be fetched at this time": "Your account history could not be fetched at this time.",
   "Your Freighter install is complete": "Your Freighter install is complete",
   "Your recovery phrase gives you access to your account and is the": "Your recovery phrase gives you access to your account and is the",
   "Your Stellar secret key": "Your Stellar secret key"

--- a/extension/src/popup/locales/pt/translation.json
+++ b/extension/src/popup/locales/pt/translation.json
@@ -158,6 +158,7 @@
   "Executable Wasm Hash": "Executable Wasm Hash",
   "Extend To": "Extend To",
   "Failed to fetch your account balances": "Failed to fetch your account balances.",
+  "Failed to fetch your account history": "Failed to fetch your account history.",
   "FEDERATION ADDRESS": "FEDERATION ADDRESS",
   "Fee": "Fee",
   "Fees can vary depending on the network congestion": {
@@ -510,6 +511,7 @@
     " Please review the transaction and try again": "Your account balance is not sufficient for this transaction. Please review the transaction and try again."
   },
   "Your account balances could not be fetched at this time": "Your account balances could not be fetched at this time.",
+  "Your account history could not be fetched at this time": "Your account history could not be fetched at this time.",
   "Your Freighter install is complete": "Your Freighter install is complete",
   "Your recovery phrase gives you access to your account and is the": "Your recovery phrase gives you access to your account and is the",
   "Your Stellar secret key": "Your Stellar secret key"

--- a/extension/src/popup/views/Account/index.tsx
+++ b/extension/src/popup/views/Account/index.tsx
@@ -193,7 +193,6 @@ export const Account = () => {
       ) : (
         <>
           <AccountHeader
-            // accountDropDownRef={accountDropDownRef}
             allAccounts={allAccounts}
             currentAccountName={currentAccountName}
             publicKey={publicKey}
@@ -246,6 +245,7 @@ export const Account = () => {
                   </div>
                   <div className="AccountView__send-receive-button">
                     <NavButton
+                      disabled={hasError}
                       showBorder
                       title={t("Send Payment")}
                       id="nav-btn-send"

--- a/extension/src/popup/views/AccountHistory/index.tsx
+++ b/extension/src/popup/views/AccountHistory/index.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { useTranslation } from "react-i18next";
-import { Loader } from "@stellar/design-system";
+import { Loader, Notification } from "@stellar/design-system";
 import { Horizon } from "stellar-sdk";
+import { captureException } from "@sentry/browser";
 
 import {
   getAccountHistoryStandalone,
@@ -76,6 +77,7 @@ export const AccountHistory = () => {
     defaultDetailViewProps,
   );
   const [isLoading, setIsLoading] = useState(false);
+  const [hasHistoryError, setHasHistoryError] = React.useState(false);
 
   const stellarExpertUrl = getStellarExpertUrl(networkDetails);
 
@@ -144,6 +146,8 @@ export const AccountHistory = () => {
         }
         setHistorySegments(createSegments(operations));
       } catch (e) {
+        captureException(`Failed to fetch account history - ${e}`);
+        setHasHistoryError(true);
         console.error(e);
       }
     };
@@ -215,6 +219,14 @@ export const AccountHistory = () => {
                   </div>
                 )}
               </div>
+              {hasHistoryError && (
+                <Notification
+                  variant="error"
+                  title={t("Failed to fetch your account history.")}
+                >
+                  {t("Your account history could not be fetched at this time.")}
+                </Notification>
+              )}
             </>
           )}
         </div>


### PR DESCRIPTION
What
Disables send link when account balances are unavailable
Adds error state for account history, with notification

Why
Currently if we fail to get account balances, users can still attempt to go through the payment flow even though it won't work
Currently we display an empty history page with no error message if we fail to get account history