### PR TITLE
restore border for swap card

### DIFF
--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/styles.scss
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/styles.scss
@@ -158,10 +158,9 @@
   display: flex;
   flex-direction: column;
   border-radius: 0.5rem;
-  border: 1px solid var(--sds-clr-gray-01);
+  border: 1px solid var(--sds-clr-gray-06);
   position: relative;
-  margin: -1.5rem 0 1.5rem 0;
-  padding-top: #{pxToRem(24px)};
+  margin: 0 0 pxToRem(24px) 0;
 
   &__row:first-child {
     border-bottom: 1px solid var(--sds-clr-gray-01);


### PR DESCRIPTION
Closes #1769 

Restores the border for the Swap asset card
<img width="364" alt="Screenshot 2025-01-08 at 7 04 16 PM" src="https://github.com/user-attachments/assets/8ec5a92d-1143-4a3a-a2ce-6871263525ff" />
