### PR TITLE
[BUG] SAC payment displayed as generic host fn

### DIFF
--- a/extension/src/popup/components/__tests__/HistoryItem.test.tsx
+++ b/extension/src/popup/components/__tests__/HistoryItem.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render, waitFor, screen } from "@testing-library/react";
+
+import { HistoryItem } from "popup/components/accountHistory/HistoryItem";
+import { TESTNET_NETWORK_DETAILS } from "@shared/constants/stellar";
+import * as sorobanHelpers from "popup/helpers/soroban";
+
+describe("HistoryItem", () => {
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+  jest
+    .spyOn(sorobanHelpers, "getAttrsFromSorobanHorizonOp")
+    .mockImplementation(() => {
+      return {
+        to: "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF",
+        from: "GCGORBD5DB4JDIKVIA536CJE3EWMWZ6KBUBWZWRQM7Y3NHFRCLOKYVAL",
+        contractId: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+        fnName: "transfer",
+        amount: "100000000",
+      };
+    });
+  it("renders SAC transfers as payments", async () => {
+    const props = {
+      accountBalances: {
+        balances: {
+          native: {
+            token: {
+              code: "XLM",
+            },
+            decimals: 7,
+          },
+        } as any,
+        isFunded: true,
+        subentryCount: 0,
+      },
+      operation: {
+        account: "GCGORBD5DB4JDIKVIA536CJE3EWMWZ6KBUBWZWRQM7Y3NHFRCLOKYVAL",
+        amount: "10",
+        asset_code: "XLM",
+        created_at: Date.now(),
+        id: "op-id",
+        to: "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF",
+        from: "GCGORBD5DB4JDIKVIA536CJE3EWMWZ6KBUBWZWRQM7Y3NHFRCLOKYVAL",
+        starting_balance: "10",
+        type: "invokeHostFunction",
+        type_i: 24,
+        transaction_attr: {
+          operation_count: 1,
+        },
+        isCreateExternalAccount: false,
+        isPayment: false,
+        isSwap: false,
+      } as any,
+      publicKey: "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF",
+      url: "example.com",
+      networkDetails: TESTNET_NETWORK_DETAILS,
+      setDetailViewProps: () => null,
+      setIsDetailViewShowing: () => null,
+    };
+    render(<HistoryItem {...props} />);
+    await waitFor(() => screen.getByTestId("history-item"));
+    expect(screen.getByTestId("history-item")).toBeDefined();
+    expect(screen.getByTestId("history-item-body-component")).toHaveTextContent(
+      "+10 XLM",
+    );
+  });
+});

--- a/extension/src/popup/components/accountHistory/HistoryItem/index.tsx
+++ b/extension/src/popup/components/accountHistory/HistoryItem/index.tsx
@@ -458,13 +458,13 @@ export const HistoryItem = ({
     publicKey,
     srcAssetCode,
     startingBalance,
-    t,
     to,
     accountBalances.balances,
   ]);
 
   return (
     <div
+      data-testid="history-item"
       className="HistoryItem"
       onClick={() => {
         emitMetric(METRIC_NAMES.historyOpenItem);
@@ -485,7 +485,12 @@ export const HistoryItem = ({
               <div className="HistoryItem__date">{dateText}</div>
             </div>
 
-            <div className="HistoryItem__payment">{renderBodyComponent()}</div>
+            <div
+              className="HistoryItem__payment"
+              data-testid="history-item-body-component"
+            >
+              {renderBodyComponent()}
+            </div>
           </>
         )}
       </div>

--- a/extension/src/popup/components/accountHistory/HistoryItem/index.tsx
+++ b/extension/src/popup/components/accountHistory/HistoryItem/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 // In order to allow that rule we need to refactor this to use the correct Horizon types and narrow operation types
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { captureException } from "@sentry/browser";
 import camelCase from "lodash/camelCase";
 import { Icon, Loader } from "@stellar/design-system";
@@ -138,6 +138,8 @@ export const HistoryItem = ({
 
   const renderBodyComponent = () => BodyComponent;
   const renderIcon = () => IconComponent;
+  /* eslint-disable react-hooks/exhaustive-deps */
+  const translations = useCallback(t, []);
 
   useEffect(() => {
     const buildHistoryItem = async () => {
@@ -148,17 +150,20 @@ export const HistoryItem = ({
           </>,
         );
         setRowText(
-          t(`{{srcAssetCode}} for {{destAssetCode}}`, {
+          translations(`{{srcAssetCode}} for {{destAssetCode}}`, {
             srcAssetCode,
             destAssetCode,
           }),
         );
         setTxDetails((_state) => ({
           ..._state,
-          headerTitle: t(`Swapped {{srcAssetCode}} for {{destAssetCode}}`, {
-            srcAssetCode,
-            destAssetCode,
-          }),
+          headerTitle: translations(
+            `Swapped {{srcAssetCode}} for {{destAssetCode}}`,
+            {
+              srcAssetCode,
+              destAssetCode,
+            },
+          ),
           operationText: `+${new BigNumber(amount)} ${destAssetCode}`,
         }));
       } else if (isPayment) {
@@ -181,13 +186,15 @@ export const HistoryItem = ({
         setRowText(destAssetCode);
         setDateText(
           (_dateText) =>
-            `${_isRecipient ? t("Received") : t("Sent")} \u2022 ${date}`,
+            `${
+              _isRecipient ? translations("Received") : translations("Sent")
+            } \u2022 ${date}`,
         );
         setTxDetails((_state) => ({
           ..._state,
           isRecipient: _isRecipient,
           headerTitle: `${
-            _isRecipient ? t("Received") : t("Sent")
+            _isRecipient ? translations("Received") : translations("Sent")
           } ${destAssetCode}`,
           operationText: `${paymentDifference}${new BigNumber(
             amount,
@@ -199,10 +206,10 @@ export const HistoryItem = ({
         );
         setIconComponent(<Icon.ArrowUp className="HistoryItem__icon--sent" />);
         setRowText("XLM");
-        setDateText((_dateText) => `${t("Sent")} \u2022 ${date}`);
+        setDateText((_dateText) => `${translations("Sent")} \u2022 ${date}`);
         setTxDetails((_state) => ({
           ..._state,
-          headerTitle: t("Create Account"),
+          headerTitle: translations("Create Account"),
           isPayment: true,
           operation: {
             ...operation,
@@ -237,7 +244,7 @@ export const HistoryItem = ({
           setRowText(operationString);
           setTxDetails((_state) => ({
             ..._state,
-            headerTitle: t("Transaction"),
+            headerTitle: translations("Transaction"),
             operationText: operationString,
           }));
         } else if (attrs.fnName === SorobanTokenInterface.mint) {
@@ -268,7 +275,7 @@ export const HistoryItem = ({
                 setRowText(operationString);
                 setTxDetails((_state) => ({
                   ..._state,
-                  headerTitle: t("Transaction"),
+                  headerTitle: translations("Transaction"),
                   operationText: operationString,
                 }));
               } else {
@@ -294,10 +301,12 @@ export const HistoryItem = ({
                 setDateText(
                   (_dateText) =>
                     `${
-                      isRecieving ? t("Received") : t("Minted")
+                      isRecieving
+                        ? translations("Received")
+                        : translations("Minted")
                     } \u2022 ${date}`,
                 );
-                setRowText(t(capitalize(attrs.fnName)));
+                setRowText(translations(capitalize(attrs.fnName)));
                 setTxDetails((_state) => ({
                   ..._state,
                   operation: {
@@ -305,7 +314,7 @@ export const HistoryItem = ({
                     from: attrs.from,
                     to: attrs.to,
                   },
-                  headerTitle: `${t(capitalize(attrs.fnName))} ${
+                  headerTitle: `${translations(capitalize(attrs.fnName))} ${
                     _token.symbol
                   }`,
                   isPayment: false,
@@ -317,7 +326,7 @@ export const HistoryItem = ({
             } catch (error) {
               console.error(error);
               captureException(`Error fetching token details: ${error}`);
-              setRowText(t(capitalize(attrs.fnName)));
+              setRowText(translations(capitalize(attrs.fnName)));
               setBodyComponent(
                 <>
                   {isRecieving && "+ "}
@@ -326,7 +335,11 @@ export const HistoryItem = ({
               );
               setDateText(
                 (_dateText) =>
-                  `${isRecieving ? t("Received") : t("Minted")} \u2022 ${date}`,
+                  `${
+                    isRecieving
+                      ? translations("Received")
+                      : translations("Minted")
+                  } \u2022 ${date}`,
               );
               setTxDetails((_state) => ({
                 ..._state,
@@ -335,7 +348,7 @@ export const HistoryItem = ({
                   from: attrs.from,
                   to: attrs.to,
                 },
-                headerTitle: t(capitalize(attrs.fnName)),
+                headerTitle: translations(capitalize(attrs.fnName)),
                 // manually set `isPayment` now that we've passed the above `isPayment` conditional
                 isPayment: false,
                 isRecipient: isRecieving,
@@ -358,9 +371,13 @@ export const HistoryItem = ({
 
             setDateText(
               (_dateText) =>
-                `${isRecieving ? t("Received") : t("Minted")} \u2022 ${date}`,
+                `${
+                  isRecieving
+                    ? translations("Received")
+                    : translations("Minted")
+                } \u2022 ${date}`,
             );
-            setRowText(t(capitalize(attrs.fnName)));
+            setRowText(translations(capitalize(attrs.fnName)));
             setTxDetails((_state) => ({
               ..._state,
               operation: {
@@ -368,7 +385,9 @@ export const HistoryItem = ({
                 from: attrs.from,
                 to: attrs.to,
               },
-              headerTitle: `${t(capitalize(attrs.fnName))} ${token.code}`,
+              headerTitle: `${translations(capitalize(attrs.fnName))} ${
+                token.code
+              }`,
               isPayment: false,
               isRecipient: isRecieving,
               operationText: `${formattedTokenAmount} ${token.code}`,
@@ -384,7 +403,7 @@ export const HistoryItem = ({
             setRowText(operationString);
             setTxDetails((_state) => ({
               ..._state,
-              headerTitle: t("Transaction"),
+              headerTitle: translations("Transaction"),
               operationText: operationString,
             }));
           } else {
@@ -412,14 +431,16 @@ export const HistoryItem = ({
             setRowText(token.code);
             setDateText(
               (_dateText) =>
-                `${_isRecipient ? t("Received") : t("Sent")} \u2022 ${date}`,
+                `${
+                  _isRecipient ? translations("Received") : translations("Sent")
+                } \u2022 ${date}`,
             );
             setTxDetails((_state) => ({
               ..._state,
               isRecipient: _isRecipient,
-              headerTitle: `${_isRecipient ? t("Received") : t("Sent")} ${
-                token.code
-              }`,
+              headerTitle: `${
+                _isRecipient ? translations("Received") : translations("Sent")
+              } ${token.code}`,
               operationText: `${paymentDifference}${formattedTokenAmount} ${token.code}`,
             }));
           }
@@ -427,7 +448,7 @@ export const HistoryItem = ({
           setRowText(operationString);
           setTxDetails((_state) => ({
             ..._state,
-            headerTitle: t("Transaction"),
+            headerTitle: translations("Transaction"),
             operationText: operationString,
           }));
         }
@@ -435,7 +456,7 @@ export const HistoryItem = ({
         setRowText(operationString);
         setTxDetails((_state) => ({
           ..._state,
-          headerTitle: t("Transaction"),
+          headerTitle: translations("Transaction"),
           operationText: operationString,
         }));
       }
@@ -458,6 +479,7 @@ export const HistoryItem = ({
     publicKey,
     srcAssetCode,
     startingBalance,
+    translations,
     to,
     accountBalances.balances,
   ]);


### PR DESCRIPTION
What
Adds a tokenKey check using the derived SAC address when processing transfers in account history
Updates history item detail in transfer cases to use same display as classic side payments

Why
SAC payments are shown as `InvokeHostFunction` because we fail to find a key for the balance in the SAC case due to the balances being stored under keys that are `{assetCode}:{issuer}` where the issuer is a G address for classic assets.

Also, SEP41/SAC transfers can be shown as payments to avoid confusion.

Result: (Top 2 are classic payments, next two are a SAC transfer and SEP41 transfer)
![Screenshot 2024-08-28 at 3 24 15 PM](https://github.com/user-attachments/assets/edc00be9-6d0a-4662-932e-a37082911b7e)
