### PR TITLE
[BUG] Make signMessage API SEP-43 compliant

### DIFF
--- a/@shared/api/external.ts
+++ b/@shared/api/external.ts
@@ -94,6 +94,7 @@ export const submitTransaction = async (
 
 export const submitMessage = async (
   blob: string,
+  version: string,
   opts?: {
     address?: string;
     networkPassphrase?: string;
@@ -110,6 +111,7 @@ export const submitMessage = async (
     response = await sendMessageToContentScript({
       blob,
       accountToSign,
+      apiVersion: version,
       type: EXTERNAL_SERVICE_TYPES.SUBMIT_BLOB,
     });
   } catch (e) {

--- a/@shared/api/types.ts
+++ b/@shared/api/types.ts
@@ -115,6 +115,7 @@ export interface ExternalRequestTx extends ExternalRequestBase {
 }
 
 export interface ExternalRequestBlob extends ExternalRequestBase {
+  apiVersion: string;
   blob: string;
 }
 

--- a/@stellar/freighter-api/package.json
+++ b/@stellar/freighter-api/package.json
@@ -15,7 +15,10 @@
     "start": "webpack --config webpack.dev.js --watch --mode development"
   },
   "types": "build/@stellar/freighter-api/src/index.d.ts",
-  "dependencies": {},
+  "dependencies": {
+    "buffer": "^6.0.3",
+    "semver": "^7.6.3"
+  },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.3.1"
   }

--- a/@stellar/freighter-api/src/signMessage.ts
+++ b/@stellar/freighter-api/src/signMessage.ts
@@ -1,5 +1,4 @@
 import packageJson from "../package.json";
-import semver from "semver";
 import { Buffer } from "buffer";
 
 import { submitMessage } from "@shared/api/external";
@@ -29,18 +28,10 @@ export const signMessage = async (
   }
 ): Promise<SignMessageV3Response | SignMessageV4Response> => {
   if (isBrowser) {
-    const req = await submitMessage(message, opts);
+    const req = await submitMessage(message, packageJson.version, opts);
 
     if (req.error) {
       return { signedMessage: null, signerAddress: "", error: req.error };
-    }
-
-    if (semver.gte(packageJson.version, "4.0.0") && req.signedMessage) {
-      const signedMessage = Buffer.from(req.signedMessage).toString("base64");
-      return {
-        signedMessage,
-        signerAddress: req.signerAddress,
-      };
     }
 
     return {

--- a/@stellar/freighter-api/src/signMessage.ts
+++ b/@stellar/freighter-api/src/signMessage.ts
@@ -1,7 +1,25 @@
+import packageJson from "../package.json";
+import semver from "semver";
+import { Buffer } from "buffer";
+
 import { submitMessage } from "@shared/api/external";
 import { FreighterApiError } from "@shared/api/types";
 import { FreighterApiNodeError } from "@shared/api/helpers/extensionMessaging";
 import { isBrowser } from ".";
+
+type SignMessageV3Response = {
+  signedMessage: Buffer | null;
+  signerAddress: string;
+} & {
+  error?: FreighterApiError;
+};
+
+type SignMessageV4Response = {
+  signedMessage: string;
+  signerAddress: string;
+} & {
+  error?: FreighterApiError;
+};
 
 export const signMessage = async (
   message: string,
@@ -9,16 +27,20 @@ export const signMessage = async (
     networkPassphrase?: string;
     address?: string;
   }
-): Promise<
-  { signedMessage: Buffer | null; signerAddress: string } & {
-    error?: FreighterApiError;
-  }
-> => {
+): Promise<SignMessageV3Response | SignMessageV4Response> => {
   if (isBrowser) {
     const req = await submitMessage(message, opts);
 
     if (req.error) {
       return { signedMessage: null, signerAddress: "", error: req.error };
+    }
+
+    if (semver.gte(packageJson.version, "4.0.0") && req.signedMessage) {
+      const signedMessage = Buffer.from(req.signedMessage).toString("base64");
+      return {
+        signedMessage,
+        signerAddress: req.signerAddress,
+      };
     }
 
     return {

--- a/extension/src/background/messageListener/freighterApiMessageListener.ts
+++ b/extension/src/background/messageListener/freighterApiMessageListener.ts
@@ -3,6 +3,7 @@
 import * as StellarSdk from "stellar-sdk";
 import browser from "webextension-polyfill";
 import { Store } from "redux";
+import semver from "semver";
 
 import {
   ExternalRequestAuthEntry,
@@ -288,7 +289,7 @@ export const freighterApiMessageListener = (
 
   const submitBlob = async () => {
     try {
-      const { blob, accountToSign, address, networkPassphrase } =
+      const { apiVersion, blob, accountToSign, address, networkPassphrase } =
         request as ExternalRequestBlob;
 
       const { tab, url: tabUrl = "" } = sender;
@@ -338,6 +339,14 @@ export const freighterApiMessageListener = (
             if (!isDomainListedAllowed) {
               allowList.push(punycodedDomain);
               localStore.setItem(ALLOWLIST_ID, allowList.join());
+            }
+
+            if (semver.gte(apiVersion, "4.0.0")) {
+              resolve({
+                signedBlob: Buffer.from(signedBlob).toString("base64"),
+                signerAddress,
+              });
+              return;
             }
             resolve({ signedBlob, signerAddress });
           }

--- a/extension/src/popup/locales/en/translation.json
+++ b/extension/src/popup/locales/en/translation.json
@@ -528,7 +528,6 @@
   "You must have a buying liability of": "You must have a buying liability of",
   "You still have a balance of": "You still have a balance of",
   "You still have a buying liability of": "You still have a buying liability of",
-  "You won’t be asked to do this again for the next 24 hours": "You won’t be asked to do this again for the next 24 hours.",
   "You’re all set!": "You’re all set!",
   "You’re good to go!": "You’re good to go!",
   "Your account balance is not sufficient for this transaction": {

--- a/extension/src/popup/locales/pt/translation.json
+++ b/extension/src/popup/locales/pt/translation.json
@@ -528,7 +528,6 @@
   "You must have a buying liability of": "You must have a buying liability of",
   "You still have a balance of": "You still have a balance of",
   "You still have a buying liability of": "You still have a buying liability of",
-  "You won’t be asked to do this again for the next 24 hours": "You won’t be asked to do this again for the next 24 hours.",
   "You’re all set!": "You’re all set!",
   "You’re good to go!": "You’re good to go!",
   "Your account balance is not sufficient for this transaction": {


### PR DESCRIPTION
Closes #1634 

What
`signMessage` returns a Buffer like object for the `signedMessage` key. [The SEP](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0043.md) defines this to return a string instead.

Why
Implementation not aligned with standard.

This should be a major version bump due to the API change but was implemented to be backwards compatible for earlier versions. Versions < 4.0 will still return the old response.