### PR TITLE
tweaks tx detail row layouts to avoid overflows

### DIFF
--- a/extension/src/popup/components/accountHistory/TransactionDetail/index.tsx
+++ b/extension/src/popup/components/accountHistory/TransactionDetail/index.tsx
@@ -110,7 +110,7 @@ export const TransactionDetail = ({
                   {isRecipient ? (
                     <>
                       <div>{t("From")}</div>
-                      <div>
+                      <div className="InfoRow__right">
                         <KeyIdenticon
                           publicKey={from}
                           customSize={identiconDimensions}
@@ -120,7 +120,7 @@ export const TransactionDetail = ({
                   ) : (
                     <>
                       <div>{t("To")}</div>
-                      <div>
+                      <div className="InfoRow__right">
                         <KeyIdenticon
                           publicKey={to}
                           customSize={identiconDimensions}
@@ -133,24 +133,26 @@ export const TransactionDetail = ({
                 !isSwap && (
                   <>
                     <div>{t("Action")}</div>
-                    <div>{operationText}</div>
+                    <div className="InfoRow__right">{operationText}</div>
                   </>
                 )
               )}
             </div>
             <div className="TransactionDetail__info__row">
               <div>{t("Date")}</div>
-              <div>
+              <div className="InfoRow__right">
                 {createdAtTime} &bull; {createdAtDateStr}
               </div>
             </div>
             <div className="TransactionDetail__info__row">
               <div>{t("Memo")}</div>
-              <div>{memo || `None`}</div>
+              <div className="InfoRow__right">{memo || `None`}</div>
             </div>
             <div className="TransactionDetail__info__row">
               <div>{t("Transaction fee")}</div>
-              <div>{stroopToXlm(feeCharged as string).toString()} XLM</div>
+              <div className="InfoRow__right">
+                {stroopToXlm(feeCharged as string).toString()} XLM
+              </div>
             </div>
           </div>
         </div>

--- a/extension/src/popup/components/accountHistory/TransactionDetail/styles.scss
+++ b/extension/src/popup/components/accountHistory/TransactionDetail/styles.scss
@@ -26,7 +26,6 @@
     &__row {
       color: rgba(255, 255, 255, 0.6);
       display: flex;
-      height: 1.5rem;
       justify-content: space-between;
 
       div:nth-child(2) {
@@ -35,6 +34,12 @@
 
       &:empty {
         display: none;
+      }
+
+      .InfoRow {
+        &__right {
+          width: 50%;
+        }
       }
     }
   }


### PR DESCRIPTION
What
Tweaks tx detail row layout in order to avoid text overflows for long strings

Before:
![Screenshot 2024-05-02 at 10 36 36 AM](https://github.com/stellar/freighter/assets/6886006/0d8cb0bf-cb8c-494f-81e0-74a42912bc8f)

After:
![Screenshot 2024-05-02 at 10 42 45 AM](https://github.com/stellar/freighter/assets/6886006/2719e537-4d8f-4c87-b9fb-a7eade3d0064)
