### PR TITLE
make sure to show sim errors in send flow; add tests

### DIFF
--- a/extension/src/popup/__testHelpers__/index.tsx
+++ b/extension/src/popup/__testHelpers__/index.tsx
@@ -96,8 +96,45 @@ export const mockBalances = {
       available: new BigNumber("100"),
       blockaidData: {
         result_type: "Spam",
-        features: [{ description: "" }],
+        features: [{ feature_id: "METADATA", description: "baz" }],
       },
+    },
+    native: {
+      token: { type: "native", code: "XLM" },
+      total: new BigNumber("50"),
+      available: new BigNumber("50"),
+      blockaidData: defaultBlockaidScanAssetResult,
+    },
+  } as any as Balances,
+  isFunded: true,
+  subentryCount: 1,
+};
+
+// balances with no blockaid spam data as we only do the scan on Mainnet
+export const mockTestnetBalances = {
+  balances: {
+    ["DT:CCXVDIGMR6WTXZQX2OEVD6YM6AYCYPXPQ7YYH6OZMRS7U6VD3AVHNGBJ"]: {
+      token: {
+        code: "DT",
+        issuer: {
+          key: "CCXVDIGMR6WTXZQX2OEVD6YM6AYCYPXPQ7YYH6OZMRS7U6VD3AVHNGBJ",
+        },
+      },
+      decimals: 7,
+      total: new BigNumber("1000000000"),
+      available: new BigNumber("1000000000"),
+      blockaidData: defaultBlockaidScanAssetResult,
+    },
+    ["USDC:GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM"]: {
+      token: {
+        code: "USDC",
+        issuer: {
+          key: "GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM",
+        },
+      },
+      total: new BigNumber("100"),
+      available: new BigNumber("100"),
+      blockaidData: defaultBlockaidScanAssetResult,
     },
     native: {
       token: { type: "native", code: "XLM" },

--- a/extension/src/popup/components/WarningMessages/index.tsx
+++ b/extension/src/popup/components/WarningMessages/index.tsx
@@ -1326,7 +1326,7 @@ export const BlockaidWarningModal = ({
               :
               <ul className="ScamAssetWarning__list">
                 {description.map((d) => (
-                  <li key={d}>{truncatedDescription(d)}</li>
+                  <li key={d.replace(" ", "-")}>{truncatedDescription(d)}</li>
                 ))}
               </ul>
             </div>

--- a/extension/src/popup/components/WarningMessages/index.tsx
+++ b/extension/src/popup/components/WarningMessages/index.tsx
@@ -1126,18 +1126,27 @@ export const BlockAidSiteScanLabel = ({
 
 export const BlockaidTxScanLabel = ({
   scanResult,
+  isPopup = false,
 }: {
   scanResult: BlockAidScanTxResult;
+  isPopup?: boolean;
 }) => {
   const { t } = useTranslation();
   const { simulation, validation } = scanResult;
 
   if (simulation && "error" in simulation) {
+    const header = t("This transaction is expected to fail");
+    if (isPopup) {
+      return (
+        <BlockaidWarningModal
+          header={header}
+          description={[simulation.error]}
+          isWarning
+        />
+      );
+    }
     return (
-      <WarningMessage
-        header="This transaction is expected to fail"
-        variant={WarningMessageVariant.warning}
-      >
+      <WarningMessage header={header} variant={WarningMessageVariant.warning}>
         <div>
           <p>{t(simulation.error)}</p>
         </div>
@@ -1150,10 +1159,21 @@ export const BlockaidTxScanLabel = ({
     switch (validation.result_type) {
       case "Malicious": {
         message = {
-          header: "This transaction was flagged as malicious",
+          header: t("This transaction was flagged as malicious"),
           variant: WarningMessageVariant.highAlert,
           message: validation.description,
         };
+
+        if (isPopup) {
+          return (
+            <BlockaidWarningModal
+              header={message.header}
+              description={[message.message]}
+              isWarning={false}
+            />
+          );
+        }
+
         return (
           <WarningMessage header={message.header} variant={message.variant}>
             <div>
@@ -1169,6 +1189,17 @@ export const BlockaidTxScanLabel = ({
           variant: WarningMessageVariant.warning,
           message: validation.description,
         };
+
+        if (isPopup) {
+          return (
+            <BlockaidWarningModal
+              header={message.header}
+              description={[message.message]}
+              isWarning
+            />
+          );
+        }
+
         return (
           <WarningMessage header={message.header} variant={message.variant}>
             <div>
@@ -1257,7 +1288,7 @@ export const BlockaidWarningModal = ({
         );
       }
 
-      return <span>{word} </span>;
+      return <span key={word}>{word} </span>;
     });
   };
 
@@ -1265,7 +1296,10 @@ export const BlockaidWarningModal = ({
     <>
       <WarningInfoBlock />
       {createPortal(
-        <div className="BlockaidWarningModal">
+        <div
+          className="BlockaidWarningModal"
+          data-testid={`BlockaidWarningModal__${isAsset ? "asset" : "tx"}`}
+        >
           <LoadingBackground isActive />
           <div className="BlockaidWarningModal__modal">
             <div
@@ -1292,7 +1326,7 @@ export const BlockaidWarningModal = ({
               :
               <ul className="ScamAssetWarning__list">
                 {description.map((d) => (
-                  <li key={d.replace(" ", "-")}>{truncatedDescription(d)}</li>
+                  <li key={d}>{truncatedDescription(d)}</li>
                 ))}
               </ul>
             </div>
@@ -1301,6 +1335,7 @@ export const BlockaidWarningModal = ({
             </div>
 
             <Button
+              data-testid="BlockaidWarningModal__button"
               size="md"
               variant="secondary"
               isFullWidth
@@ -1320,7 +1355,7 @@ export const BlockaidWarningModal = ({
     <div
       className="WarningMessage__activate-button"
       onClick={() => setIsModalActive(true)}
-      data-testid="BlockaidWarningModal__button"
+      data-testid={`BlockaidWarningModal__button__${isAsset ? "asset" : "tx"}`}
     >
       <WarningInfoBlock />
     </div>

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
@@ -31,7 +31,6 @@ import {
 } from "@shared/helpers/stellar";
 import {
   isAssetSuspicious,
-  isBlockaidWarning,
   isTxSuspicious,
   useScanAsset,
   useScanTx,
@@ -72,7 +71,7 @@ import {
 } from "popup/components/account/AccountAssets";
 import { HardwareSign } from "popup/components/hardwareConnect/HardwareSign";
 import {
-  BlockaidWarningModal,
+  BlockaidTxScanLabel,
   FlaggedWarningMessage,
 } from "popup/components/WarningMessages";
 import { View } from "popup/basics/layout/View";
@@ -702,17 +701,9 @@ export const TransactionDetails = ({
               </div>
             )}
             <div className="TransactionDetails__warnings">
-              {scanResult?.validation &&
-                "result_type" in scanResult.validation && (
-                  <BlockaidWarningModal
-                    header={`This transaction was flagged as ${scanResult.validation.result_type}`}
-                    description={[scanResult.validation.description]}
-                    isWarning={isBlockaidWarning(
-                      scanResult.validation.result_type,
-                    )}
-                    isAsset
-                  />
-                )}
+              {scanResult && (
+                <BlockaidTxScanLabel scanResult={scanResult} isPopup />
+              )}
               {submission.submitStatus === ActionStatus.IDLE && (
                 <FlaggedWarningMessage
                   isMemoRequired={isMemoRequired}

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/styles.scss
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/styles.scss
@@ -127,10 +127,13 @@
   }
 
   &__warnings {
+    display: flex;
+    flex-flow: column;
+    gap: 0.5rem;
     margin-top: 1.5rem;
 
     .WarningMessage__infoBlock {
-      margin-bottom: 0.375rem;
+      margin-bottom: 0;
     }
   }
 }


### PR DESCRIPTION
<img width="494" alt="Screenshot 2024-10-04 at 3 45 31 PM" src="https://github.com/user-attachments/assets/141c9677-71fe-4a91-88c0-3f4fd0034aa8">

Seems as though Blockaid's tx scanning isn't responding properly, so I stubbed some data to show what this would look like if the endpoint came back with a sim error

This PR fixes an issue with showing Benign warnings and not showing tx sim errors