### PR TITLE
[BUG] uses key val for public keys for inflation dest and trustor fields

### DIFF
--- a/extension/src/popup/components/signTransaction/Operations/index.tsx
+++ b/extension/src/popup/components/signTransaction/Operations/index.tsx
@@ -322,7 +322,7 @@ export const Operations = ({
           <>
             {signer && <KeyValueSigner signer={signer} />}
             {inflationDest && (
-              <KeyValueList
+              <KeyValueWithPublicKey
                 operationKey={t("Inflation Destination")}
                 operationValue={inflationDest}
               />
@@ -519,7 +519,7 @@ export const Operations = ({
         const { trustor, asset, flags } = op;
         return (
           <>
-            <KeyValueList
+            <KeyValueWithPublicKey
               operationKey={t("Trustor")}
               operationValue={trustor}
             />


### PR DESCRIPTION
What
Uses the pub key key val type component for two fields that are public keys

Why
They were displayed as plain strings, but should have identicons to match the rest of the ops.