### PR TITLE
enable e2e tests in CI and add cleanup tasks

### DIFF
--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -6,16 +6,16 @@ jobs:
   test-ci:
     name: test
     timeout-minutes: 20
-    runs-on: ubuntu-latest
-    container:
-      image: mcr.microsoft.com/playwright:v1.45.3-jammy
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 21
       - run: npm install -g yarn && yarn
+      - run: npx playwright install --with-deps chromium
       - run: yarn setup
       - run: yarn build:freighter-api
       - run: yarn build:extension
       - run: yarn test:ci
+      - run: yarn test:e2e

--- a/.husky/e2eTests.sh
+++ b/.husky/e2eTests.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-yarn test:e2e

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,4 +2,3 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 bash ./.husky/addTranslations.sh
-bash ./.husky/e2eTests.sh

--- a/extension/e2e-tests/addAsset.test.ts
+++ b/extension/e2e-tests/addAsset.test.ts
@@ -81,3 +81,23 @@ test("Adding Soroban verified token", async ({ page, extensionId }) => {
     timeout: 30000,
   });
 });
+test.afterAll(async ({ page, extensionId }) => {
+  if (
+    test.info().status !== test.info().expectedStatus &&
+    test.info().title === "Adding Soroban verified token"
+  ) {
+    // remove trustline in cleanup if Adding Soroban verified token test failed
+    test.slow();
+    await loginToTestAccount({ page, extensionId });
+
+    await page.getByText("Manage Assets").click({ force: true });
+    await page.getByPlaceholder("Enter password").fill(PASSWORD);
+    await page.getByText("Log In").click({ force: true });
+
+    await page.getByTestId("ManageAssetRowButton__ellipsis-USDC").click();
+    await page.getByText("Remove asset").click();
+    await expect(page.getByTestId("account-view")).toBeVisible({
+      timeout: 30000,
+    });
+  }
+});

--- a/extension/e2e-tests/addAsset.test.ts
+++ b/extension/e2e-tests/addAsset.test.ts
@@ -19,7 +19,7 @@ test("Adding unverified Soroban token", async ({ page, extensionId }) => {
   await expect(page.getByTestId("asset-notification")).toHaveText(
     "Not on your listsFreighter uses asset lists to check assets you interact with. You can define your own assets lists in Settings.",
   );
-  await expect(page.getByTestId("ManageAssetCode")).toHaveText("E2E");
+  await expect(page.getByTestId("ManageAssetCode")).toHaveText("E2E Token");
   await expect(page.getByTestId("ManageAssetRowButton")).toHaveText("Add");
   await page.getByTestId("ManageAssetRowButton").click({ force: true });
 

--- a/extension/e2e-tests/sendPayment.test.ts
+++ b/extension/e2e-tests/sendPayment.test.ts
@@ -282,3 +282,23 @@ test("Send token payment to C address", async ({ page, extensionId }) => {
   await expect(page.getByText("Sent E2E")).toBeVisible();
   await expect(page.getByTestId("asset-amount")).toContainText(".001 E2E");
 });
+test.afterAll(async ({ page, extensionId }) => {
+  if (
+    test.info().status !== test.info().expectedStatus &&
+    test.info().title === "Send SAC to C address"
+  ) {
+    // remove trustline in cleanup if Send SAC to C address test failed
+    test.slow();
+    await loginToTestAccount({ page, extensionId });
+
+    await page.getByText("Manage Assets").click({ force: true });
+    await page.getByPlaceholder("Enter password").fill(PASSWORD);
+    await page.getByText("Log In").click({ force: true });
+
+    await page.getByTestId("ManageAssetRowButton__ellipsis-USDC").click();
+    await page.getByText("Remove asset").click();
+    await expect(page.getByTestId("account-view")).toBeVisible({
+      timeout: 30000,
+    });
+  }
+});


### PR DESCRIPTION
re-roll of https://github.com/stellar/freighter/pull/1631

https://github.com/stellar/freighter/issues/1579

Moves from the e2e tests from a pre-push git hook to running in CI on every commit
Because we use the same Testnet account for a few different tests, we've had some issues where a failing test would leave the test account in a weird state. https://github.com/stellar/freighter/issues/1653. To combat that, I created some "cleanup jobs" that run only if one of these tests fails. They basically just revert the account back to it's base state