### PR TITLE
[FEATURE] Scrub logs

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -453,7 +453,6 @@ export const getAccountIndexerBalances = async (
   }
 
   if ("error" in data && (data?.error?.horizon || data?.error?.soroban)) {
-    const _err = JSON.stringify(data.error);
     captureException(
       `Failed to fetch account balances - ${response.status}: ${response.statusText}`,
     );

--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -446,13 +446,17 @@ export const getAccountIndexerBalances = async (
   const data = (await response.json()) as AccountBalancesInterface;
   if (!response.ok) {
     const _err = JSON.stringify(data);
-    captureException(`Failed to fetch account balances - ${_err}`);
+    captureException(
+      `Failed to fetch account balances - ${response.status}: ${response.statusText}`,
+    );
     throw new Error(_err);
   }
 
   if ("error" in data && (data?.error?.horizon || data?.error?.soroban)) {
     const _err = JSON.stringify(data.error);
-    captureException(`Failed to fetch account balances - ${_err}`);
+    captureException(
+      `Failed to fetch account balances - ${response.status}: ${response.statusText}`,
+    );
   }
 
   const formattedBalances = {} as NonNullable<

--- a/extension/src/background/helpers/account.ts
+++ b/extension/src/background/helpers/account.ts
@@ -256,10 +256,6 @@ export const subscribeAccount = async (publicKey: string) => {
     }
   } catch (e) {
     console.error(e);
-    // Turn on when Mercury is enabled
-    // captureException(
-    //   `Failed to subscribe account with Mercury - ${JSON.stringify(e)}`,
-    // );
   }
 
   return { publicKey };
@@ -296,9 +292,7 @@ export const subscribeTokenBalance = async (
     }
   } catch (e) {
     console.error(e);
-    captureException(
-      `Failed to subscribe token balance - ${JSON.stringify(e)}`,
-    );
+    captureException(`Failed to subscribe token balance - ${contractId}`);
   }
 };
 
@@ -324,9 +318,7 @@ export const subscribeTokenHistory = async (
     }
   } catch (e) {
     console.error(e);
-    captureException(
-      `Failed to subscribe token history - ${JSON.stringify(e)}`,
-    );
+    captureException(`Failed to subscribe token history - ${contractId}`);
   }
 };
 

--- a/extension/src/popup/components/ErrorTracking/index.tsx
+++ b/extension/src/popup/components/ErrorTracking/index.tsx
@@ -5,8 +5,8 @@ import { Integrations } from "@sentry/tracing";
 import { SENTRY_KEY } from "constants/env";
 import { settingsDataSharingSelector } from "popup/ducks/settings";
 import { scrubPathGkey } from "popup/helpers/formatters";
-import packageJson from "../../../../package.json";
 import { INDEXER_URL } from "@shared/constants/mercury";
+import packageJson from "../../../../package.json";
 
 export const ErrorTracking = () => {
   const isDataSharingAllowed = useSelector(settingsDataSharingSelector);
@@ -30,12 +30,14 @@ export const ErrorTracking = () => {
         if (url?.includes(`${INDEXER_URL}/account-history`)) {
           const route = "account-history/";
           const scrubbedUrl = scrubPathGkey(route, url);
+          // eslint-disable-next-line no-param-reassign
           event.request.url = scrubbedUrl;
         }
 
         if (url?.includes(`${INDEXER_URL}/account-balances`)) {
           const route = "account-balances/";
           const scrubbedUrl = scrubPathGkey(route, url);
+          // eslint-disable-next-line no-param-reassign
           event.request.url = scrubbedUrl;
         }
 

--- a/extension/src/popup/helpers/__tests__/formatters.test.js
+++ b/extension/src/popup/helpers/__tests__/formatters.test.js
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { formatAmount } from "../formatters";
+import { formatAmount, scrubPathGkey } from "../formatters";
 import { formatTokenAmount } from "../soroban";
 
 describe("formatAmount", () => {
@@ -13,5 +13,29 @@ describe("formatAmount", () => {
     const value = new BigNumber("10000001000");
     const formatted = "1000.0001";
     expect(formatTokenAmount(value, 7)).toBe(formatted);
+  });
+});
+
+describe("scrubPathGkey", () => {
+  const ADDRESS = "GCBDC5AVPZEOSO3IAASQZSVRJMHX3UCCZH5O7S53FPZ636LQ5RHEW65H";
+  it("should redact a G address from a URL", () => {
+    const route = "account-history/";
+    const url =
+      "http://0.0.0.0:3002/api/v1/account-history/GCBDC5AVPZEOSO3IAASQZSVRJMHX3UCCZH5O7S53FPZ636LQ5RHEW65H?network=PUBLIC";
+    const expected =
+      "http://0.0.0.0:3002/api/v1/account-history/REDACTED?network=PUBLIC";
+    expect(scrubPathGkey(route, url)).toBe(expected);
+  });
+  it("should redact a G address from a URL with no query params", () => {
+    const route = "account-history/";
+    const url =
+      "http://0.0.0.0:3002/api/v1/account-history/GCBDC5AVPZEOSO3IAASQZSVRJMHX3UCCZH5O7S53FPZ636LQ5RHEW65H";
+    const expected = "http://0.0.0.0:3002/api/v1/account-history/REDACTED";
+    expect(scrubPathGkey(route, url)).toBe(expected);
+  });
+  it("should return the URL in cases where it cannot redact", () => {
+    const route = "account-history/";
+    const url = "not-even-a-url";
+    expect(scrubPathGkey(route, url)).toBe(url);
   });
 });

--- a/extension/src/popup/helpers/formatters.ts
+++ b/extension/src/popup/helpers/formatters.ts
@@ -100,7 +100,11 @@ export const formattedBuffer = (data: Buffer) =>
   truncatedPublicKey(Buffer.from(data).toString("hex").toUpperCase());
 
 export const scrubPathGkey = (route: string, url: string) => {
-  const start = url.indexOf(route);
-  const end = url.indexOf("?");
-  return url.substring(start + route.length) + "REDACTED" + url.substring(end);
+  try {
+    const [base, slug] = url.split(route);
+    const end = slug.indexOf("?") === -1 ? slug.length : slug.indexOf("?");
+    return `${base}${route}` + "REDACTED" + slug.substring(end);
+  } catch (error) {
+    return url;
+  }
 };

--- a/extension/src/popup/helpers/formatters.ts
+++ b/extension/src/popup/helpers/formatters.ts
@@ -98,3 +98,9 @@ export const formatAmount = (val: string) => {
 
 export const formattedBuffer = (data: Buffer) =>
   truncatedPublicKey(Buffer.from(data).toString("hex").toUpperCase());
+
+export const scrubPathGkey = (route: string, url: string) => {
+  const start = url.indexOf(route);
+  const end = url.indexOf("?");
+  return url.substring(start + route.length) + "REDACTED" + url.substring(end);
+};

--- a/extension/src/popup/helpers/formatters.ts
+++ b/extension/src/popup/helpers/formatters.ts
@@ -103,7 +103,7 @@ export const scrubPathGkey = (route: string, url: string) => {
   try {
     const [base, slug] = url.split(route);
     const end = slug.indexOf("?") === -1 ? slug.length : slug.indexOf("?");
-    return `${base}${route}` + "REDACTED" + slug.substring(end);
+    return `${base}${route}${"REDACTED"}${slug.substring(end)}`;
   } catch (error) {
     return url;
   }


### PR DESCRIPTION
What
Tweaks calls to `captureException` to only use allowed identifiers
Adds Sentry hook to scrub route paths with G addresses

Why
Remove G addresses from Sentry logs