### PR TITLE
[BUG] tweaks styles for key identicon to make identicon rounded properly

### DIFF
--- a/extension/src/popup/components/identicons/KeyIdenticon/styles.scss
+++ b/extension/src/popup/components/identicons/KeyIdenticon/styles.scss
@@ -8,10 +8,9 @@
   &--icon {
     background: var(--color-white);
     border: 1px solid var(--color-gray-60);
-    border-radius: 2rem;
+    border-radius: 50%;
     display: flex;
     padding: var(--Icon-padding);
-    height: var(--Icon-dimension);
     width: var(--Icon-dimension);
   }
 


### PR DESCRIPTION
Before:
![Screenshot 2024-10-17 at 9 42 49 AM](https://github.com/user-attachments/assets/f371fea2-6f6e-4d32-961d-0f72c25534ea)

After:
![Screenshot 2024-10-17 at 9 43 06 AM](https://github.com/user-attachments/assets/1c03de1f-9e83-4645-b4bb-8355b1aed565)

What:
Tweaks KeyIdenticon css to make the identicon rounded