### PR TITLE
[FEATURE] adds sign blob error for encoding mismatch

### DIFF
--- a/extension/src/background/messageListener/freighterApiMessageListener.ts
+++ b/extension/src/background/messageListener/freighterApiMessageListener.ts
@@ -296,6 +296,14 @@ export const freighterApiMessageListener = (
           }),
         );
       }
+
+      // reject if not b64 encoded
+      try {
+        atob(blob);
+      } catch (error) {
+        resolve({ error: "encoding error: blob should be base64 encoded" });
+      }
+
       const response = (signedBlob: string) => {
         if (signedBlob) {
           if (!isDomainListedAllowed) {

--- a/extension/src/popup/components/signBlob/index.tsx
+++ b/extension/src/popup/components/signBlob/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import * as Sentry from "@sentry/browser";
-import { Card, Heading } from "@stellar/design-system";
+import { Card } from "@stellar/design-system";
 
 import "./index.scss";
 
@@ -9,22 +9,22 @@ interface BlobProps {
 }
 
 export const Blob = (props: BlobProps) => {
-  let displayBlob = props.blob;
-
-  try {
-    displayBlob = atob(props.blob);
-  } catch (error) {
-    Sentry.captureException(
-      `Failed to convert blob to display - ${props.blob}`,
-    );
+  function renderBlob() {
+    try {
+      const displayBlob = atob(props.blob);
+      return displayBlob;
+    } catch (error) {
+      Sentry.captureException(
+        `Failed to convert blob to display - ${props.blob}`,
+      );
+      return JSON.stringify(props.blob);
+    }
   }
 
   return (
     <Card variant="secondary">
-      <Heading size="md" as="h4">
-        Signing data:
-      </Heading>
-      <div className="Blob">{displayBlob}</div>
+      <p>Signing data:</p>
+      <div className="Blob">{renderBlob()}</div>
     </Card>
   );
 };


### PR DESCRIPTION
What
Adds a specific error for encoding mis-matches when using the sign blob API.
Tweaks the popup to not fail on non-b64 blobs

Why
Users are attempting to use this API without b64 encoding the blob, this should improve visibility into the issue.