### PR TITLE
don't clear all of localStore on recoverAccount

### DIFF
--- a/extension/src/background/helpers/dataStorage.ts
+++ b/extension/src/background/helpers/dataStorage.ts
@@ -62,6 +62,9 @@ export const dataStorage = (
   clear: async () => {
     await storageApi.clear();
   },
+  remove: async (keys: string | string[]) => {
+    await storageApi.remove(keys);
+  },
 });
 
 export const dataStorageAccess = (
@@ -74,6 +77,7 @@ export const dataStorageAccess = (
       await store.setItem({ [keyId]: value });
     },
     clear: () => store.clear(),
+    remove: store.remove,
   };
 };
 
@@ -148,17 +152,17 @@ export const migrateSorobanRpcUrlNetworkDetails = async () => {
 // This migration migrates the storage for custom tokens IDs to be keyed by network
 const migrateTokenIdList = async () => {
   const localStore = dataStorageAccess(browserLocalStorage);
-  const tokenIdsByKey = (await localStore.getItem(TOKEN_ID_LIST)) as Record<
-    string,
-    object
-  >;
+  const tokenIdsByKey = await localStore.getItem(TOKEN_ID_LIST);
   const storageVersion = (await localStore.getItem(STORAGE_VERSION)) as string;
 
   if (!storageVersion || semver.lt(storageVersion, "1.0.0")) {
-    const newTokenList = {
-      [NETWORKS.FUTURENET]: tokenIdsByKey,
-    };
-    await localStore.setItem(TOKEN_ID_LIST, newTokenList);
+    if (Array.isArray(tokenIdsByKey)) {
+      const newTokenList = {
+        [NETWORKS.FUTURENET]: tokenIdsByKey,
+      };
+      await localStore.setItem(TOKEN_ID_LIST, newTokenList);
+    }
+
     await migrateDataStorageVersion("1.0.0");
   }
 };

--- a/extension/src/background/messageListener/popupMessageListener.ts
+++ b/extension/src/background/messageListener/popupMessageListener.ts
@@ -34,6 +34,7 @@ import { MessageResponder } from "background/types";
 
 import {
   ALLOWLIST_ID,
+  ACCOUNT_NAME_LIST_ID,
   APPLICATION_ID,
   ASSETS_LISTS_ID,
   CACHED_ASSET_ICONS_ID,
@@ -766,7 +767,21 @@ export const popupMessageListener = (request: Request, sessionStore: Store) => {
         publicKey: wallet.getPublicKey(0),
         privateKey: wallet.getSecret(0),
       };
-      localStore.clear();
+
+      const keyIdList = await getKeyIdList();
+
+      if (keyIdList.length) {
+        /* Clear any existing account data while maintaining app settings */
+
+        // eslint-disable-next-line @typescript-eslint/prefer-for-of
+        for (let i = 0; i < keyIdList.length; i += 1) {
+          await localStore.remove(`stellarkeys:${keyIdList[i]}`);
+        }
+
+        await localStore.setItem(KEY_ID_LIST, []);
+        await localStore.remove(ACCOUNT_NAME_LIST_ID);
+      }
+
       await localStore.setItem(KEY_DERIVATION_NUMBER_ID, "0");
 
       await _storeAccount({


### PR DESCRIPTION
When we call `recoverAccount` to load an acct from mnemonic phrase, we had been clearing all of the localStore. When this was implemented, this was meant to cover the use case where a user already has an account, but wanted to import a new account from seed phrase on this screen:

<img width="362" alt="Screenshot 2024-05-28 at 11 37 57 AM" src="https://github.com/stellar/freighter/assets/6789586/ce07ed0b-2c6f-41b1-a8b0-5a01516f65be">

We would want to clear out all old information and start the user over with the new account. This was fine when localStore just had account info and settings. The problem is now we have other non-account information in localStore, namely `storageVersion`, which was also getting cleared.

The data looked like this:
<img width="1339" alt="Screenshot 2024-05-28 at 11 47 21 AM" src="https://github.com/stellar/freighter/assets/6789586/41a1f5be-8204-441f-b7fa-6e54da15ed9e">


The Bug:
So, when calling `recoverAccount`, we entered into a state where a user had no `storageVersion`. Thus, on the next update, they were running through ALL the migrations again. This actually wasn't a huge deal because this would just restore all the data that localStore.clear had erased. But it did run the `tokenIdList` migration again, which meant if you had added a token before these migrations ran, it would mess up the structure of `tokenIdList` and your token would not show on Account anymore.

That _appears_ to be the only real symptom of this bug and why we hadn't noticed this bug until now. All the other new migrated data (things like AssetsLists) had defaults to obfuscate the missing data until the user took action to fill it in