### PR TITLE
[BUG] fixes transparent bg on asset warning

### DIFF
--- a/extension/src/popup/components/WarningMessages/styles.scss
+++ b/extension/src/popup/components/WarningMessages/styles.scss
@@ -216,6 +216,7 @@
 
   .View__inset {
     padding-bottom: 1rem;
+    background: var(--color-gray-00);
   }
 
   &__wrapper {


### PR DESCRIPTION
What
Fixes transparent warning background

Before:
![Screenshot 2024-09-09 at 10 07 21 AM](https://github.com/user-attachments/assets/0aacaaca-9c58-48f9-b4fa-1248c7a5b81d)


After:
![Screenshot 2024-09-09 at 10 09 40 AM](https://github.com/user-attachments/assets/690ce906-f49e-42ed-a9d5-7462e2a4d11d)
