### PR TITLE
don't babel-polyfill contentScript

### DIFF
--- a/extension/public/static/manifest/v3.json
+++ b/extension/public/static/manifest/v3.json
@@ -3,6 +3,12 @@
   "version": "5.18.5",
   "version_name": "5.18.5",
   "description": "Freighter is a non-custodial wallet extension that enables you to sign Stellar transactions via your browser.",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{3ee0dd4e-8c64-4b92-b539-25718a10f62f}",
+      "strict_min_version": "48.0"
+    }
+  },
   "background": {
     "service_worker": "background.min.js",
     "scripts": ["background.min.js"]

--- a/extension/webpack.common.js
+++ b/extension/webpack.common.js
@@ -16,10 +16,7 @@ const commonConfig = (
   entry: {
     background: path.resolve(__dirname, "./public/background.ts"),
     index: ["babel-polyfill", path.resolve(__dirname, "./src/popup/index.tsx")],
-    contentScript: [
-      "babel-polyfill",
-      path.resolve(__dirname, "./public/contentScript.ts"),
-    ],
+    contentScript: [path.resolve(__dirname, "./public/contentScript.ts")],
   },
   watchOptions: {
     ignored: ["node_modules/**/*", "build/**/*"],


### PR DESCRIPTION
Firefox has a strict Content Security Policy where they don't allow `eval()` in an extension content script. `eval` is added as a byproduct of Webpack compiling our code with `babel-polyfill`. I simply removed the `babel-polyfill` compilation for `contentScript`.

I don't think we'll lose much here, as we're not supporting old versions of (for ex) IE. Also, FF and Chrome do autoupdate. We'll need to be mindful of using only ES approved features. ES2023 has been supported by Chrome and FF since 2022