### PR TITLE
fix issue with metric middleware not running on page load

### DIFF
--- a/extension/src/popup/Router.tsx
+++ b/extension/src/popup/Router.tsx
@@ -227,10 +227,13 @@ const HomeRoute = () => {
 const RouteListener = () => {
   const dispatch = useDispatch();
   const location = useLocation();
+  const settingsState = useSelector(settingsStateSelector);
 
   useEffect(() => {
-    dispatch(navigate(location));
-  }, [dispatch, location]);
+    if (settingsState === SettingsState.SUCCESS) {
+      dispatch(navigate(location));
+    }
+  }, [dispatch, location, settingsState]);
 
   return null;
 };

--- a/extension/src/popup/metrics/views.ts
+++ b/extension/src/popup/metrics/views.ts
@@ -19,7 +19,7 @@ const routeToEventName = {
   [ROUTES.connectDevice]: METRIC_NAMES.viewConnectDevice,
   [ROUTES.signBlob]: METRIC_NAMES.viewSignBlob,
   [ROUTES.signTransaction]: METRIC_NAMES.viewSignTransaction,
-  [ROUTES.reviewAuthorization]: METRIC_NAMES.viewSignTransaction,
+  [ROUTES.reviewAuthorization]: METRIC_NAMES.viewReviewAuthorization,
   [ROUTES.signAuthEntry]: METRIC_NAMES.viewSignAuthEntry,
   [ROUTES.grantAccess]: METRIC_NAMES.viewGrantAccess,
   [ROUTES.mnemonicPhrase]: METRIC_NAMES.viewMnemonicPhrase,


### PR DESCRIPTION
This fixes an issue where the loading of the Sign Transaction view was not being logged correctly in Amplitude. We were getting events for `loaded screen: sign transaction`, but they were all missing the `domain` property, which we use to see what dapps people are signing tx's on.

Context: https://stellarfoundation.slack.com/archives/C016CPSLVLG/p1715202813917719?thread_ts=1715200459.695319&cid=C016CPSLVLG

There were 2 bugs here:

1) the /review-auth route was incorrectly emitting the `loaded screen: sign transaction` metric. This route isn't configured to report `domain`, so it was sending that event but without the custom property.

2) /sign-transaction, the view that's supposed to be emitting that metric, wasn't reporting at all. That's because it was reporting _before_ the user loaded their settings. Before a user loads their settings, `isDataSharingAllowed` defaults to `false`. So, it would get ready to emit the correct event (with the `domain` custom property), but it would abort when it hit the `isDataSharingAllowed` flag.