### PR TITLE
login before showing mnemonic phrase

### DIFF
--- a/extension/src/background/ducks/session.ts
+++ b/extension/src/background/ducks/session.ts
@@ -78,15 +78,6 @@ export const sessionSlice = createSlice({
   reducers: {
     reset: () => initialState,
     logOut: () => initialState,
-    setActivePrivateKey: (state, action: { payload: AppData }) => {
-      const { privateKey = "", password = "" } = action.payload;
-
-      return {
-        ...state,
-        privateKey,
-        password,
-      };
-    },
     setActiveHashKey: (state, action: { payload: AppData }) => {
       const {
         hashKey = {
@@ -166,7 +157,6 @@ export const {
   actions: {
     reset,
     logOut,
-    setActivePrivateKey,
     setActiveHashKey,
     timeoutAccountAccess,
     updateAllAccountsAccountName,


### PR DESCRIPTION
Similar to the last bugfix, making sure we log in before trying to show the user their backup phrase if their session has timed out