### PR TITLE
skip this test since our test token is currently verified

### DIFF
--- a/extension/e2e-tests/addAsset.test.ts
+++ b/extension/e2e-tests/addAsset.test.ts
@@ -2,7 +2,7 @@ import { test, expect, expectPageToHaveScreenshot } from "./test-fixtures";
 import { loginToTestAccount, PASSWORD } from "./helpers/login";
 import { TEST_TOKEN_ADDRESS } from "./helpers/test-token";
 
-test("Adding unverified Soroban token", async ({ page, extensionId }) => {
+test.skip("Adding unverified Soroban token", async ({ page, extensionId }) => {
   test.slow();
   await loginToTestAccount({ page, extensionId });
 


### PR DESCRIPTION
After the Testnet reset, our test token ended up on stellar.expert's verified token list (because of all the interactions our e2e tests were generating). Because of that, this test, which was designed to test for an unverified token, is now broken. This will be solved once Testnet's usage increases/I  stub out the API response from stellar.expert