### PR TITLE
[QA] Use class instead of css var for hasNoTopPadding toggle

### DIFF
--- a/extension/src/popup/basics/layout/View/index.tsx
+++ b/extension/src/popup/basics/layout/View/index.tsx
@@ -243,29 +243,22 @@ export const ViewInset: React.FC<ViewInsetProps> = ({
   hasScrollShadow,
   hasNoTopPadding,
   ...props
-}: ViewInsetProps) => {
-  const customStyle = {
-    // eslint-disable-next-line
-    ...(hasNoTopPadding ? { "--View-inset-padding-top": "0" } : {}),
-  } as React.CSSProperties;
-
-  return (
-    <div
-      className={`View__inset ${addStyleClasses([
-        isWide ? "View__inset--wide" : "",
-        isInline ? "View__inset--inline" : "",
-        alignment === "center" ? "View__inset--align-center" : "",
-        hasVerticalBorder ? "View__inset--vertical-border" : "",
-        hasTopBorder ? "View__inset--top-border" : "",
-        hasScrollShadow ? "View__inset--scroll-shadows" : "",
-      ])}${additionalClassName ? ` ${additionalClassName}` : ""}`}
-      style={customStyle}
-      {...props}
-    >
-      {children}
-    </div>
-  );
-};
+}: ViewInsetProps) => (
+  <div
+    className={`View__inset ${addStyleClasses([
+      isWide ? "View__inset--wide" : "",
+      isInline ? "View__inset--inline" : "",
+      alignment === "center" ? "View__inset--align-center" : "",
+      hasVerticalBorder ? "View__inset--vertical-border" : "",
+      hasTopBorder ? "View__inset--top-border" : "",
+      hasScrollShadow ? "View__inset--scroll-shadows" : "",
+      hasNoTopPadding ? "View__inset--no-top-padding" : "",
+    ])}${additionalClassName ? ` ${additionalClassName}` : ""}`}
+    {...props}
+  >
+    {children}
+  </div>
+);
 
 // View
 interface ViewComponent {

--- a/extension/src/popup/basics/layout/View/styles.scss
+++ b/extension/src/popup/basics/layout/View/styles.scss
@@ -168,6 +168,10 @@
     }
   }
 
+  &__inset--no-top-padding {
+    padding-top: 0 !important;
+  }
+
   &__inset--scroll-shadows {
     // https://css-tricks.com/books/greatest-css-tricks/scroll-shadows/
     --bgRGB: 22, 22, 24;


### PR DESCRIPTION
What
Use class instead of css var for hasNoTopPadding toggle

Why
During QA we decided to remove the padding from some of our view insets. This uncovered a bug in how our `hasNoTopPadding` prop worked.
Since this prop toggled a css variable, if two components were rendered at once and set this flag opposite of each other, you can experience clashes due to the nature of css cascading.