### PR TITLE
[BUG] checks for migrated account in migration logic to set migrated network

### DIFF
--- a/extension/src/background/helpers/dataStorage.ts
+++ b/extension/src/background/helpers/dataStorage.ts
@@ -247,6 +247,7 @@ const migrateSorobanRpcUrlNetwork = async () => {
       NETWORK_ID,
     );
     if (
+      migratedNetwork &&
       migratedNetwork.network === NETWORKS.FUTURENET &&
       !migratedNetwork.sorobanRpcUrl
     ) {


### PR DESCRIPTION
What
Checks for `migratedNetwork` in a migration that was missing that check

Why
`migratedNetwork` could be null, causing an error in the logic