### PR TITLE
[FEATURE] renders byte arrays in hex

### DIFF
--- a/extension/src/popup/helpers/__tests__/scValByType.test.js
+++ b/extension/src/popup/helpers/__tests__/scValByType.test.js
@@ -29,7 +29,7 @@ describe("scValByType", () => {
     const parsedBool = scValByType(bool);
     expect(parsedBool).toEqual(true);
   });
-  it.only("should render bytes as a a hex string", () => {
+  it("should render bytes as a a hex string", () => {
     const bytesBuffer = Buffer.from([0x00, 0x01]);
     const bytes = xdr.ScVal.scvBytes(bytesBuffer);
     const parsedBytes = scValByType(bytes);

--- a/extension/src/popup/helpers/__tests__/scValByType.test.js
+++ b/extension/src/popup/helpers/__tests__/scValByType.test.js
@@ -29,11 +29,11 @@ describe("scValByType", () => {
     const parsedBool = scValByType(bool);
     expect(parsedBool).toEqual(true);
   });
-  it("should render bytes as an array of numbers", () => {
+  it.only("should render bytes as a a hex string", () => {
     const bytesBuffer = Buffer.from([0x00, 0x01]);
     const bytes = xdr.ScVal.scvBytes(bytesBuffer);
     const parsedBytes = scValByType(bytes);
-    expect(parsedBytes).toEqual("[0,1]");
+    expect(parsedBytes).toEqual("0001");
   });
   it("should render an error as a string, including the contract code and name", () => {
     const contractErrorCode = 1;

--- a/extension/src/popup/helpers/soroban.ts
+++ b/extension/src/popup/helpers/soroban.ts
@@ -355,7 +355,11 @@ export const scValByType = (scVal: xdr.ScVal) => {
     }
 
     case xdr.ScValType.scvBytes(): {
-      return JSON.stringify(scVal.bytes().toJSON().data);
+      return scVal
+        .bytes()
+        .toJSON()
+        .data.map((d) => d.toString(16).padStart(2, "0"))
+        .join("");
     }
 
     case xdr.ScValType.scvContractInstance(): {


### PR DESCRIPTION
What
Renders byte arrays as hex in the transform helper used to render ScVals.

Why
Hex is a more common representation for random blobs in the ecosystem and other tooling.