### PR TITLE
use yarn to build docs

### DIFF
--- a/docs/docs/guide/basics/VersionedUrl.tsx
+++ b/docs/docs/guide/basics/VersionedUrl.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import packageJson from "../../../../@stellar/freighter-api/package.json";
+
+export const VersionedUrl = () => (
+  <p>
+    <code>{`<head><script src='https://cdnjs.cloudflare.com/ajax/libs/stellar-freighter-api/${packageJson.version}/index.min.js' /></head>`}</code>
+  </p>
+);

--- a/docs/docs/guide/usingFreighterBrowser.md
+++ b/docs/docs/guide/usingFreighterBrowser.md
@@ -15,7 +15,7 @@ _NOTE:_ You must use version `1.1.2` or above
 
 ```html
 <head>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/stellar-freighter-api/{version}/index.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/stellar-freighter-api/2.0.0/index.min.js"></script>
 </head>
 ```
 

--- a/docs/docs/guide/usingFreighterBrowser.mdx
+++ b/docs/docs/guide/usingFreighterBrowser.mdx
@@ -4,7 +4,6 @@ title: Using Freighter in the browser
 ---
 
 import { VersionedUrl } from "./basics/VersionedUrl";
-const v = "12";
 
 We now have an extension installed on our machine and a library to interact with it. This library will provide you methods to send and receive data from a user's extension in your website or application.
 

--- a/docs/docs/guide/usingFreighterBrowser.mdx
+++ b/docs/docs/guide/usingFreighterBrowser.mdx
@@ -3,6 +3,9 @@ id: usingFreighterBrowser
 title: Using Freighter in the browser
 ---
 
+import { VersionedUrl } from "./basics/VersionedUrl";
+const v = "12";
+
 We now have an extension installed on our machine and a library to interact with it. This library will provide you methods to send and receive data from a user's extension in your website or application.
 
 ### Importing
@@ -13,11 +16,9 @@ First import the library in the `<head>` tag of your page.
 
 _NOTE:_ You must use version `1.1.2` or above
 
-```html
-<head>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/stellar-freighter-api/2.0.0/index.min.js"></script>
-</head>
-```
+For example, include the `script` in your `head` tag using the following code:
+
+<VersionedUrl />
 
 This will expose a global variable called `window.freighterApi` that will contain our library.
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@docusaurus/core": "2.4.1",
     "@docusaurus/preset-classic": "2.4.1",
-    "@stellar/freighter-api": "^2.0.0",
+    "@stellar/freighter-api": "latest",
     "clsx": "^1.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "setup": "yarn install && yarn allow-scripts",
     "build": "run-p --print-label build:freighter-api build:docs build:extension",
-    "build:netlify": "cd docs && npm i --legacy-peer-deps && npm run build",
+    "build:netlify": "cd docs && yarn --legacy-peer-deps && yarn build",
     "build:extension-preview": "run-s build:freighter-api build:extension:experimental",
     "build:freighter-api": "yarn workspace @stellar/freighter-api build",
     "build:docs": "yarn workspace docs build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3063,6 +3063,11 @@
   resolved "https://registry.yarnpkg.com/@stellar/eslint-config/-/eslint-config-2.1.2.tgz#95c223d10a5dfc2c89486e76cc7c9f1b56df3564"
   integrity sha512-5aUkncDMmx0SvVlZD4rld5snGKt3mc0Gno1Jik3Pp31HUmpgrkRUD3ZZekEOqB9mDKadZhQZNNsS0jhyuXaayw==
 
+"@stellar/freighter-api@latest":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stellar/freighter-api/-/freighter-api-2.0.0.tgz#488915a4aa0cec8c9a3fc84ef31e21cd5ec41343"
+  integrity sha512-j/R7MLPL8S3QhwOEdAxSl7MgWBTXWlOXQKQyXR8mPk1JMKKR4tF8e4U+Fs9TPQH0HZoYqfVDvLOOUrTMMY058Q==
+
 "@stellar/js-xdr@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@stellar/js-xdr/-/js-xdr-3.1.1.tgz#be0ff90c8a861d6e1101bca130fa20e74d5599bb"


### PR DESCRIPTION
The yarn-specific aliases I created for stellar-sdk and stellar-sdk-next weren't playing nice with the docs build because they use `npm` instead of yarn. 

I had been using `npm` to make sure the docs grabbed freighter-api from the registry rather than trying to symlink to the workspace in this repo. This PR finds a different workaround for this