### PR TITLE
wrap sac match logic in try catch to gracefully fall through

### DIFF
--- a/@shared/helpers/stellar.ts
+++ b/@shared/helpers/stellar.ts
@@ -15,6 +15,7 @@ import {
 import { INDEXER_URL } from "@shared/constants/mercury";
 
 export const CUSTOM_NETWORK = "STANDALONE";
+export const LP_ISSUER_KEY = "lp";
 
 export const isNextSdk = (networkPassphrase: string) =>
   [""].includes(networkPassphrase);
@@ -40,7 +41,7 @@ export function getBalanceIdentifier(
       return `${balance.asset_code}:${balance.asset_issuer}`;
 
     case "liquidity_pool_shares":
-      return `${balance.liquidity_pool_id}:lp`;
+      return `${balance.liquidity_pool_id}:${LP_ISSUER_KEY}`;
 
     default:
       return "native";

--- a/extension/src/popup/components/__tests__/HistoryItem.test.tsx
+++ b/extension/src/popup/components/__tests__/HistoryItem.test.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { render, waitFor, screen } from "@testing-library/react";
+import BigNumber from "bignumber.js";
 
 import { HistoryItem } from "popup/components/accountHistory/HistoryItem";
 import { TESTNET_NETWORK_DETAILS } from "@shared/constants/stellar";
 import * as sorobanHelpers from "popup/helpers/soroban";
 import * as internalApi from "@shared/api/internal";
-import BigNumber from "bignumber.js";
 
 describe("HistoryItem", () => {
   afterAll(() => {

--- a/extension/src/popup/components/__tests__/HistoryItem.test.tsx
+++ b/extension/src/popup/components/__tests__/HistoryItem.test.tsx
@@ -5,6 +5,7 @@ import { HistoryItem } from "popup/components/accountHistory/HistoryItem";
 import { TESTNET_NETWORK_DETAILS } from "@shared/constants/stellar";
 import * as sorobanHelpers from "popup/helpers/soroban";
 import * as internalApi from "@shared/api/internal";
+import BigNumber from "bignumber.js";
 
 describe("HistoryItem", () => {
   afterAll(() => {
@@ -32,6 +33,58 @@ describe("HistoryItem", () => {
     const props = {
       accountBalances: {
         balances: {
+          native: {
+            token: {
+              code: "XLM",
+            },
+            decimals: 7,
+          },
+        } as any,
+        isFunded: true,
+        subentryCount: 0,
+      },
+      operation: {
+        account: "GCGORBD5DB4JDIKVIA536CJE3EWMWZ6KBUBWZWRQM7Y3NHFRCLOKYVAL",
+        amount: "10",
+        asset_code: "XLM",
+        created_at: Date.now(),
+        id: "op-id",
+        to: "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF",
+        from: "GCGORBD5DB4JDIKVIA536CJE3EWMWZ6KBUBWZWRQM7Y3NHFRCLOKYVAL",
+        starting_balance: "10",
+        type: "invokeHostFunction",
+        type_i: 24,
+        transaction_attr: {
+          operation_count: 1,
+        },
+        isCreateExternalAccount: false,
+        isPayment: false,
+        isSwap: false,
+      } as any,
+      publicKey: "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF",
+      url: "example.com",
+      networkDetails: TESTNET_NETWORK_DETAILS,
+      setDetailViewProps: () => null,
+      setIsDetailViewShowing: () => null,
+    };
+    render(<HistoryItem {...props} />);
+    await waitFor(() => screen.getByTestId("history-item"));
+    expect(screen.getByTestId("history-item")).toBeDefined();
+    expect(screen.getByTestId("history-item-body-component")).toHaveTextContent(
+      "+10 XLM",
+    );
+  });
+  it("renders SAC transfer correctly when balance includes LP shares", async () => {
+    const props = {
+      accountBalances: {
+        balances: {
+          "a468d41d8e9b8f3c7209651608b74b7db7ac9952dcae0cdf24871d1d9c7b0088:lp":
+            {
+              liquidityPoolId:
+                "a468d41d8e9b8f3c7209651608b74b7db7ac9952dcae0cdf24871d1d9c7b0088",
+              total: new BigNumber(10),
+              limit: new BigNumber(100),
+            },
           native: {
             token: {
               code: "XLM",

--- a/extension/src/popup/components/account/AccountAssets/styles.scss
+++ b/extension/src/popup/components/account/AccountAssets/styles.scss
@@ -27,7 +27,7 @@ $loader-light-color: #444961;
 
     &--lp-share,
     &--soroban-token {
-      border: 1px solid var(--sds-clr-gray-02);
+      border: 1px solid var(--sds-clr-gray-06);
       height: 32px;
       width: 32px;
       border-radius: 2rem;

--- a/extension/src/popup/components/accountHistory/HistoryItem/index.tsx
+++ b/extension/src/popup/components/accountHistory/HistoryItem/index.tsx
@@ -7,8 +7,6 @@ import camelCase from "lodash/camelCase";
 import { Icon, Loader } from "@stellar/design-system";
 import { BigNumber } from "bignumber.js";
 import { useTranslation } from "react-i18next";
-import { Asset } from "stellar-sdk";
-import * as Sentry from "@sentry/browser";
 
 import { OPERATION_TYPES } from "constants/transaction";
 import { SorobanTokenInterface } from "@shared/constants/soroban/token";
@@ -18,9 +16,9 @@ import { emitMetric } from "helpers/metrics";
 import {
   formatTokenAmount,
   getAttrsFromSorobanHorizonOp,
-  isContractId,
 } from "popup/helpers/soroban";
 import { formatAmount } from "popup/helpers/formatters";
+import { getBalanceByKey } from "popup/helpers/balance";
 
 import {
   AccountBalancesInterface,
@@ -225,28 +223,11 @@ export const HistoryItem = ({
         const balances =
           accountBalances.balances || ({} as NonNullable<Balances>);
 
-        const tokenKey = Object.keys(balances).find((balanceKey) => {
-          const [code, issuer] =
-            balanceKey === "native" ? ["XLM"] : balanceKey.split(":");
-          const matchesIssuer = attrs?.contractId === issuer;
-
-          // if issuer is a G address or xlm, check for a SAC match
-          if ((issuer && !isContractId(issuer)) || code === "XLM") {
-            try {
-              const sacAddress = new Asset(code, issuer).contractId(
-                networkDetails.networkPassphrase,
-              );
-              const matchesSac = attrs?.contractId === sacAddress;
-              return matchesSac;
-            } catch (e) {
-              console.error(e);
-              Sentry.captureException(
-                `Error checking for SAC match with code ${code} and issuer ${issuer}. Error: ${e}`,
-              );
-            }
-          }
-          return matchesIssuer;
-        });
+        const tokenKey = getBalanceByKey(
+          attrs.contractId,
+          balances,
+          networkDetails,
+        );
 
         if (!attrs) {
           setRowText(operationString);

--- a/extension/src/popup/helpers/__tests__/balance.test.js
+++ b/extension/src/popup/helpers/__tests__/balance.test.js
@@ -1,0 +1,67 @@
+import BigNumber from "bignumber.js";
+
+import { TESTNET_NETWORK_DETAILS } from "@shared/constants/stellar";
+import { defaultBlockaidScanAssetResult } from "@shared/helpers/stellar";
+
+import { getBalanceByKey } from "../balance";
+
+const CLASSIC_ISSUER =
+  "CBANAM7DMVGXE7C3XPE2RZ7RU5FSVGY7RELHN2B6F5XLGFWX7BQ5D7S5";
+const CONTRACT_ID = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+const TOKEN_BALANCE_KEY = `DT:${CONTRACT_ID}`;
+const CLASSIC_BALANCE_KEY =
+  "USDC:GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM";
+const LP_ID =
+  "a468d41d8e9b8f3c7209651608b74b7db7ac9952dcae0cdf24871d1d9c7b0088";
+const BALANCES = {
+  [TOKEN_BALANCE_KEY]: {
+    token: {
+      code: "DT",
+      issuer: {
+        key: "CCXVDIGMR6WTXZQX2OEVD6YM6AYCYPXPQ7YYH6OZMRS7U6VD3AVHNGBJ",
+      },
+    },
+    decimals: 7,
+    total: new BigNumber("1000000000"),
+    available: new BigNumber("1000000000"),
+    blockaidData: defaultBlockaidScanAssetResult,
+  },
+  [CLASSIC_BALANCE_KEY]: {
+    token: {
+      code: "USDC",
+      issuer: {
+        key: "GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM",
+      },
+    },
+    total: new BigNumber("100"),
+    available: new BigNumber("100"),
+    blockaidData: defaultBlockaidScanAssetResult,
+  },
+  [`${LP_ID}:lp`]: {
+    liquidityPoolId:
+      "a468d41d8e9b8f3c7209651608b74b7db7ac9952dcae0cdf24871d1d9c7b0088",
+    total: new BigNumber(10),
+    limit: new BigNumber(100),
+  },
+  native: {
+    token: {
+      code: "XLM",
+    },
+    decimals: 7,
+  },
+};
+
+describe("getBalanceByKey", () => {
+  it("should return a valid key for a classic asset", () => {
+    const key = getBalanceByKey(
+      CLASSIC_ISSUER,
+      BALANCES,
+      TESTNET_NETWORK_DETAILS,
+    );
+    expect(key).toEqual(CLASSIC_BALANCE_KEY);
+  });
+  it("should return a valid key for a token", () => {
+    const key = getBalanceByKey(CONTRACT_ID, BALANCES, TESTNET_NETWORK_DETAILS);
+    expect(key).toEqual(TOKEN_BALANCE_KEY);
+  });
+});

--- a/extension/src/popup/helpers/balance.ts
+++ b/extension/src/popup/helpers/balance.ts
@@ -7,6 +7,8 @@ import { NetworkDetails } from "@shared/constants/stellar";
 import { isContractId } from "./soroban";
 
 /*
+  Attempts to match a balance to a related contract ID, expects a token or SAC contract ID.
+
   BalanceMap keys can be one of two variants - 
   An asset balance - {code}:{issuer}
   A token - {symbol}:{contract id}
@@ -17,7 +19,7 @@ export const getBalanceByKey = (
   balances: BalanceMap,
   networkDetails: NetworkDetails,
 ) => {
-  const tokenKey = Object.keys(balances).find((balanceKey) => {
+  const key = Object.keys(balances).find((balanceKey) => {
     const [code, issuer] =
       balanceKey === "native" ? ["XLM"] : balanceKey.split(":");
     const matchesIssuer = contractId === issuer;
@@ -42,5 +44,5 @@ export const getBalanceByKey = (
     }
     return matchesIssuer;
   });
-  return tokenKey;
+  return key;
 };

--- a/extension/src/popup/helpers/balance.ts
+++ b/extension/src/popup/helpers/balance.ts
@@ -1,0 +1,46 @@
+import { Asset } from "stellar-sdk";
+import { captureException } from "@sentry/browser";
+
+import { BalanceMap } from "@shared/api/types";
+import { LP_ISSUER_KEY } from "@shared/helpers/stellar";
+import { NetworkDetails } from "@shared/constants/stellar";
+import { isContractId } from "./soroban";
+
+/*
+  BalanceMap keys can be one of two variants - 
+  An asset balance - {code}:{issuer}
+  A token - {symbol}:{contract id}
+  An LP share - {LP ID}:lp
+*/
+export const getBalanceByKey = (
+  contractId: string,
+  balances: BalanceMap,
+  networkDetails: NetworkDetails,
+) => {
+  const tokenKey = Object.keys(balances).find((balanceKey) => {
+    const [code, issuer] =
+      balanceKey === "native" ? ["XLM"] : balanceKey.split(":");
+    const matchesIssuer = contractId === issuer;
+
+    // if issuer is a G address or xlm, check for a SAC match
+    if (
+      (issuer && !isContractId(issuer) && issuer !== LP_ISSUER_KEY) ||
+      code === "XLM"
+    ) {
+      try {
+        const sacAddress = new Asset(code, issuer).contractId(
+          networkDetails.networkPassphrase,
+        );
+        const matchesSac = contractId === sacAddress;
+        return matchesSac;
+      } catch (e) {
+        console.error(e);
+        captureException(
+          `Error checking for SAC match with code ${code} and issuer ${issuer}. Error: ${e}`,
+        );
+      }
+    }
+    return matchesIssuer;
+  });
+  return tokenKey;
+};


### PR DESCRIPTION
User reported issue of SAC transfer to C address throwing an uncaught error when creating Asset instance. `try...catch` will catch the error and allow for gracefully falling through to next if statement