### PR TITLE
use modern-compiler for sass-loader

### DIFF
--- a/extension/webpack.common.js
+++ b/extension/webpack.common.js
@@ -110,7 +110,12 @@ const commonConfig = (
               sourceMap: true,
             },
           },
-          { loader: "sass-loader" },
+          {
+            loader: "sass-loader",
+            options: {
+              api: "modern-compiler",
+            },
+          },
         ],
       },
       {


### PR DESCRIPTION
This should make sure we don't get any more warnings about [legacy js api](https://sass-lang.com/documentation/breaking-changes/legacy-js-api/) from sass-loader