### PR TITLE
Run snapshot tests in CI

### DIFF
--- a/.github/workflows/runSnapshots.yml
+++ b/.github/workflows/runSnapshots.yml
@@ -2,12 +2,10 @@ name: Run Snapshots
 env:
   INDEXER_URL: ${{ secrets.INDEXER_URL }}
 on:
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: Branch name
-        default: ""
-        required: true
+  workflow_run:
+    workflows: ["Run Tests"]
+    types:
+      - in_progress
 jobs:
   test-ci:
     name: test snapshots

--- a/.github/workflows/runSnapshots.yml
+++ b/.github/workflows/runSnapshots.yml
@@ -37,4 +37,7 @@ jobs:
       - run: yarn setup
       - run: yarn build:freighter-api
       - run: yarn build:extension
+      - name: Update snapshots
+        if: ${{inputs.update-snapshots == 'true'}}
+        run: yarn test:e2e --update-snapshots
       - run: yarn test:e2e

--- a/.github/workflows/runSnapshots.yml
+++ b/.github/workflows/runSnapshots.yml
@@ -2,6 +2,18 @@ name: Run Snapshots
 env:
   INDEXER_URL: ${{ secrets.INDEXER_URL }}
 on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch name
+        default: ""
+        required: true
+  # Allow updating snapshots during manual runs
+  workflow_call:
+    inputs:
+      update-snapshots:
+        description: "Update snapshots?"
+        type: boolean
   workflow_run:
     workflows: ["Run Tests"]
     types:
@@ -33,6 +45,6 @@ jobs:
       - run: yarn build:freighter-api
       - run: yarn build:extension
       - name: Initialize snapshots
-        if: ${{steps.cache.outputs.cache-hit != 'true'}}
+        if: ${{steps.cache.outputs.cache-hit != 'true' || inputs.update-snapshots == 'true'}}
         run: yarn test:e2e --update-snapshots
       - run: yarn test:e2e

--- a/.github/workflows/runSnapshots.yml
+++ b/.github/workflows/runSnapshots.yml
@@ -39,5 +39,12 @@ jobs:
       - run: yarn build:extension
       - name: Update snapshots
         if: ${{inputs.update-snapshots == 'true'}}
-        run: yarn test:e2e --update-snapshots
+        run: |
+          yarn test:e2e --update-snapshots
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add -A
+          git commit -m "chore: updating snapshot tests"
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@7380612b49221684fefa025244f2ef4008ae50ad #v3.10.1
       - run: yarn test:e2e

--- a/.github/workflows/runSnapshots.yml
+++ b/.github/workflows/runSnapshots.yml
@@ -34,17 +34,7 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
       - run: npm install -g yarn && yarn
       - run: npx playwright install --with-deps chromium
-      - name: Set up cache
-        id: cache
-        uses: actions/cache@v4
-        with:
-          key: cache/${{github.repository}}/${{github.ref}}
-          restore-keys: cache/${{github.repository}}/refs/heads/master
-          path: .extension/e2e-tests/**
       - run: yarn setup
       - run: yarn build:freighter-api
       - run: yarn build:extension
-      - name: Initialize snapshots
-        if: ${{steps.cache.outputs.cache-hit != 'true' || inputs.update-snapshots == 'true'}}
-        run: yarn test:e2e --update-snapshots
       - run: yarn test:e2e

--- a/.github/workflows/runSnapshots.yml
+++ b/.github/workflows/runSnapshots.yml
@@ -22,16 +22,19 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.branch }}
-      - name: Install docker # Taken from https://github.com/actions/virtual-environments/issues/1143#issuecomment-652264388
-        run: |
-          mkdir -p ~/.docker/machine/cache
-          curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
-          brew install docker docker-machine
-          docker-machine create --driver virtualbox default
-          docker-machine env default
       - run: npm install -g yarn && yarn
       - run: npx playwright install --with-deps chromium
+      - name: Set up cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          key: cache/${{github.repository}}/${{github.ref}}
+          restore-keys: cache/${{github.repository}}/refs/heads/master
+          path: .extension/e2e-tests/**
       - run: yarn setup
       - run: yarn build:freighter-api
       - run: yarn build:extension
+      - name: Initialize snapshots
+        if: ${{steps.cache.outputs.cache-hit != 'true'}}
+        run: yarn test:e2e --update-snapshots
       - run: yarn test:e2e

--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -19,4 +19,3 @@ jobs:
       - run: yarn build:freighter-api
       - run: yarn build:extension
       - run: yarn test:ci
-      # - run: yarn test:e2e

--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -19,4 +19,4 @@ jobs:
       - run: yarn build:freighter-api
       - run: yarn build:extension
       - run: yarn test:ci
-      - run: yarn test:e2e
+      # - run: yarn test:e2e

--- a/extension/e2e-tests/helpers/login.ts
+++ b/extension/e2e-tests/helpers/login.ts
@@ -76,7 +76,7 @@ export const loginToTestAccount = async ({ page, extensionId }) => {
 
   await page.goto(`chrome-extension://${extensionId}/index.html#/account`);
   await expect(page.getByTestId("network-selector-open")).toBeVisible({
-    timeout: 10000,
+    timeout: 50000,
   });
   await page.getByTestId("network-selector-open").click();
   await page.getByText("Test Net").click();

--- a/extension/e2e-tests/test-fixtures.ts
+++ b/extension/e2e-tests/test-fixtures.ts
@@ -36,9 +36,6 @@ export const expectPageToHaveScreenshot = async (
   { page, screenshot }: { page: any; screenshot: string },
   options?: any,
 ) => {
-  if (process.env.CI) {
-    return true;
-  }
   await expect(page).toHaveScreenshot(screenshot, {
     maxDiffPixelRatio: 0.02,
     ...options,

--- a/extension/src/popup/helpers/useNetworkFees.ts
+++ b/extension/src/popup/helpers/useNetworkFees.ts
@@ -15,7 +15,7 @@ export const useNetworkFees = () => {
   const { networkUrl, networkPassphrase } = useSelector(
     settingsNetworkDetailsSelector,
   );
-  const [recommendedFee, setRecommendedFee] = useState("");
+  const [recommendedFee, setRecommendedFee] = useState("100");
   const [networkCongestion, setNetworkCongestion] = useState(
     "" as NetworkCongestion,
   );


### PR DESCRIPTION
What
Moves end to end tests to their own action, running in a different container in order to support snapshot tests.
Snapshot tests are triggered when test suite runs or manually
Manual option to update snapshots in run


Why
Snapshot tests were failing in Ubuntu due to OS differences in chromium.