### PR TITLE
[CHORE] adds fetchJson to handle non json fetch responses

### DIFF
--- a/extension/src/popup/helpers/blockaid.ts
+++ b/extension/src/popup/helpers/blockaid.ts
@@ -7,6 +7,7 @@ import { isCustomNetwork } from "@shared/helpers/stellar";
 import { isMainnet } from "helpers/stellar";
 import { emitMetric } from "helpers/metrics";
 import { METRIC_NAMES } from "popup/constants/metricsNames";
+import { fetchJson } from "./fetch";
 
 interface BlockAidScanSiteResult {
   status: "hit" | "miss";
@@ -84,25 +85,26 @@ export const useScanTx = () => {
         setLoading(false);
         return;
       }
-      const res = await fetch(
+      const response = await fetchJson<{
+        data: BlockAidScanTxResult;
+        error: string | null;
+      }>(
         `${INDEXER_URL}/scan-tx?url=${encodeURIComponent(
           url,
         )}&tx_xdr=${xdr}&network=${networkDetails.network}`,
       );
-      const response = (await res.json()) as {
-        data: BlockAidScanTxResult;
-        error: string | null;
-      };
 
-      if (!res.ok) {
-        setError(response.error || "Failed to scan transaction");
-      }
       setData(response.data);
       emitMetric(METRIC_NAMES.blockaidTxScan, { response: response.data });
       setLoading(false);
     } catch (err) {
       setError("Failed to scan transaction");
-      Sentry.captureException(err);
+      Sentry.captureException({
+        error: err,
+        xdr,
+        url,
+        networkDetails,
+      });
       setLoading(false);
     }
   };

--- a/extension/src/popup/helpers/fetch.ts
+++ b/extension/src/popup/helpers/fetch.ts
@@ -1,0 +1,14 @@
+export const fetchJson = async <T>(url: string, options?: RequestInit) => {
+  const res = await fetch(url, options);
+  if (!res.ok) {
+    throw new Error(res.statusText);
+  }
+
+  if (res.headers.get("content-type") !== "application/json") {
+    const content = await res.text();
+    throw new Error(content);
+  }
+
+  const data = res.json() as T;
+  return data;
+};

--- a/extension/src/popup/helpers/fetch.ts
+++ b/extension/src/popup/helpers/fetch.ts
@@ -9,6 +9,6 @@ export const fetchJson = async <T>(url: string, options?: RequestInit) => {
     throw new Error(content);
   }
 
-  const data = res.json() as T;
+  const data = (await res.json()) as T;
   return data;
 };


### PR DESCRIPTION
What
Adds `fetchJson` to handle non json response types and general error handling in fetch calls

Why
We have an error that is hard to trace due to the text response handling