### PR TITLE
[BUG] encodes xdr for query param usage

### DIFF
--- a/extension/src/popup/helpers/blockaid.ts
+++ b/extension/src/popup/helpers/blockaid.ts
@@ -91,7 +91,7 @@ export const useScanTx = () => {
       }>(
         `${INDEXER_URL}/scan-tx?url=${encodeURIComponent(
           url,
-        )}&tx_xdr=${xdr}&network=${networkDetails.network}`,
+        )}&tx_xdr=${encodeURIComponent(xdr)}&network=${networkDetails.network}`,
       );
 
       setData(response.data);


### PR DESCRIPTION
What
Encodes the xdr parameter for safe URL use

Why
xdr can have non URL safe chars