### PR TITLE
Improve error boundary

### DIFF
--- a/extension/src/popup/components/ErrorBoundary/index.tsx
+++ b/extension/src/popup/components/ErrorBoundary/index.tsx
@@ -5,8 +5,6 @@ import { useTranslation } from "react-i18next";
 
 import IconFail from "popup/assets/icon-fail.svg";
 import { Button } from "@stellar/design-system";
-import { navigateTo } from "popup/helpers/navigate";
-import { ROUTES } from "popup/constants/routes";
 
 import "./styles.scss";
 
@@ -51,10 +49,8 @@ export const UnhandledError = ({
   errorString: string;
 }) => {
   const { t } = useTranslation();
-  // expected to work outside of <Router />
-  const isOnAccount = window.location.hash === "#/account";
   return (
-    <React.Fragment>
+    <div className="UnexpectedError">
       <View.AppHeader pageTitle={t("Error")} />
       <View.Content>
         <div className="UnexpectedError__content">
@@ -67,28 +63,19 @@ export const UnhandledError = ({
         <div className="UnexpectedError__error-string">{errorString}</div>
       </View.Content>
       <View.Footer>
-        {isOnAccount ? (
-          <Button
-            isFullWidth
-            variant="tertiary"
-            size="md"
-            onClick={window.close}
-          >
-            {t("Close")}
-          </Button>
-        ) : (
-          <Button
-            isFullWidth
-            variant="tertiary"
-            size="md"
-            onClick={() => {
-              navigateTo(ROUTES.account);
-            }}
-          >
-            {t("Got it")}
-          </Button>
-        )}
+        <Button
+          isFullWidth
+          variant="tertiary"
+          size="md"
+          onClick={() => {
+            // https://stackoverflow.com/questions/57854/how-can-i-close-a-browser-window-without-receiving-the-do-you-want-to-close-thi
+            window.open("", "_self", "");
+            window.close();
+          }}
+        >
+          {t("Close")}
+        </Button>
       </View.Footer>
-    </React.Fragment>
+    </div>
   );
 };

--- a/extension/src/popup/components/ErrorBoundary/styles.scss
+++ b/extension/src/popup/components/ErrorBoundary/styles.scss
@@ -1,4 +1,17 @@
 .UnexpectedError {
+  width: 100%;
+  height: 100%;
+  min-width: 360px;
+  min-height: 600px;
+
+  .View__inset {
+    border: 0;
+  }
+
+  button {
+    margin-bottom: 0.5rem;
+  }
+
   &__content {
     flex-grow: 1;
     display: flex;
@@ -101,18 +114,15 @@
   }
 
   &__error-code {
-    font-size: 0.75rem;
     line-height: 1.25rem;
   }
 
   &__error-block {
     margin-top: auto;
-    font-size: 0.875rem;
     text-align: center;
   }
 
   &__error-string {
-    font-size: 0.5rem;
     color: var(--sds-clr-gray-12);
     margin-top: 0.5rem;
     text-align: center;


### PR DESCRIPTION
Closes #1595 

What
Makes the error boundary close in every scenario
Updates error boundary styles to not overflow header and better display error messages

Why
The navigation never works here because the error boundary sits at a higher level than the router. 
Navigation patterns using the global navigation context don't work very well either because of the hash routing model so we would have to reload the window anyways.