### PR TITLE
align advanced settings warning buttons to bottom of screen

### DIFF
--- a/extension/src/popup/views/AdvancedSettings/index.tsx
+++ b/extension/src/popup/views/AdvancedSettings/index.tsx
@@ -155,29 +155,31 @@ export const AdvancedSettings = () => {
     <>
       <SubviewHeader title={t("Important")} />
       <View.Content hasNoTopPadding>
-        <Notification
-          variant="warning"
-          title={t(
-            "Advanced settings are not recommended for new or unexperienced users. Enabling these may impact the security of your wallets and result in loss of funds. Only utilize these features if you can understand and manage the potential security risks.",
-          )}
-        />
-        <div className="AdvancedSettings__understood-buttons">
-          <Button
-            size="md"
-            variant="error"
-            isFullWidth
-            onClick={() => setIsUnderstood(true)}
-          >
-            {t("I understand, continue")}
-          </Button>
-          <Button
-            size="md"
-            variant="secondary"
-            isFullWidth
-            onClick={() => history.goBack()}
-          >
-            {t("Go back")}
-          </Button>
+        <div className="AdvancedSettings__column">
+          <Notification
+            variant="warning"
+            title={t(
+              "Advanced settings are not recommended for new or unexperienced users. Enabling these may impact the security of your wallets and result in loss of funds. Only utilize these features if you can understand and manage the potential security risks.",
+            )}
+          />
+          <div className="AdvancedSettings__understood-buttons">
+            <Button
+              size="md"
+              variant="error"
+              isFullWidth
+              onClick={() => setIsUnderstood(true)}
+            >
+              {t("I understand, continue")}
+            </Button>
+            <Button
+              size="md"
+              variant="secondary"
+              isFullWidth
+              onClick={() => history.goBack()}
+            >
+              {t("Go back")}
+            </Button>
+          </div>
         </div>
       </View.Content>
     </>

--- a/extension/src/popup/views/AdvancedSettings/styles.scss
+++ b/extension/src/popup/views/AdvancedSettings/styles.scss
@@ -1,4 +1,11 @@
 .AdvancedSettings {
+  &__column {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
   &__understood-buttons {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
<img width="368" alt="Screenshot 2024-08-15 at 1 28 14 PM" src="https://github.com/user-attachments/assets/77cf99d6-98ac-4e44-83c6-1a48e68aaa6b">
