### PR TITLE
[BUG] `buildAndSimulateSoroswapTx` uses Horizon directly

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -1496,6 +1496,33 @@ export const simulateTokenTransfer = async (args: {
   };
 };
 
+export const simulateTransaction = async (args: {
+  xdr: string;
+  networkDetails: NetworkDetails;
+}) => {
+  const { xdr, networkDetails } = args;
+  const options = {
+    method: "POST",
+    headers: {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      xdr,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      network_url: networkDetails.sorobanRpcUrl,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      network_passphrase: networkDetails.networkPassphrase,
+    }),
+  };
+  const res = await fetch(`${INDEXER_URL}/simulate-tx`, options);
+  const response = await res.json();
+  return {
+    ok: res.ok,
+    response,
+  };
+};
+
 export const saveIsBlockaidAnnounced = async ({
   isBlockaidAnnounced,
 }: {


### PR DESCRIPTION
Closes #1459 
Depends on [BE #183](https://github.com/stellar/freighter-backend/pull/183)

What
Splits `buildAndSimulateSoroswapTx` for custom networks
Uses the `simulate-tx` endpoint for other networks

Why
All simulations should go through the backend for non custom networks in order to ensure we can continue to run Freighter on pubnet|testnet without relying on a publicly available instance of Horizon.