### PR TITLE
[BUG FIX] Only render Account footer when needed

### DIFF
--- a/extension/src/popup/views/Account/index.tsx
+++ b/extension/src/popup/views/Account/index.tsx
@@ -288,15 +288,15 @@ export const Account = () => {
               )}
             </div>
           </View.Content>
-          <View.Footer>
-            {!isFunded && !hasError && !error?.horizon && (
+          {!isFunded && !hasError && !error?.horizon && (
+            <View.Footer>
               <NotFundedMessage
                 canUseFriendbot={!!networkDetails.friendbotUrl}
                 setIsAccountFriendbotFunded={setIsAccountFriendbotFunded}
                 publicKey={publicKey}
               />
-            )}
-          </View.Footer>
+            </View.Footer>
+          )}
         </>
       )}
     </>


### PR DESCRIPTION
[This other PR](https://github.com/stellar/freighter/pull/1706/files#diff-2575d5f069f0cb7afc27c3eb65256135e8cb1f1210999d1415f55535d784b440R291-R299) wrapped the `NotFundedMessage` component with `Account footer` component to keep the UI consistent but it created a bug for people with lots of assets since the (invisible) footer component is always there.

This PR fixes it by only rendering the footer component when needed.

Thanks @piyalbasu for raising this!

### Before fix
https://github.com/user-attachments/assets/b2b8b903-b73d-4c84-9015-5f19d23cf7d9

### After fix
https://github.com/user-attachments/assets/8867f306-1db8-4a25-9e37-27646677818a