### PR TITLE
Redesign Unfunded account notification

### DIFF
--- a/extension/src/popup/components/account/NotFundedMessage/index.tsx
+++ b/extension/src/popup/components/account/NotFundedMessage/index.tsx
@@ -1,10 +1,12 @@
-import React from "react";
-import { useDispatch } from "react-redux";
+import { Button, Notification } from "@stellar/design-system";
 import { Formik, Form } from "formik";
-import { Button, Icon } from "@stellar/design-system";
+import React from "react";
 import { useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
 
 import { fundAccount } from "popup/ducks/accountServices";
+import { ROUTES } from "popup/constants/routes";
+import { navigateTo } from "popup/helpers/navigate";
 
 import "./styles.scss";
 
@@ -27,47 +29,41 @@ export const NotFundedMessage = ({
   };
 
   return (
-    <>
-      <div className="NotFunded" data-testid="not-funded">
-        <div className="NotFunded__header">
-          <Icon.InfoCircle />
-          {t("Stellar address is not funded")}
-        </div>
-        <div className="NotFunded__copy">
-          {t("To create this account, fund it with a minimum of 1 XLM.")}
-          {canUseFriendbot ? (
-            <span>
-              {t(
-                "You can fund this account using the friendbot tool. The friendbot is a horizon API endpoint that will fund an account with 10,000 lumens.",
-              )}
-            </span>
-          ) : null}{" "}
-          <a
-            href="https://developers.stellar.org/docs/tutorials/create-account/#create-account"
-            rel="noreferrer"
-            target="_blank"
-          >
-            {t("Learn more about account creation")}
-          </a>
-        </div>
-      </div>
-      {canUseFriendbot ? (
+    <div className="NotFunded" data-testid="not-funded">
+      <Notification
+        variant="primary"
+        title={t("To start using this account, fund it with at least 1 XLM.")}
+      />
+
+      <div className="NotFunded__spacer" />
+
+      <Button
+        variant="secondary"
+        size="md"
+        isFullWidth
+        onClick={() => navigateTo(ROUTES.viewPublicKey)}
+      >
+        {t("Add XLM")}
+      </Button>
+
+      <div className="NotFunded__spacer" />
+
+      {canUseFriendbot && (
         <Formik initialValues={{}} onSubmit={handleFundAccount}>
           {({ isSubmitting }) => (
-            <Form className="NotFunded__form">
+            <Form>
               <Button
                 variant="primary"
                 size="md"
                 isFullWidth
                 isLoading={isSubmitting}
-                type="submit"
               >
                 {t("Fund with Friendbot")}
               </Button>
             </Form>
           )}
         </Formik>
-      ) : null}
-    </>
+      )}
+    </div>
   );
 };

--- a/extension/src/popup/components/account/NotFundedMessage/index.tsx
+++ b/extension/src/popup/components/account/NotFundedMessage/index.tsx
@@ -33,7 +33,16 @@ export const NotFundedMessage = ({
       <Notification
         variant="primary"
         title={t("To start using this account, fund it with at least 1 XLM.")}
-      />
+      >
+        <a
+          className="NotFunded__link"
+          href="https://developers.stellar.org/docs/tutorials/create-account/#create-account"
+          rel="noreferrer"
+          target="_blank"
+        >
+          {t("Learn more about account creation")}
+        </a>
+      </Notification>
 
       <div className="NotFunded__spacer" />
 

--- a/extension/src/popup/components/account/NotFundedMessage/styles.scss
+++ b/extension/src/popup/components/account/NotFundedMessage/styles.scss
@@ -1,37 +1,11 @@
 .NotFunded {
-  background: rgba(100, 50, 241, 0.32);
-  border-radius: 0.5rem;
-  margin-top: 2rem;
   padding: 1rem;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
 
-  &__header {
-    display: flex;
-    align-items: center;
-    color: var(--sds-clr-gray-12);
-    font-size: 0.875rem;
-    line-height: 1.5rem;
-    font-weight: var(--font-weight-medium);
-    padding-bottom: 0.25rem;
-
-    svg {
-      color: rgba(100, 50, 241, 1);
-      height: 0.75rem;
-      margin-left: -0.375rem;
-    }
-  }
-
-  &__copy {
-    font-size: 0.875rem;
-    line-height: 1.375rem;
-    padding-top: 0.5rem;
-
-    a {
-      color: var(--sds-clr-gray-12);
-      text-decoration: underline;
-    }
-  }
-
-  &__form {
-    padding-top: 3.375rem;
+  &__spacer {
+    height: 0.75rem;
   }
 }

--- a/extension/src/popup/components/account/NotFundedMessage/styles.scss
+++ b/extension/src/popup/components/account/NotFundedMessage/styles.scss
@@ -5,6 +5,10 @@
   left: 0;
   right: 0;
 
+  &__link {
+    margin-left: 1.5rem;
+  }
+
   &__spacer {
     height: 0.75rem;
   }


### PR DESCRIPTION
Closes #1540 

This PR redesigns the Unfunded account notification using the `Notification` component from `@stellar/design-system`.

If it's on Mainnet it'll display just the "Add XLM" button.
If it's on Testnet it'll display both the "Add XLM" + "Fund with friendbot" buttons.

The "Add XLM" button redirects users to the QR Code screen so they can use it to receive a XLM payment.

### Mainnet
![mainnet](https://github.com/user-attachments/assets/477ac448-6ce6-4fe3-b7c0-bf30db98fa22)

https://github.com/user-attachments/assets/24b80f01-a452-414b-99ba-d597c30c0d05

### Testnet
![testnet](https://github.com/user-attachments/assets/a1ac442d-ac69-4602-9860-21ee8fc0de2f)

https://github.com/user-attachments/assets/498e8f8b-107a-47de-ae1f-92adbf52b79d