### PR TITLE
[BUG] Allow degradation to contract address when token details fail for sub invocation

### DIFF
--- a/extension/src/popup/views/ReviewAuth/index.tsx
+++ b/extension/src/popup/views/ReviewAuth/index.tsx
@@ -384,6 +384,7 @@ const AuthDetail = ({
       } catch (error) {
         console.error(error);
         setCheckingTransfers(false);
+        setLoading(false);
       }
     }
     if (isInvokeContract) {
@@ -438,7 +439,6 @@ const AuthDetail = ({
     _getTokenDetails();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [transfersDepKey]);
-
   return (
     <div className="AuthDetail" data-testid="AuthDetail">
       {isLoading || isCheckingTransfers ? (


### PR DESCRIPTION
What
Toggles off the `isLoading` data loader flag in the catch block of the sub invocation token spec workflows.

Why
In the event that we fail to fetch the token details in a sub invocation, we still want to be able to display the contract address and let the user finish the review workflow.

Details:
Reported internally by @jeesunikim by using https://tokentool.bitbond.com/stellar/create-token/security-token/soroban-testnet to build/deploy a token. The token-spec "failure" here was due to the backend responding with a 400 for the XLM SAC instance. Should we handle this differently?

We can improve this further by refactoring the loading states in `ReviewAuth` to live under one action and by improving the backend `token-spec` handling of SAC instances. 