### PR TITLE
add scripts tag for Firefox

### DIFF
--- a/extension/public/static/manifest/v3.json
+++ b/extension/public/static/manifest/v3.json
@@ -4,7 +4,8 @@
   "version_name": "5.18.5",
   "description": "Freighter is a non-custodial wallet extension that enables you to sign Stellar transactions via your browser.",
   "background": {
-    "service_worker": "background.min.js"
+    "service_worker": "background.min.js",
+    "scripts": ["background.min.js"]
   },
   "content_scripts": [
     {


### PR DESCRIPTION
Firefox expects a different key for the background script than Chrome. Luckily, just listing them under both keys make this cross browser compatible:

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background#browser_support