### PR TITLE
adjust button color and fix bad merge

### DIFF
--- a/extension/src/popup/components/ErrorBoundary/index.tsx
+++ b/extension/src/popup/components/ErrorBoundary/index.tsx
@@ -70,7 +70,7 @@ export const UnhandledError = ({
         {isOnAccount ? (
           <Button
             isFullWidth
-            variant="secondary"
+            variant="tertiary"
             size="md"
             onClick={window.close}
           >
@@ -79,7 +79,7 @@ export const UnhandledError = ({
         ) : (
           <Button
             isFullWidth
-            variant="secondary"
+            variant="tertiary"
             size="md"
             onClick={() => {
               navigateTo(ROUTES.account);

--- a/extension/src/popup/components/WarningMessages/index.tsx
+++ b/extension/src/popup/components/WarningMessages/index.tsx
@@ -142,7 +142,7 @@ export const WarningMessage = ({
         <div className="WarningMessage__children-wrapper">{children}</div>
         <Button
           size="md"
-          variant="secondary"
+          variant="tertiary"
           isFullWidth
           type="button"
           onClick={() =>
@@ -1337,7 +1337,7 @@ export const BlockaidWarningModal = ({
             <Button
               data-testid="BlockaidWarningModal__button"
               size="md"
-              variant="secondary"
+              variant="tertiary"
               isFullWidth
               type="button"
               onClick={() =>

--- a/extension/src/popup/components/account/BlockaidAnnouncement/index.tsx
+++ b/extension/src/popup/components/account/BlockaidAnnouncement/index.tsx
@@ -79,7 +79,7 @@ export const BlockaidAnnouncement = () => {
             <Button
               data-testid="BlockaidAnnouncement__accept"
               size="md"
-              variant="primary"
+              variant="tertiary"
               isFullWidth
               type="button"
               onClick={handleCloseModal}

--- a/extension/src/popup/components/manageAssets/TrustlineError/index.tsx
+++ b/extension/src/popup/components/manageAssets/TrustlineError/index.tsx
@@ -207,7 +207,7 @@ export const TrustlineError = ({
               <Button
                 size="md"
                 isFullWidth
-                variant="primary"
+                variant="tertiary"
                 onClick={() => {
                   setIsModalShowing(false);
                   if (handleClose) {

--- a/extension/src/popup/components/manageNetwork/NetworkForm/index.tsx
+++ b/extension/src/popup/components/manageNetwork/NetworkForm/index.tsx
@@ -203,7 +203,7 @@ export const NetworkForm = ({ isEditing }: NetworkFormProps) => {
       size="md"
       type="button"
       isFullWidth
-      variant="secondary"
+      variant="tertiary"
       onClick={() => {
         setIsNetworkInUse(false);
         setIsNetworkUrlValid(false);

--- a/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
@@ -459,7 +459,7 @@ export const SubmitFail = () => {
       <View.Footer>
         <Button
           isFullWidth
-          variant="secondary"
+          variant="tertiary"
           size="md"
           onClick={() => {
             navigateTo(ROUTES.account);

--- a/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
@@ -242,7 +242,7 @@ export const SubmitSuccess = ({ viewDetails }: { viewDetails: () => void }) => {
       <View.Footer isInline>
         <Button
           size="md"
-          variant="secondary"
+          variant="tertiary"
           onClick={() => viewDetails()}
           data-testid="SubmitResultDetailsButton"
         >
@@ -250,7 +250,7 @@ export const SubmitSuccess = ({ viewDetails }: { viewDetails: () => void }) => {
         </Button>
         <Button
           size="md"
-          variant="primary"
+          variant="secondary"
           onClick={() => {
             navigateTo(ROUTES.account);
           }}

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
@@ -532,7 +532,7 @@ export const TransactionDetails = ({
       <Button
         size="md"
         isFullWidth
-        variant="secondary"
+        variant="tertiary"
         onClick={() =>
           openTab(
             `${getStellarExpertUrl(networkDetails)}/tx/${transactionHash}`,

--- a/extension/src/popup/components/sendPayment/SendSettings/SettingsFail/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendSettings/SettingsFail/index.tsx
@@ -41,7 +41,7 @@ export const SettingsFail = () => {
       <View.Footer>
         <Button
           isFullWidth
-          variant="secondary"
+          variant="tertiary"
           size="md"
           onClick={() => {
             dispatch(resetSimulation());

--- a/extension/src/popup/components/signAuthEntry/AuthEntry/index.tsx
+++ b/extension/src/popup/components/signAuthEntry/AuthEntry/index.tsx
@@ -85,7 +85,7 @@ const InvalidAuthEntry = ({
         <View.Footer>
           <Button
             isFullWidth
-            variant="secondary"
+            variant="tertiary"
             size="md"
             onClick={rejectAndClose}
           >

--- a/extension/src/popup/views/Account/index.tsx
+++ b/extension/src/popup/views/Account/index.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
-  Button,
   CopyText,
   Icon,
   NavButton,
@@ -34,8 +33,6 @@ import {
   transactionSubmissionSelector,
   resetSubmission,
   resetAccountBalanceStatus,
-  saveAssetSelectType,
-  AssetSelectType,
   getAccountBalances,
   getSoroswapTokens,
 } from "popup/ducks/transactionSubmission";
@@ -183,25 +180,7 @@ export const Account = () => {
             setLoading={setLoading}
           />
           {/* <BlockaidAnnouncement /> */}
-          <View.Content
-            hasNoTopPadding
-            contentFooter={
-              isFunded ? (
-                <div className="AccountView__assets-button">
-                  <Button
-                    size="md"
-                    variant="secondary"
-                    onClick={() => {
-                      dispatch(saveAssetSelectType(AssetSelectType.MANAGE));
-                      navigateTo(ROUTES.manageAssets);
-                    }}
-                  >
-                    {t("Manage Assets")}
-                  </Button>
-                </div>
-              ) : null
-            }
-          >
+          <View.Content hasNoTopPadding>
             <div className="AccountView" data-testid="account-view">
               <div className="AccountView__account-actions">
                 <div className="AccountView__name-key-display">

--- a/extension/src/popup/views/Account/styles.scss
+++ b/extension/src/popup/views/Account/styles.scss
@@ -44,7 +44,7 @@
         stroke: var(--sds-clr-base-01);
         width: 1rem;
         height: 1rem;
-        stroke: var(--sds-clr-gray-11);
+        stroke: var(--sds-clr-gray-12);
       }
     }
   }

--- a/extension/src/popup/views/Account/styles.scss
+++ b/extension/src/popup/views/Account/styles.scss
@@ -38,7 +38,6 @@
     button {
       width: 2.5rem;
       height: 2.5rem;
-      border-color: var(--sds-clr-gray-11);
 
       svg {
         stroke: var(--sds-clr-base-01);

--- a/extension/src/popup/views/AdvancedSettings/index.tsx
+++ b/extension/src/popup/views/AdvancedSettings/index.tsx
@@ -178,7 +178,7 @@ export const AdvancedSettings = () => {
             </Button>
             <Button
               size="md"
-              variant="secondary"
+              variant="tertiary"
               isFullWidth
               onClick={() => history.goBack()}
             >

--- a/extension/src/popup/views/DisplayBackupPhrase/index.tsx
+++ b/extension/src/popup/views/DisplayBackupPhrase/index.tsx
@@ -77,7 +77,7 @@ export const DisplayBackupPhrase = () => {
             <Button
               size="md"
               isFullWidth
-              variant="primary"
+              variant="tertiary"
               onClick={() => navigateTo(ROUTES.account)}
             >
               {t("Done")}

--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -410,7 +410,7 @@ export const SignTransaction = () => {
                   <Button
                     isFullWidth
                     size="md"
-                    variant="secondary"
+                    variant="tertiary"
                     onClick={() => rejectAndClose()}
                   >
                     {t("Reject")}
@@ -421,7 +421,7 @@ export const SignTransaction = () => {
                   <Button
                     isFullWidth
                     size="md"
-                    variant="secondary"
+                    variant="tertiary"
                     onClick={() => rejectAndClose()}
                   >
                     {t("Cancel")}
@@ -429,7 +429,7 @@ export const SignTransaction = () => {
                   {needsReviewAuth ? (
                     <Button
                       disabled={isSubmitDisabled}
-                      variant="tertiary"
+                      variant="secondary"
                       isFullWidth
                       size="md"
                       isLoading={isConfirming}
@@ -452,7 +452,7 @@ export const SignTransaction = () => {
                   ) : (
                     <Button
                       disabled={isSubmitDisabled}
-                      variant="tertiary"
+                      variant="secondary"
                       isFullWidth
                       size="md"
                       isLoading={isConfirming}

--- a/extension/src/popup/views/UnlockAccount/index.tsx
+++ b/extension/src/popup/views/UnlockAccount/index.tsx
@@ -80,7 +80,7 @@ export const UnlockAccount = () => {
                     <Button
                       size="md"
                       isFullWidth
-                      variant="tertiary"
+                      variant="secondary"
                       type="submit"
                       isLoading={isSubmitting}
                       disabled={!(dirty && isValid)}


### PR DESCRIPTION
Changing button colors to adhere to the pattern established in the Figma of using:

* button variant "secondary" for the main CTA
* button variant "tertiary" for the cancel/secondary CTA (for ex: "Got it" and "Cancel")
* button variant "primary" for actions that will cause changes to your account 

Some examples:

<img width="362" alt="Screenshot 2024-11-05 at 12 29 53 PM" src="https://github.com/user-attachments/assets/127933d5-7635-46bf-817f-ada91a2f9063">
<img width="358" alt="Screenshot 2024-11-05 at 12 36 40 PM" src="https://github.com/user-attachments/assets/b5043f6f-db1b-4d4a-a665-edaa3be917b1">
<img width="362" alt="Screenshot 2024-11-05 at 12 36 11 PM" src="https://github.com/user-attachments/assets/1a5832cd-4b4e-4288-82fb-6ec0f5baabb2">
<img width="398" alt="Screenshot 2024-11-05 at 12 35 49 PM" src="https://github.com/user-attachments/assets/9e20953f-b0b8-45da-8956-7344dc426fbc">

