### PR TITLE
[CHORE] dont show dapp scan warning in grant access

### DIFF
--- a/extension/src/popup/views/GrantAccess/index.tsx
+++ b/extension/src/popup/views/GrantAccess/index.tsx
@@ -12,7 +12,6 @@ import { ModalInfo } from "popup/components/ModalInfo";
 import { KeyIdenticon } from "popup/components/identicons/KeyIdenticon";
 import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
 import { useScanSite } from "popup/helpers/blockaid";
-import { BlockAidMissWarning } from "popup/components/WarningMessages";
 
 import "popup/metrics/access";
 import "./styles.scss";
@@ -64,7 +63,6 @@ export const GrantAccess = () => {
               `Allow ${domain} to view your wallet address, balance, activity and request approval for transactions`,
             )}
           >
-            {!isLoading && data?.status === "miss" && <BlockAidMissWarning />}
             <div className="GrantAccess__SigningWith">
               <h5>Connecting with</h5>
               <div className="GrantAccess__PublicKey">


### PR DESCRIPTION
What
Hides dapp scan warning in grant access modal

Why
We dont want to show any UI elements related to blockaid for v1