### PR TITLE
disable husky in prod build

### DIFF
--- a/.github/workflows/submitProduction.yml
+++ b/.github/workflows/submitProduction.yml
@@ -1,6 +1,7 @@
 name: Production Deployment
 env:
   INDEXER_URL: ${{ secrets.INDEXER_URL }}
+  HUSKY: 0
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
When committing the version bump, the pipeline breaks on the snapshot pre-push. This is actually a side effect and is only designed to be needed when pushing a new feature to the repo. We can safely disable here as no code is actually being changed with this version bump.