### PR TITLE
[FIX] removes benign scan label for site scans

### DIFF
--- a/extension/src/popup/components/WarningMessages/index.tsx
+++ b/extension/src/popup/components/WarningMessages/index.tsx
@@ -1076,7 +1076,8 @@ export const BlockAidSiteScanLabel = ({
     return <BlockAidMaliciousLabel />;
   }
 
-  return <BlockAidBenignLabel />;
+  // benign case should not show anything for now
+  return <React.Fragment />;
 };
 
 export const BlockaidTxScanLabel = ({

--- a/extension/src/popup/views/__tests__/GrantAccess.test.tsx
+++ b/extension/src/popup/views/__tests__/GrantAccess.test.tsx
@@ -51,7 +51,8 @@ describe("Grant Access view", () => {
     expect(screen.getByTestId("grant-access-view")).toBeDefined();
   });
 
-  it("shows a benign label when scan site returns non malicious flag", async () => {
+  // not applicable right now, but we may show this warning in the future
+  it.skip("shows a benign label when scan site returns non malicious flag", async () => {
     jest.spyOn(blockAidHelpers, "useScanSite").mockImplementation(() => {
       return {
         error: null,


### PR DESCRIPTION
What
Removes benign scan site label

Why
This was removed from the scope of this feature