### PR TITLE
[BUG] makes swap amount persist across destination asset changes

### DIFF
--- a/extension/src/popup/components/sendPayment/SendAmount/AssetSelect/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/AssetSelect/index.tsx
@@ -12,6 +12,7 @@ import {
   saveAssetSelectSource,
   saveAssetSelectType,
   AssetSelectType,
+  saveAmount,
 } from "popup/ducks/transactionSubmission";
 import { isContractId } from "popup/helpers/soroban";
 import { useIsSwap } from "popup/helpers/useIsSwap";
@@ -121,6 +122,9 @@ export const PathPayAssetSelect = ({
       ),
     );
     dispatch(saveAssetSelectSource(source));
+    if (source) {
+      dispatch(saveAmount("0"));
+    }
     navigateTo(ROUTES.manageAssets, isSwap ? "?swap=true" : "");
   };
 

--- a/extension/src/popup/components/sendPayment/SendAmount/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/index.tsx
@@ -553,6 +553,7 @@ export const SendAmount = ({
                           e.target.selectionStart || 1,
                         );
                       formik.setFieldValue("amount", newAmount);
+                      dispatch(saveAmount(newAmount));
                       runAfterUpdate(() => {
                         input.selectionStart = newCursor;
                         input.selectionEnd = newCursor;


### PR DESCRIPTION
What
Makes the swap amount value persist after a user has changed the destination asset.

Why
There is no reason to reset the source amount if the asset does not change, we only need to recalculate the exchange rate.