### PR TITLE
Bugfix/rm duped ssl toggle

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -1171,13 +1171,11 @@ export const saveSettings = async ({
   isMemoValidationEnabled,
   isSafetyValidationEnabled,
   isValidatingSafeAssetsEnabled,
-  isNonSSLEnabled,
 }: {
   isDataSharingAllowed: boolean;
   isMemoValidationEnabled: boolean;
   isSafetyValidationEnabled: boolean;
   isValidatingSafeAssetsEnabled: boolean;
-  isNonSSLEnabled: boolean;
 }): Promise<Settings & IndexerSettings> => {
   let response = {
     allowList: [""],
@@ -1201,7 +1199,6 @@ export const saveSettings = async ({
       isMemoValidationEnabled,
       isSafetyValidationEnabled,
       isValidatingSafeAssetsEnabled,
-      isNonSSLEnabled,
       type: SERVICE_TYPES.SAVE_SETTINGS,
     });
   } catch (e) {

--- a/extension/src/popup/ducks/settings.ts
+++ b/extension/src/popup/ducks/settings.ts
@@ -116,7 +116,6 @@ export const saveSettings = createAsyncThunk<
     isMemoValidationEnabled: boolean;
     isSafetyValidationEnabled: boolean;
     isValidatingSafeAssetsEnabled: boolean;
-    isNonSSLEnabled: boolean;
   },
   { rejectValue: ErrorMessage }
 >(
@@ -127,7 +126,6 @@ export const saveSettings = createAsyncThunk<
       isMemoValidationEnabled,
       isSafetyValidationEnabled,
       isValidatingSafeAssetsEnabled,
-      isNonSSLEnabled,
     },
     thunkApi,
   ) => {
@@ -146,7 +144,6 @@ export const saveSettings = createAsyncThunk<
         isMemoValidationEnabled,
         isSafetyValidationEnabled,
         isValidatingSafeAssetsEnabled,
-        isNonSSLEnabled,
       });
     } catch (e) {
       console.error(e);

--- a/extension/src/popup/views/IntegrationTest.tsx
+++ b/extension/src/popup/views/IntegrationTest.tsx
@@ -299,7 +299,6 @@ export const IntegrationTest = () => {
         isMemoValidationEnabled: true,
         isSafetyValidationEnabled: true,
         isValidatingSafeAssetsEnabled: true,
-        isNonSSLEnabled: true,
       });
       runAsserts("saveSettings", () => {
         assertEq(res.networkDetails, FUTURENET_NETWORK_DETAILS);

--- a/extension/src/popup/views/Preferences/index.tsx
+++ b/extension/src/popup/views/Preferences/index.tsx
@@ -20,7 +20,6 @@ export const Preferences = () => {
     isMemoValidationEnabled,
     isSafetyValidationEnabled,
     isValidatingSafeAssetsEnabled,
-    isNonSSLEnabled,
   } = useSelector(settingsSelector);
 
   interface SettingValues {
@@ -28,7 +27,6 @@ export const Preferences = () => {
     isValidatingSafetyValue: boolean;
     isDataSharingAllowedValue: boolean;
     isValidatingSafeAssetsValue: boolean;
-    isNonSSLEnabledValue: boolean;
   }
 
   const initialValues: SettingValues = {
@@ -36,7 +34,6 @@ export const Preferences = () => {
     isValidatingSafetyValue: isSafetyValidationEnabled,
     isDataSharingAllowedValue: isDataSharingAllowed,
     isValidatingSafeAssetsValue: isValidatingSafeAssetsEnabled,
-    isNonSSLEnabledValue: isNonSSLEnabled,
   };
 
   const handleSubmit = async (formValue: SettingValues) => {
@@ -45,7 +42,6 @@ export const Preferences = () => {
       isValidatingSafetyValue,
       isDataSharingAllowedValue,
       isValidatingSafeAssetsValue,
-      isNonSSLEnabledValue,
     } = formValue;
 
     // eslint-disable-next-line
@@ -55,7 +51,6 @@ export const Preferences = () => {
         isSafetyValidationEnabled: isValidatingSafetyValue,
         isDataSharingAllowed: isDataSharingAllowedValue,
         isValidatingSafeAssetsEnabled: isValidatingSafeAssetsValue,
-        isNonSSLEnabled: isNonSSLEnabledValue,
       }),
     );
   };
@@ -136,28 +131,6 @@ export const Preferences = () => {
                     checked={initialValues.isDataSharingAllowedValue}
                     customInput={<Field />}
                     id="isDataSharingAllowedValue"
-                  />
-                </div>
-              </div>
-
-              <div className="Preferences--section">
-                <div className="Preferences--section--title">
-                  {t("Connect to domain without SSL certificate")}{" "}
-                </div>
-
-                <div className="Preferences--toggle">
-                  <label
-                    htmlFor="isNonSSLEnabledValue"
-                    className="Preferences--label"
-                  >
-                    {t(
-                      "Allow Freighter to connect to domains that do not have an SSL certificate on Mainnet. SSL certificates provide an encrypted network connection and also provide proof of ownership of the domain. Use caution when connecting to domains without an SSL certificate.",
-                    )}
-                  </label>
-                  <Toggle
-                    checked={initialValues.isNonSSLEnabledValue}
-                    customInput={<Field />}
-                    id="isNonSSLEnabledValue"
                   />
                 </div>
               </div>


### PR DESCRIPTION
Looks like this may have been a bad merge. We move the non-SSL toggle to `Security`, so we can rm it from `Preferences`