### PR TITLE
Feature/insufficient fee warning

### DIFF
--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -71,6 +71,8 @@ export const SignTransaction = () => {
   const dispatch = useDispatch();
 
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [hasAcceptedInsufficientFee, setHasAcceptedInsufficientFee] =
+    useState(false);
 
   const { accountBalances, accountBalanceStatus } = useSelector(
     transactionSubmissionSelector,
@@ -250,10 +252,15 @@ export const SignTransaction = () => {
   const hasEnoughXlm = accountBalances.balances?.native.available.gt(
     stroopToXlm(_fee as string),
   );
-  if (hasBalance && currentAccount.publicKey && !hasEnoughXlm) {
+  if (
+    hasBalance &&
+    currentAccount.publicKey &&
+    !hasEnoughXlm &&
+    !hasAcceptedInsufficientFee
+  ) {
     return (
       <WarningMessage
-        handleCloseClick={() => window.close()}
+        handleCloseClick={() => setHasAcceptedInsufficientFee(true)}
         isActive
         variant={WarningMessageVariant.warning}
         header={t("INSUFFICIENT FUNDS FOR FEE")}

--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -55,6 +55,7 @@ import {
 import { HardwareSign } from "popup/components/hardwareConnect/HardwareSign";
 import { KeyIdenticon } from "popup/components/identicons/KeyIdenticon";
 import { SlideupModal } from "popup/components/SlideupModal";
+import { Loading } from "popup/components/Loading";
 
 import { VerifyAccount } from "popup/views/VerifyAccount";
 import { Tabs } from "popup/components/Tabs";
@@ -236,6 +237,37 @@ export const SignTransaction = () => {
     );
   }
 
+  const hasLoadedBalances =
+    accountBalanceStatus !== ActionStatus.PENDING &&
+    accountBalanceStatus !== ActionStatus.IDLE;
+
+  if (!hasLoadedBalances) {
+    return <Loading />;
+  }
+
+  const hasBalance =
+    hasLoadedBalances && accountBalanceStatus !== ActionStatus.ERROR;
+  const hasEnoughXlm = accountBalances.balances?.native.available.lte(
+    new BigNumber(_fee as string),
+  );
+  if (hasBalance && currentAccount.publicKey && !hasEnoughXlm) {
+    return (
+      <WarningMessage
+        handleCloseClick={() => window.close()}
+        isActive
+        variant={WarningMessageVariant.warning}
+        header={t("INSUFFICIENT FUNDS FOR FEE")}
+      >
+        <p>
+          <Trans domain={domain}>
+            Your available XLM balance is not enough to pay for the transaction
+            fee.
+          </Trans>
+        </p>
+      </WarningMessage>
+    );
+  }
+
   function renderTab(tab: string) {
     function renderTabBody() {
       const _tx = transaction as Transaction<Memo<MemoType>, Operation[]>;
@@ -301,32 +333,6 @@ export const SignTransaction = () => {
         ) : null}
         {renderTabBody()}
       </div>
-    );
-  }
-
-  const hasLoadedBalances =
-    accountBalanceStatus !== ActionStatus.PENDING &&
-    accountBalanceStatus !== ActionStatus.IDLE &&
-    accountBalanceStatus !== ActionStatus.ERROR;
-  // needs a loading state, only show instead of the rest of dom here
-  const hasEnoughXlm = accountBalances.balances?.native.available.lte(
-    new BigNumber(_fee as string),
-  );
-  if (hasLoadedBalances && currentAccount.publicKey && !hasEnoughXlm) {
-    return (
-      <WarningMessage
-        handleCloseClick={() => window.close()}
-        isActive
-        variant={WarningMessageVariant.warning}
-        header={t("INSUFFICIENT FUNDS FOR FEE")}
-      >
-        <p>
-          <Trans domain={domain}>
-            Your available XLM balance is not enough to pay for the transaction
-            fee.
-          </Trans>
-        </p>
-      </WarningMessage>
     );
   }
 

--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -247,7 +247,7 @@ export const SignTransaction = () => {
 
   const hasBalance =
     hasLoadedBalances && accountBalanceStatus !== ActionStatus.ERROR;
-  const hasEnoughXlm = accountBalances.balances?.native.available.lte(
+  const hasEnoughXlm = accountBalances.balances?.native.available.gt(
     new BigNumber(_fee as string),
   );
   if (hasBalance && currentAccount.publicKey && !hasEnoughXlm) {

--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -3,7 +3,6 @@ import { useLocation } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { useTranslation, Trans } from "react-i18next";
 import { Button, Icon, Notification } from "@stellar/design-system";
-import BigNumber from "bignumber.js";
 import {
   MuxedAccount,
   Transaction,
@@ -36,6 +35,7 @@ import {
   getTransactionInfo,
   isFederationAddress,
   isMuxedAccount,
+  stroopToXlm,
   truncatedPublicKey,
 } from "helpers/stellar";
 import { decodeMemo } from "popup/helpers/parseTransaction";
@@ -248,7 +248,7 @@ export const SignTransaction = () => {
   const hasBalance =
     hasLoadedBalances && accountBalanceStatus !== ActionStatus.ERROR;
   const hasEnoughXlm = accountBalances.balances?.native.available.gt(
-    new BigNumber(_fee as string),
+    stroopToXlm(_fee as string),
   );
   if (hasBalance && currentAccount.publicKey && !hasEnoughXlm) {
     return (


### PR DESCRIPTION
What
Adds a check and warning associated with a user trying to sign a transaction with an account that does not have enough xlm to cover the associated tx fee.

Why
This keeps users from going all the way through the flow just to get rejected on submission.

![Screenshot 2024-07-02 at 8 52 25 AM](https://github.com/stellar/freighter/assets/6886006/0c974bec-6b44-4f79-a3f4-3e41435947aa)
