### PR TITLE
[FEATURE] add empty asset list message on manage asset page

### DIFF
--- a/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
@@ -172,18 +172,27 @@ export const ChooseAsset = ({ balances }: ChooseAssetProps) => {
           </div>
         ) : (
           <div className="ChooseAsset__wrapper">
-            <div
-              className={`ChooseAsset__assets${
-                isManagingAssets && isSorobanSuported ? "--short" : ""
-              }`}
-              ref={ManageAssetRowsWrapperRef}
-            >
-              {isManagingAssets ? (
-                <ManageAssetRows assetRows={assetRows} />
-              ) : (
-                <SelectAssetRows assetRows={assetRows} />
-              )}
-            </div>
+            {!assetRows.length ? (
+              <div className="ChooseAsset__empty">
+                <p>
+                  You have no assets added. Get started by adding an asset
+                  below.
+                </p>
+              </div>
+            ) : (
+              <div
+                className={`ChooseAsset__assets${
+                  isManagingAssets && isSorobanSuported ? "--short" : ""
+                }`}
+                ref={ManageAssetRowsWrapperRef}
+              >
+                {isManagingAssets ? (
+                  <ManageAssetRows assetRows={assetRows} />
+                ) : (
+                  <SelectAssetRows assetRows={assetRows} />
+                )}
+              </div>
+            )}
           </div>
         )}
       </View.Content>

--- a/extension/src/popup/components/manageAssets/ChooseAsset/styles.scss
+++ b/extension/src/popup/components/manageAssets/ChooseAsset/styles.scss
@@ -12,6 +12,19 @@
     left: 0;
   }
 
+  &__empty {
+    display: flex;
+    justify-content: center;
+    height: 100%;
+    width: 100%;
+    color: var(--sds-clr-gray-11);
+    text-align: center;
+
+    p {
+      font-size: var(--sds-fs-secondary);
+    }
+  }
+
   &__wrapper {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Closes #1619 

What
Adds empty asset list message on asset management screen.

Why
Missing empty state

Design: https://www.figma.com/design/C3G0a4Gd6RQyplRBppGDsL/Freighter-(SDS-v3)?node-id=2932-3383&t=XdeMvXWoCGmqoOrr-0

Screen:
![Screenshot 2024-12-17 at 9 59 23 AM](https://github.com/user-attachments/assets/087f63ab-198c-41c4-846c-fcb572b348fc)
