### PR TITLE
Limit concurrency e2e tests

### DIFF
--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -2,6 +2,8 @@ name: Run Tests
 env:
   INDEXER_URL: ${{ secrets.INDEXER_URL }}
 on: [pull_request]
+concurrency:
+  group: ${{ github.workflow }}
 jobs:
   test-ci:
     name: test


### PR DESCRIPTION
Because the e2e tests actually make changes to the test account when running through test scenarios, if we run multiple instances of the tests at the same time, there can be collisions as the test account may be in an unexpected state. This limits the `runTests` job to only running one at a time to make sure multiple jobs can't collide