### PR TITLE
add blockaid scan for custom mainnet and use blockaid lib for types

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -518,9 +518,11 @@ export const getSorobanTokenBalance = async (
 export const getAccountBalancesStandalone = async ({
   publicKey,
   networkDetails,
+  isMainnet,
 }: {
   publicKey: string;
   networkDetails: NetworkDetails;
+  isMainnet: boolean;
 }) => {
   const { network, networkUrl, networkPassphrase } = networkDetails;
 
@@ -532,7 +534,10 @@ export const getAccountBalancesStandalone = async ({
     const server = stellarSdkServer(networkUrl, networkPassphrase);
     const accountSummary = await server.accounts().accountId(publicKey).call();
 
-    const displayableBalances = makeDisplayableBalances(accountSummary);
+    const displayableBalances = await makeDisplayableBalances(
+      accountSummary,
+      isMainnet,
+    );
     const sponsor = accountSummary.sponsor
       ? { sponsor: accountSummary.sponsor }
       : {};

--- a/@shared/api/package.json
+++ b/@shared/api/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "@blockaid/client": "^0.25.0",
     "@stellar/js-xdr": "^3.1.1",
     "bignumber.js": "^9.1.1",
     "prettier": "^2.0.5",

--- a/@shared/api/types.ts
+++ b/@shared/api/types.ts
@@ -1,5 +1,6 @@
 import BigNumber from "bignumber.js";
 import { AssetType as SdkAssetType, Horizon } from "stellar-sdk";
+import Blockaid from "@blockaid/client";
 
 import { SERVICE_TYPES, EXTERNAL_SERVICE_TYPES } from "../constants/services";
 import { APPLICATION_STATE } from "../constants/applicationState";
@@ -245,10 +246,9 @@ export interface Balance {
   blockaidData: BlockAidScanAssetResult;
 }
 
-export interface BlockAidScanAssetResult {
-  result_type: "Benign" | "Warning" | "Malicious" | "Spam";
-  features: { description: string }[];
-}
+export type BlockAidScanAssetResult = Blockaid.TokenScanResponse;
+export type BlockAidScanSiteResult = Blockaid.SiteScanResponse;
+export type BlockAidScanTxResult = Blockaid.StellarTransactionScanResponse;
 
 export interface AssetBalance extends Balance {
   limit: BigNumber;

--- a/extension/src/popup/ducks/transactionSubmission.ts
+++ b/extension/src/popup/ducks/transactionSubmission.ts
@@ -41,7 +41,10 @@ import { NETWORKS, NetworkDetails } from "@shared/constants/stellar";
 import { ConfigurableWalletType } from "@shared/constants/hardwareWallet";
 import { isCustomNetwork } from "@shared/helpers/stellar";
 
-import { getCanonicalFromAsset } from "helpers/stellar";
+import {
+  getCanonicalFromAsset,
+  isMainnet as isMainnetHelper,
+} from "helpers/stellar";
 import { METRICS_DATA } from "constants/localStorageTypes";
 import { MetricsData, emitMetric } from "helpers/metrics";
 import { METRIC_NAMES } from "popup/constants/metricsNames";
@@ -359,10 +362,13 @@ export const getAccountBalances = createAsyncThunk<
   try {
     let balances;
 
+    const isMainnet = isMainnetHelper(networkDetails);
+
     if (isCustomNetwork(networkDetails)) {
       balances = await internalGetAccountBalancesStandalone({
         publicKey,
         networkDetails,
+        isMainnet,
       });
     } else {
       balances = await internalgetAccountIndexerBalances(
@@ -391,6 +397,7 @@ export const getDestinationBalances = createAsyncThunk<
       return await internalGetAccountBalancesStandalone({
         publicKey,
         networkDetails,
+        isMainnet: isMainnetHelper(networkDetails),
       });
     }
     return await internalgetAccountIndexerBalances(publicKey, networkDetails);

--- a/extension/src/popup/helpers/blockaid.ts
+++ b/extension/src/popup/helpers/blockaid.ts
@@ -5,24 +5,15 @@ import { useSelector } from "react-redux";
 import { INDEXER_URL } from "@shared/constants/mercury";
 import { NetworkDetails } from "@shared/constants/stellar";
 import { isCustomNetwork } from "@shared/helpers/stellar";
-import { BlockAidScanAssetResult } from "@shared/api/types";
+import {
+  BlockAidScanAssetResult,
+  BlockAidScanSiteResult,
+} from "@shared/api/types";
 import { isMainnet } from "helpers/stellar";
 import { emitMetric } from "helpers/metrics";
 import { METRIC_NAMES } from "popup/constants/metricsNames";
 import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
 import { fetchJson } from "./fetch";
-
-export interface BlockAidScanSiteResult {
-  status: "hit" | "miss";
-  url: string;
-  scan_start_time: Date;
-  scan_end_time: Date;
-  malicious_score: number; // 0-1
-  is_reachable: boolean;
-  is_web3_site: true;
-  is_malicious: boolean;
-  // ...
-}
 
 interface ValidationResult {
   status: "Success" | "Error";

--- a/extension/src/popup/views/GrantAccess/index.tsx
+++ b/extension/src/popup/views/GrantAccess/index.tsx
@@ -48,6 +48,9 @@ export const GrantAccess = () => {
     window.close();
   };
 
+  const isMalicious =
+    data && "is_malicious" in data ? data.is_malicious : false;
+
   return (
     <>
       <ModalWrapper>
@@ -58,7 +61,7 @@ export const GrantAccess = () => {
         ) : (
           <DomainScanModalInfo
             domain={domain}
-            isMalicious={data?.is_malicious || false}
+            isMalicious={isMalicious}
             scanStatus={data.status}
             subject={t(
               `Allow ${domain} to view your wallet address, balance, activity and request approval for transactions`,
@@ -73,7 +76,7 @@ export const GrantAccess = () => {
                 <KeyIdenticon publicKey={publicKey} />
               </div>
             </div>
-            {data?.is_malicious ? (
+            {isMalicious ? (
               <ButtonsContainer>
                 <Button
                   size="md"

--- a/extension/src/popup/views/__tests__/GrantAccess.test.tsx
+++ b/extension/src/popup/views/__tests__/GrantAccess.test.tsx
@@ -10,6 +10,7 @@ import {
 } from "@shared/constants/stellar";
 import { GrantAccess } from "../GrantAccess";
 import * as blockAidHelpers from "popup/helpers/blockaid";
+import { BlockAidScanSiteResult } from "@shared/api/types";
 import * as urlHelpers from "../../../helpers/urls";
 
 jest.spyOn(urlHelpers, "parsedSearchParam").mockImplementation(() => {
@@ -57,7 +58,7 @@ describe("Grant Access view", () => {
         isLoading: false,
         data: {
           is_malicious: false,
-        } as blockAidHelpers.BlockAidScanSiteResult,
+        } as BlockAidScanSiteResult,
         scanSite: (_url: string, _networkDetails: NetworkDetails) => {
           return Promise.resolve();
         },
@@ -96,7 +97,7 @@ describe("Grant Access view", () => {
         isLoading: false,
         data: {
           status: "miss",
-        } as blockAidHelpers.BlockAidScanSiteResult,
+        } as BlockAidScanSiteResult,
         scanSite: (_url: string, _networkDetails: NetworkDetails) => {
           return Promise.resolve();
         },
@@ -135,7 +136,7 @@ describe("Grant Access view", () => {
         isLoading: false,
         data: {
           is_malicious: true,
-        } as blockAidHelpers.BlockAidScanSiteResult,
+        } as BlockAidScanSiteResult,
         scanSite: (_url: string, _networkDetails: NetworkDetails) => {
           return Promise.resolve();
         },

--- a/extension/src/popup/views/__tests__/ManageAssets.test.tsx
+++ b/extension/src/popup/views/__tests__/ManageAssets.test.tsx
@@ -17,6 +17,7 @@ import {
 } from "@shared/constants/stellar";
 import { Balances } from "@shared/api/types";
 import { createMemoryHistory } from "history";
+import { defaultBlockaidScanAssetResult } from "@shared/helpers/stellar";
 
 import { APPLICATION_STATE as ApplicationState } from "@shared/constants/applicationState";
 import { ROUTES } from "popup/constants/routes";
@@ -249,16 +250,26 @@ jest.spyOn(BlockaidHelpers, "scanAsset").mockImplementation((address) => {
     address === "BMAL-GBFJZSHWOMYS6U73NXQRRD4JX6TZNWEAFII6Z5INGWVJ2VCQ2K4NQMHP"
   ) {
     return Promise.resolve({
+      ...defaultBlockaidScanAssetResult,
       result_type: "Malicious",
-      features: [{ description: "bad asset" }],
+      features: [
+        {
+          description: "bad asset",
+          feature_id: "KNOWN_MALICIOUS",
+          type: "Malicious",
+        },
+      ],
     });
   }
 
   return Promise.resolve({
+    ...defaultBlockaidScanAssetResult,
     result_type: "Benign",
     features: [
       {
         description: "good asset",
+        feature_id: "METADATA",
+        type: "Benign",
       },
     ],
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1363,6 +1363,19 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@blockaid/client@^0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@blockaid/client/-/client-0.25.0.tgz#047edad9b4a2400b316041aa0932f53120b14448"
+  integrity sha512-QcFuurS6sAOFY8/d8rmWpmJAUJbYojSQlOAJ97eWSAW9WI9D1tjAC1JpEBvGUlfwLjO4/+kOqk4KvDXxEleIgA==
+  dependencies:
+    "@types/node" "^18.11.18"
+    "@types/node-fetch" "^2.6.4"
+    abort-controller "^3.0.0"
+    agentkeepalive "^4.2.1"
+    form-data-encoder "1.7.2"
+    formdata-node "^4.3.2"
+    node-fetch "^2.6.7"
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
@@ -3836,6 +3849,14 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.34.tgz#10964ba0dee6ac4cd462e2795b6bebd407303433"
   integrity sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==
 
+"@types/node-fetch@^2.6.4":
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.11.tgz#9b39b78665dae0e82a08f02f4967d62c66f95d24"
+  integrity sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==
+  dependencies:
+    "@types/node" "*"
+    form-data "^4.0.0"
+
 "@types/node-forge@^1.3.0":
   version "1.3.11"
   resolved "https://registry.yarnpkg.com/@types/node-forge/-/node-forge-1.3.11.tgz#0972ea538ddb0f4d9c2fa0ec5db5724773a604da"
@@ -3859,6 +3880,13 @@
   version "17.0.45"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
   integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
+
+"@types/node@^18.11.18":
+  version "18.19.50"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.50.tgz#8652b34ee7c0e7e2004b3f08192281808d41bf5a"
+  integrity sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/parse-json@^4.0.0":
   version "4.0.2"
@@ -8218,6 +8246,11 @@ fork-ts-checker-webpack-plugin@^9.0.2:
     semver "^7.3.5"
     tapable "^2.2.1"
 
+form-data-encoder@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-1.7.2.tgz#1f1ae3dccf58ed4690b86d87e4f57c654fbab040"
+  integrity sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==
+
 form-data-encoder@^2.1.2:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-2.1.4.tgz#261ea35d2a70d48d30ec7a9603130fa5515e9cd5"
@@ -8245,6 +8278,14 @@ format@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==
+
+formdata-node@^4.3.2:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/formdata-node/-/formdata-node-4.4.1.tgz#23f6a5cb9cb55315912cbec4ff7b0f59bbd191e2"
+  integrity sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==
+  dependencies:
+    node-domexception "1.0.0"
+    web-streams-polyfill "4.0.0-beta.3"
 
 formik@^2.1.4:
   version "2.4.6"
@@ -12463,6 +12504,11 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
+node-domexception@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-emoji@^2.1.0:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-2.1.3.tgz#93cfabb5cc7c3653aa52f29d6ffb7927d8047c06"
@@ -16363,6 +16409,11 @@ underscore.string@~3.3.4:
     sprintf-js "^1.1.1"
     util-deprecate "^1.0.2"
 
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
 undici-types@~6.19.2:
   version "6.19.8"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
@@ -16854,6 +16905,11 @@ web-namespaces@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
   integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
+
+web-streams-polyfill@4.0.0-beta.3:
+  version "4.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz#2898486b74f5156095e473efe989dcf185047a38"
+  integrity sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==
 
 webextension-polyfill@^0.12.0:
   version "0.12.0"


### PR DESCRIPTION
We should make sure that users who are using Mainnet with a custom network (a common occurrence with people wanting to use their rpc/horizon instances) still get the benefit of Blockaid asset scanning