### PR TITLE
Bugfix/warning qa

### DIFF
--- a/extension/src/popup/basics/LoadingBackground/index.tsx
+++ b/extension/src/popup/basics/LoadingBackground/index.tsx
@@ -7,12 +7,14 @@ interface LoadingBackgroundProps {
   isActive: boolean;
   isOpaque?: boolean;
   isClear?: boolean;
+  isFullScreen?: boolean;
 }
 
 export const LoadingBackground = ({
   isActive,
   isOpaque,
   isClear,
+  isFullScreen,
   onClick,
 }: LoadingBackgroundProps) => (
   <div
@@ -21,6 +23,6 @@ export const LoadingBackground = ({
       isActive ? "LoadingBackground--active" : ""
     } ${isOpaque ? "LoadingBackground--isOpaque" : ""} ${
       isClear ? "LoadingBackground--isClear" : ""
-    }`}
+    } ${isFullScreen ? "LoadingBackground--isFullScreen" : ""}`}
   />
 );

--- a/extension/src/popup/basics/LoadingBackground/styles.scss
+++ b/extension/src/popup/basics/LoadingBackground/styles.scss
@@ -24,4 +24,8 @@
     height: 100vh;
     width: 100vw;
   }
+  &--isFullScreen {
+    height: 100vh;
+    width: 100vw;
+  }
 }

--- a/extension/src/popup/components/ModalInfo/index.tsx
+++ b/extension/src/popup/components/ModalInfo/index.tsx
@@ -75,7 +75,7 @@ export const ModalInfo = ({
 
   return (
     <div className={cardClasses}>
-      <Card variant="secondary">
+      <Card>
         <div className="ModalInfo__icon">
           <AssetIcon
             assetIcons={assetIcons}

--- a/extension/src/popup/components/WarningMessages/index.tsx
+++ b/extension/src/popup/components/WarningMessages/index.tsx
@@ -1079,18 +1079,6 @@ export const BlockAidMaliciousLabel = () => {
   );
 };
 
-export const BlockAidBenignLabel = () => {
-  const { t } = useTranslation();
-  return (
-    <div className="ScanLabel ScanBenign" data-testid="blockaid-benign-label">
-      <div className="Icon">
-        <Icon.InfoOctagon className="WarningMessage__icon" />
-      </div>
-      <p className="Message">{t("This site has been scanned and verified")}</p>
-    </div>
-  );
-};
-
 export const BlockAidMissLabel = () => {
   const { t } = useTranslation();
   return (

--- a/extension/src/popup/components/WarningMessages/styles.scss
+++ b/extension/src/popup/components/WarningMessages/styles.scss
@@ -223,8 +223,10 @@
   bottom: 0;
   left: 0;
   display: flex;
+  padding: 0.5rem;
 
   .View__inset {
+    border-radius: 0.5rem;
     padding-bottom: 1rem;
     background: var(--sds-clr-gray-01);
   }

--- a/extension/src/popup/components/WarningMessages/styles.scss
+++ b/extension/src/popup/components/WarningMessages/styles.scss
@@ -32,16 +32,16 @@
   }
 
   &__infoBlock {
-    background: var(--color-purple-20);
-    border: 1px solid var(--color-purple-30);
+    background: var(--sds-clr-lilac-02);
+    border: 1px solid var(--sds-clr-lilac-06);
     border-radius: 0.5rem;
-    color: var(--color-white) !important;
+    color: var(--sds-clr-white) !important;
     font-size: 0.875rem;
     margin-bottom: 1rem;
     padding: 0.5rem;
 
     &--high-alert {
-      border-color: #671e22;
+      border-color: var(--sds-clr-red-06);
       background: rgba(241, 50, 50, 0.32);
 
       .WarningMessage__icon {
@@ -72,7 +72,7 @@
   }
 
   &__default-icon {
-    color: var(--color-purple-50);
+    color: var(--sds-clr-lilac-05);
     width: 24px;
   }
 
@@ -87,7 +87,7 @@
   }
 
   p {
-    color: var(--color-white) !important;
+    color: var(--sds-clr-white) !important;
     font-size: var(--font-size-secondary);
     line-height: 1.375rem;
   }
@@ -97,7 +97,7 @@
     word-break: break-word;
 
     a {
-      color: var(--color-white);
+      color: var(--sds-clr-white);
     }
   }
 }
@@ -121,8 +121,8 @@
 
   &__box {
     display: flex;
-    background-color: var(--color-red-20);
-    border: 1px solid #671e22;
+    background-color: var(--sds-clr-red-02);
+    border: 1px solid var(--sds-clr-red-06);
     border-radius: 6px;
     margin-bottom: 1.5rem;
     padding: 0.5rem;
@@ -132,8 +132,8 @@
     }
 
     &--isWarning {
-      background-color: var(--color-yellow-20);
-      border: 1px solid #573300;
+      background-color: var(--sds-clr-amber-02);
+      border: 1px solid var(--sds-clr-amber-06);
     }
   }
 
@@ -181,7 +181,7 @@
   }
 
   &__footer {
-    color: var(--color-gray-70);
+    color: var(--sds-clr-gray-11);
     display: flex;
     font-size: 0.75rem;
     gap: 0.25rem;
@@ -211,19 +211,6 @@
     display: flex;
     column-gap: 1rem;
     margin-top: 1rem;
-
-    // TODO: replace with SDS error button
-    .BasicButton--primary {
-      --Button-color-background: var(--sds-clr-red-06);
-      --Button-color-border: var(--sds-clr-red-09);
-      background: var(--Button-color-background);
-      border-color: var(--Button-color-border);
-    }
-
-    .BasicButton--primary:hover {
-      border-color: var(--sds-clr-red-09);
-      background-color: var(var(--sds-clr-red-07));
-    }
   }
 }
 
@@ -238,7 +225,7 @@
 
   .View__inset {
     padding-bottom: 1rem;
-    background: var(--color-gray-00);
+    background: var(--sds-clr-gray-01);
   }
 
   &__wrapper {
@@ -389,7 +376,7 @@
     margin-bottom: 0.375rem;
     column-gap: 0.5rem;
     &__header {
-      color: var(--color-white);
+      color: var(--sds-clr-white);
       font-size: 0.875rem;
       margin-bottom: 0.25rem;
     }
@@ -399,7 +386,7 @@
       line-height: 1.25rem;
     }
     &__icon--unverified {
-      color: var(--color-yellow-50);
+      color: var(--sds-clr-amber-09);
     }
     &__content {
       color: var(--sds-clr-gray-12);
@@ -481,33 +468,22 @@
 }
 
 .ScanMalicious {
-  background-color: var(--color-red-20);
-  border: 1px solid #671e22;
+  background-color: var(--sds-clr-red-02);
+  border: 1px solid var(--sds-clr-red-06);
 
   .Icon {
     .WarningMessage__icon {
-      color: var(--color-red-60);
-    }
-  }
-}
-
-.ScanBenign {
-  background-color: var(--color-green-40);
-  border: 1px solid var(--color-green-50);
-
-  .Icon {
-    .WarningMessage__icon {
-      color: var(--color-green-50);
+      color: var(--sds-clr-red-06);
     }
   }
 }
 
 .ScanMiss {
-  border: 1px solid var(--color-grey-40);
+  border: 1px solid var(--sds-clr-gray-06);
 
   .Icon {
     .WarningMessage__icon {
-      color: var(--color-grey-40);
+      color: var(--sds-clr-gray-06);
     }
   }
 }
@@ -521,9 +497,9 @@
   justify-content: center;
 
   &__modal {
-    background: var(--color-gray-10);
+    background: var(--sds-clr-gray-06);
     border-radius: 0.5rem;
-    border: 1px solid var(--color-gray-40);
+    border: 1px solid var(--sds-clr-gray-01);
     padding: 1rem;
     width: 312px;
     z-index: 2;

--- a/extension/src/popup/components/WarningMessages/styles.scss
+++ b/extension/src/popup/components/WarningMessages/styles.scss
@@ -229,6 +229,7 @@
     border-radius: 0.5rem;
     padding-bottom: 1rem;
     background: var(--sds-clr-gray-01);
+    border: 1px solid var(--sds-clr-gray-06);
   }
 
   &__wrapper {

--- a/extension/src/popup/components/WarningMessages/styles.scss
+++ b/extension/src/popup/components/WarningMessages/styles.scss
@@ -116,7 +116,8 @@
   }
 
   .View__inset {
-    padding-bottom: 1rem;
+    background: none;
+    padding: 0.5rem;
   }
 
   &__box {

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { StellarToml } from "stellar-sdk";
 import { useDispatch, useSelector } from "react-redux";
+import { createPortal } from "react-dom";
 import { ActionStatus, BlockAidScanAssetResult } from "@shared/api/types";
 
 import { AppDispatch } from "popup/App";
@@ -228,11 +229,17 @@ export const ManageAssetRows = ({
         </div>
         {children}
       </div>
-      <LoadingBackground
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        onClick={() => {}}
-        isActive={showNewAssetWarning || showBlockedDomainWarning}
-      />
+      {showNewAssetWarning || showBlockedDomainWarning
+        ? createPortal(
+            <LoadingBackground
+              // eslint-disable-next-line @typescript-eslint/no-empty-function
+              onClick={() => {}}
+              isActive
+              isFullScreen
+            />,
+            document.querySelector("#modal-root")!,
+          )
+        : null}
     </>
   );
 };


### PR DESCRIPTION
There was a couple of small issues with these warning modals.

1) The LoadingBackground that covers the screen behind the modal wasn't covering the entire screen. Now using a portal to make sure we're not constrained by the DOM hierarchy

2) There were a couple of references to the old color var's and hex values. Replacing these with the SDS v3 versions for consistency

3) removing some unused modals and styles for cleanliness 

4) Fixed a legacy issue where the styling for the New Asset warning modal was a little different than the Scam Asset warning modal. There's still some work to be done here, but at the very least, they're not wildly different anymore. We'll need some design input on this
