### PR TITLE
checks for the existence of a version before doing semver check

### DIFF
--- a/docs/docs/guide/usingFreighterWebApp.md
+++ b/docs/docs/guide/usingFreighterWebApp.md
@@ -200,9 +200,9 @@ The second parameter is an optional `opts` object where you can specify which ac
 
 ### signMessage
 
-#### `signMessage(message: string, opts: { address: string }) -> <Promise<{ signedMessage: Buffer | null; signerAddress: string; } & { error?: string; }>>`
+#### `signMessage(message: string, opts: { address: string }) -> <Promise<{ signedMessage: string | null; signerAddress: string; } & { error?: string; }>>`
 
-This function accepts a string as the first parameter, which it will decode, sign as the user, and return a Buffer of the signed contents.
+This function accepts a string as the first parameter, which it will decode, sign as the user, and return a base64 encoded string of the signed contents.
 
 The second parameter is an optional `opts` object where you can specify which account's signature you’re requesting. If Freighter has the public key requested, it will switch to that account. If not, it will alert the user that they do not have the requested account.
 

--- a/docs/docs/playground/signMessage.mdx
+++ b/docs/docs/playground/signMessage.mdx
@@ -3,7 +3,7 @@ id: signMessage
 title: signMessage
 ---
 
-#### `signMessage(message: string, opts: { address: string }) -> <Promise<{ signedMessage: Buffer | null; signerAddress: string; } & { error?: string; }>>`
+#### `signMessage(message: string, opts: { address: string }) -> <Promise<{ signedMessage: string | null; signerAddress: string; } & { error?: string; }>>`
 
 import { SignMessageDemo } from "./components/SignMessageDemo";
 

--- a/docs/docs/playground/signMessage.mdx
+++ b/docs/docs/playground/signMessage.mdx
@@ -7,5 +7,13 @@ title: signMessage
 
 import { SignMessageDemo } from "./components/SignMessageDemo";
 
+<p>The signed message from the response is a base64 encoded string of the signature. Verification Example:</p>
+<p>
+```
+const kp = <signing key pair>
+const res = await stellarApi.signMessage("hi", { networkPassphrase: SorobanClient.Networks.TESTNET })
+const passes = kp.verify(Buffer.from("hi", "base64"), Buffer.from(res.signedMessage, "base64")) // true
+```
+</p>
 <strong>Test Freighter's `signMessage` method:</strong>
 <SignMessageDemo />

--- a/extension/src/background/messageListener/freighterApiMessageListener.ts
+++ b/extension/src/background/messageListener/freighterApiMessageListener.ts
@@ -341,7 +341,7 @@ export const freighterApiMessageListener = (
               localStore.setItem(ALLOWLIST_ID, allowList.join());
             }
 
-            if (semver.gte(apiVersion, "4.0.0")) {
+            if (apiVersion && semver.gte(apiVersion, "4.0.0")) {
               resolve({
                 signedBlob: Buffer.from(signedBlob).toString("base64"),
                 signerAddress,


### PR DESCRIPTION
What
Version 4.0 of the API introduced a breaking change in order to align with the SEP for `signMessage`.
The intention was for this change to be backwards compatible but it fails to work with older versions of the extension because of a faulty semver check.