### PR TITLE
Prevent infinity spinner when switching to same account

### DIFF
--- a/extension/src/popup/components/identicons/AccountListIdenticon/index.tsx
+++ b/extension/src/popup/components/identicons/AccountListIdenticon/index.tsx
@@ -32,7 +32,9 @@ export const AccountListIdenticon = ({
   const shortPublicKey = truncatedPublicKey(publicKey);
 
   const handleMakeAccountActive = () => {
-    if (setLoading) {
+    // If this account is already active (selected) we don't need to load any
+    // more stuff, so let's just collapse the dropdown in this case
+    if (!active && setLoading) {
       setLoading(true);
     }
 


### PR DESCRIPTION
Closes https://github.com/stellar/freighter/issues/1651

Fixes this issue where users get an infinity spinner when tapping on the currently selected account on the account dropdown as shown on the video below.

### Before fix
https://github.com/user-attachments/assets/47a5e934-a8e4-42a0-aad2-43fad24c904d

### After fix
https://github.com/user-attachments/assets/48b27a4e-dcaf-45ea-ba34-7f3eec52ded6