### PR TITLE
[BUG] Favicons overflow in API modals

### DIFF
--- a/extension/src/popup/components/PunycodedDomain/index.tsx
+++ b/extension/src/popup/components/PunycodedDomain/index.tsx
@@ -23,7 +23,7 @@ export const PunycodedDomain = ({
       className={`PunycodedDomain ${isRow ? "PunycodedDomain--row" : ""}`}
       {...props}
     >
-      <div>
+      <div className="PunycodedDomain__favicon-container">
         <img
           className="PunycodedDomain__favicon"
           src={favicon}

--- a/extension/src/popup/components/PunycodedDomain/styles.scss
+++ b/extension/src/popup/components/PunycodedDomain/styles.scss
@@ -11,6 +11,12 @@
     margin-bottom: 0;
   }
 
+  &__favicon-container {
+    width: 32px;
+    height: 32px;
+    overflow: hidden;
+  }
+
   &__favicon {
     width: 2rem;
   }


### PR DESCRIPTION
What
Adds size constraints to the container around the favicon in all of our API modals in order to avoid overflowing the layout with the favicon returned is a non standard size.

Why
We don't control the favicons returned from [the Google favicons API](https://t0.gstatic.com/faviconV2).
Some website will use a non standard asset size here, so the size and resolution of the images we render are completely unpredictable.

I think it's worth questioning if we should keep this feature. Showing the favicon is nice when it works but in practice as far as I've seen very few dapps have an icon at this API that is of a high enough resolution and a correct size(default is typically 32x32 but there are other common sizes.
