### PR TITLE
[CHORE] Upgrade minor/major deps

### DIFF
--- a/extension/e2e-tests/sendPayment.test.ts
+++ b/extension/e2e-tests/sendPayment.test.ts
@@ -103,7 +103,7 @@ test("Send XLM payment to G address", async ({ page, extensionId }) => {
     screenshot: "send-payment-details.png",
   });
   await expect(page.getByText("Sent XLM")).toBeVisible();
-  await expect(page.getByTestId("asset-amount")).toContainText("1 XLM");
+  await expect(page.getByTestId("asset-amount")).toContainText("1");
 });
 
 test("Send XLM payment to C address", async ({ page, extensionId }) => {
@@ -142,7 +142,7 @@ test("Send XLM payment to C address", async ({ page, extensionId }) => {
   await page.getByText("Details").click({ force: true });
 
   await expect(page.getByText("Sent XLM")).toBeVisible();
-  await expect(page.getByTestId("asset-amount")).toContainText(".001 XLM");
+  await expect(page.getByTestId("asset-amount")).toContainText("0.001");
 
   await page.getByTestId("BackButton").click({ force: true });
   await page.getByTestId("BottomNav-link-account").click({ force: true });
@@ -282,7 +282,7 @@ test("Send token payment to C address", async ({ page, extensionId }) => {
   await page.getByText("Details").click({ force: true });
 
   await expect(page.getByText("Sent E2E")).toBeVisible();
-  await expect(page.getByTestId("asset-amount")).toContainText(".001 E2E");
+  await expect(page.getByTestId("asset-amount")).toContainText("0.001");
 });
 test.afterAll(async ({ page, extensionId }) => {
   if (

--- a/extension/src/popup/__testHelpers__/index.tsx
+++ b/extension/src/popup/__testHelpers__/index.tsx
@@ -98,6 +98,8 @@ export const mockBalances = {
       total: new BigNumber("100"),
       available: new BigNumber("100"),
       blockaidData: {
+        address:
+          "USDC-GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM",
         result_type: "Spam",
         features: [{ feature_id: "METADATA", description: "baz" }],
       },

--- a/extension/src/popup/views/__tests__/Account.test.tsx
+++ b/extension/src/popup/views/__tests__/Account.test.tsx
@@ -483,7 +483,7 @@ describe("Account view", () => {
       const assetNodes = screen.getAllByTestId("account-assets-item");
       expect(assetNodes.length).toEqual(2);
       expect(assetNodes[1]).toHaveTextContent("LP");
-      expect(assetNodes[1]).toHaveTextContent("0 shares");
+      expect(assetNodes[1]).toHaveTextContent("0");
     });
   });
 });

--- a/extension/src/popup/views/__tests__/SendPayment.test.tsx
+++ b/extension/src/popup/views/__tests__/SendPayment.test.tsx
@@ -178,6 +178,7 @@ describe("SendPayment", () => {
           result_type: "Malicious" as any,
           status: "Success" as any,
         },
+        request_id: "123",
       };
       return {
         scanTx: () => Promise.resolve(null),
@@ -215,6 +216,7 @@ describe("SendPayment", () => {
           result_type: "Malicious" as any,
           status: "Success" as any,
         },
+        request_id: "123",
       };
       return {
         scanTx: () => Promise.resolve(null),

--- a/extension/src/popup/views/__tests__/SendTokenPayment.test.tsx
+++ b/extension/src/popup/views/__tests__/SendTokenPayment.test.tsx
@@ -216,7 +216,7 @@ describe("SendTokenPayment", () => {
     });
 
     await waitFor(async () => {
-      expect(container).toHaveTextContent("5 DT");
+      expect(container).toHaveTextContent("5");
       const sendBtn = screen.getByTestId("transaction-details-btn-send");
       await fireEvent.click(sendBtn);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -16861,16 +16861,16 @@ undici-types@~6.19.8:
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
 undici@^5.25.4:
-  version "5.28.4"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.4.tgz#6b280408edb6a1a604a9b20340f45b422e373068"
-  integrity sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==
+  version "5.28.5"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.5.tgz#b2b94b6bf8f1d919bc5a6f31f2c01deb02e54d4b"
+  integrity sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==
   dependencies:
     "@fastify/busboy" "^2.0.0"
 
 undici@^6.19.5:
-  version "6.20.1"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.20.1.tgz#fbb87b1e2b69d963ff2d5410a40ffb4c9e81b621"
-  integrity sha512-AjQF1QsmqfJys+LXfGTNum+qw4S88CojRInG/6t31W/1fk6G59s92bnAvGz5Cmur+kQv2SURXEvvudLmbrE8QA==
+  version "6.21.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.1.tgz#336025a14162e6837e44ad7b819b35b6c6af0e05"
+  integrity sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==
 
 unfetch@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
…directory (#1812)

* Bump undici in the npm_and_yarn group across 1 directory

Bumps the npm_and_yarn group with 1 update in the / directory: [undici](https://github.com/nodejs/undici).


Updates `undici` from 5.28.4 to 5.28.5
- [Release notes](https://github.com/nodejs/undici/releases)
- [Commits](https://github.com/nodejs/undici/compare/v5.28.4...v5.28.5)

---
updated-dependencies:
- dependency-name: undici dependency-type: indirect dependency-group: npm_and_yarn ...



* fixes broken e2e tests, adjusts dom expectations to rendered dom

* removes unused asset label in account view

* updates tests to align to recent dom changes

---------