### PR TITLE
[CHORE] removes sentry exceptions from expected failures to fetch contract specs

### DIFF
--- a/extension/src/popup/components/signTransaction/Operations/KeyVal/index.tsx
+++ b/extension/src/popup/components/signTransaction/Operations/KeyVal/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
-import * as Sentry from "@sentry/browser";
 import {
   Asset,
   Claimant,
@@ -412,9 +411,6 @@ export const KeyValueInvokeHostFnArgs = ({
         setArgNames(argNamesPositional);
         setLoading(false);
       } catch (error) {
-        Sentry.captureException(
-          `Failed to get contract spec for ${contractId}`,
-        );
         setLoading(false);
       }
     }

--- a/extension/src/popup/views/ReviewAuth/index.tsx
+++ b/extension/src/popup/views/ReviewAuth/index.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { useLocation } from "react-router-dom";
 import { captureException } from "@sentry/browser";
 import BigNumber from "bignumber.js";
-import * as Sentry from "@sentry/browser";
 import {
   MemoType,
   Operation,
@@ -393,9 +392,6 @@ const AuthDetail = ({
         setCheckingTransfers(false);
       } catch (error) {
         console.error(error);
-        Sentry.captureException(
-          `Failed to check spec for invocation -  ${rootJsonDepKey}`,
-        );
         setCheckingTransfers(false);
       }
     }


### PR DESCRIPTION
What
No longer captures expected failures to fetch contract specs in Sentry

Why
This is an expected failure condition and tends to be due to an expired contract or user config error. Real errors in the 500 range will be logged and trigger alert conditions in our backend infra.