### PR TITLE
split dataStorageAccess into a different file to allow for jest mocks…

### DIFF
--- a/extension/src/background/helpers/__tests__/dataStorage.test.ts
+++ b/extension/src/background/helpers/__tests__/dataStorage.test.ts
@@ -1,4 +1,4 @@
-import { dataStorage } from "../dataStorage";
+import { dataStorage } from "../dataStorageAccess";
 
 class MockStorage {
   storage: Record<string, any>;

--- a/extension/src/background/helpers/__tests__/migrations.test.ts
+++ b/extension/src/background/helpers/__tests__/migrations.test.ts
@@ -15,6 +15,7 @@ import {
   TOKEN_ID_LIST,
 } from "constants/localStorageTypes";
 import * as DataStorage from "../dataStorage";
+import * as DataStorageAccess from "../dataStorageAccess";
 import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/token";
 
 class MockStorage {
@@ -37,8 +38,8 @@ class MockStorage {
   };
 }
 
-const dataStorageAccess = (storageApi: DataStorage.StorageOption) => {
-  const store = DataStorage.dataStorage(storageApi);
+const dataStorageAccess = (storageApi: DataStorageAccess.StorageOption) => {
+  const store = DataStorageAccess.dataStorage(storageApi);
   return {
     getItem: store.getItem,
     setItem: async (keyId: string, value: any) => {
@@ -52,7 +53,7 @@ const dataStorageAccess = (storageApi: DataStorage.StorageOption) => {
 const mockStorage = new MockStorage();
 
 jest
-  .spyOn(DataStorage, "dataStorageAccess")
+  .spyOn(DataStorageAccess, "dataStorageAccess")
   .mockImplementation(() =>
     dataStorageAccess(mockStorage as Storage["StorageArea"]),
   );

--- a/extension/src/background/helpers/dataStorageAccess.ts
+++ b/extension/src/background/helpers/dataStorageAccess.ts
@@ -1,0 +1,58 @@
+import browser from "webextension-polyfill";
+
+export interface SetItemParams {
+  [key: string]: any;
+}
+
+// https://github.com/mozilla/webextension-polyfill/issues/424
+interface BrowserStorage extends browser.Storage.Static {
+  session: browser.Storage.LocalStorageArea;
+}
+
+const storage = browser.storage as BrowserStorage;
+
+// browser storage uses local storage which stores values on disk and persists data across sessions
+// session storage uses session storage which stores data in memory and clears data after every "session"
+// only use session storage for secrets or sensitive values
+export const browserLocalStorage = storage?.local;
+export const browserSessionStorage = storage?.session;
+
+export type StorageOption =
+  | typeof browserLocalStorage
+  | typeof browserSessionStorage;
+
+export const dataStorage = (
+  storageApi: StorageOption = browserLocalStorage,
+) => ({
+  getItem: async (key: string) => {
+    // TODO: re-enable defaults by passing an object. The value of the key-value pair will be the default
+
+    const storageResult = await storageApi.get(key);
+
+    return storageResult[key];
+  },
+  setItem: async (setItemParams: SetItemParams) => {
+    await storageApi.set(setItemParams);
+  },
+
+  clear: async () => {
+    await storageApi.clear();
+  },
+  remove: async (keys: string | string[]) => {
+    await storageApi.remove(keys);
+  },
+});
+
+export const dataStorageAccess = (
+  storageApi: StorageOption = browserLocalStorage,
+) => {
+  const store = dataStorage(storageApi);
+  return {
+    getItem: store.getItem,
+    setItem: async (keyId: string, value: any) => {
+      await store.setItem({ [keyId]: value });
+    },
+    clear: () => store.clear(),
+    remove: store.remove,
+  };
+};


### PR DESCRIPTION
What
Moves `dataStorageAccess` intro a new file in order to be able to mock from jest without the circular dep

Why
Build and tests compile differently so assigning to exports did not work in both cases.