### PR TITLE
[BUG] send dest suspicious check

### DIFF
--- a/extension/src/popup/helpers/blockaid.ts
+++ b/extension/src/popup/helpers/blockaid.ts
@@ -194,7 +194,7 @@ export const useScanAsset = (address: string) => {
 };
 
 export const isAssetSuspicious = (blockaidData?: BlockAidScanAssetResult) => {
-  if (!blockaidData) {
+  if (!blockaidData || !blockaidData.result_type) {
     return false;
   }
   return blockaidData.result_type !== "Benign";


### PR DESCRIPTION
What
Makes `isAssetSuspicous` stricter

Why
In some "send" scenarios, this check would return false positive because of the dest asset response