### PR TITLE
[FEATURE] Split assets by verification status

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -11,7 +11,10 @@ import {
 } from "stellar-sdk";
 import BigNumber from "bignumber.js";
 import { INDEXER_URL } from "@shared/constants/mercury";
-import { AssetsListItem, AssetsLists } from "@shared/constants/soroban/token";
+import {
+  AssetsListItem,
+  AssetsLists,
+} from "@shared/constants/soroban/asset-list";
 import {
   getBalance,
   getDecimals,

--- a/@shared/api/types.ts
+++ b/@shared/api/types.ts
@@ -6,7 +6,7 @@ import { SERVICE_TYPES, EXTERNAL_SERVICE_TYPES } from "../constants/services";
 import { APPLICATION_STATE } from "../constants/applicationState";
 import { WalletType } from "../constants/hardwareWallet";
 import { NetworkDetails } from "../constants/stellar";
-import { AssetsLists, AssetsListItem } from "../constants/soroban/token";
+import { AssetsLists, AssetsListItem } from "../constants/soroban/asset-list";
 
 export enum ActionStatus {
   IDLE = "IDLE",

--- a/@shared/constants/soroban/asset-list.ts
+++ b/@shared/constants/soroban/asset-list.ts
@@ -1,0 +1,54 @@
+import { NETWORKS } from "@shared/constants/stellar";
+
+export type AssetsListKey = NETWORKS.PUBLIC | NETWORKS.TESTNET;
+
+export type AssetsLists = {
+  [K in AssetsListKey]: AssetsListItem[];
+};
+
+export interface AssetsListItem {
+  url: string;
+  isEnabled: boolean;
+}
+
+export const DEFAULT_ASSETS_LISTS: AssetsLists = {
+  [NETWORKS.PUBLIC]: [
+    {
+      url: "https://api.stellar.expert/explorer/public/asset-list/top50",
+      isEnabled: true,
+    },
+    {
+      url: "https://raw.githubusercontent.com/soroswap/token-list/main/tokenList.json",
+      isEnabled: true,
+    },
+    {
+      url: "https://lobstr.co/api/v1/sep/assets/curated.json",
+      isEnabled: true,
+    },
+  ],
+  [NETWORKS.TESTNET]: [
+    {
+      url: "https://api.stellar.expert/explorer/testnet/asset-list/top50",
+      isEnabled: true,
+    },
+  ],
+};
+
+export interface AssetListReponseItem {
+  code: string;
+  issuer: string;
+  contract: string;
+  org?: string; //org is not optional in the spec but lobstr list does not adhere in this case
+  domain: string;
+  icon: string;
+  decimals: number;
+}
+
+export interface AssetListResponse {
+  name: string;
+  description: string;
+  network: string;
+  version: string;
+  provider: string;
+  assets: AssetListReponseItem[];
+}

--- a/@shared/constants/soroban/token.ts
+++ b/@shared/constants/soroban/token.ts
@@ -1,5 +1,3 @@
-import { NETWORKS } from "@shared/constants/stellar";
-
 // https://github.com/stellar/soroban-examples/blob/main/token/src/contract.rs
 export enum SorobanTokenInterface {
   transfer = "transfer",
@@ -28,37 +26,3 @@ export interface SorobanToken {
   symbol: string;
   decimals: number;
 }
-
-export type AssetsListKey = NETWORKS.PUBLIC | NETWORKS.TESTNET;
-
-export type AssetsLists = {
-  [K in AssetsListKey]: AssetsListItem[];
-};
-
-export interface AssetsListItem {
-  url: string;
-  isEnabled: boolean;
-}
-
-export const DEFAULT_ASSETS_LISTS: AssetsLists = {
-  [NETWORKS.PUBLIC]: [
-    {
-      url: "https://api.stellar.expert/explorer/public/asset-list/top50",
-      isEnabled: true,
-    },
-    {
-      url: "https://raw.githubusercontent.com/soroswap/token-list/main/tokenList.json",
-      isEnabled: true,
-    },
-    {
-      url: "https://lobstr.co/api/v1/sep/assets/curated.json",
-      isEnabled: true,
-    },
-  ],
-  [NETWORKS.TESTNET]: [
-    {
-      url: "https://api.stellar.expert/explorer/testnet/asset-list/top50",
-      isEnabled: true,
-    },
-  ],
-};

--- a/extension/e2e-tests/addAsset.test.ts
+++ b/extension/e2e-tests/addAsset.test.ts
@@ -16,8 +16,8 @@ test("Adding unverified Soroban token", async ({ page, extensionId }) => {
   await page.getByText("Add an asset").click({ force: true });
   await page.getByText("Add manually").click({ force: true });
   await page.getByTestId("search-token-input").fill(TEST_TOKEN_ADDRESS);
-  await expect(page.getByTestId("asset-notification")).toHaveText(
-    "Not on your listsFreighter uses asset lists to check assets you interact with. You can define your own assets lists in Settings.",
+  await expect(page.getByTestId("not-asset-on-list")).toHaveText(
+    "Not on your lists",
   );
   await expect(page.getByTestId("ManageAssetCode")).toHaveText("E2E Token");
   await expect(page.getByTestId("ManageAssetRowButton")).toHaveText("Add");
@@ -33,7 +33,7 @@ test("Adding unverified Soroban token", async ({ page, extensionId }) => {
   await page.getByTestId("add-asset").dispatchEvent("click");
   await expect(page.getByTestId("account-view")).toContainText("E2E");
 });
-test("Adding Soroban verified token", async ({ page, extensionId }) => {
+test.only("Adding Soroban verified token", async ({ page, extensionId }) => {
   test.slow();
   await loginToTestAccount({ page, extensionId });
 
@@ -44,9 +44,7 @@ test("Adding Soroban verified token", async ({ page, extensionId }) => {
   await page.getByText("Add an asset").click({ force: true });
   await page.getByText("Add manually").click({ force: true });
   await page.getByTestId("search-token-input").fill(USDC_TOKEN_ADDRESS);
-  await expect(page.getByTestId("asset-notification")).toHaveText(
-    "On your listsFreighter uses asset lists to check assets you interact with. You can define your own assets lists in Settings.",
-  );
+  await expect(page.getByTestId("asset-on-list")).toHaveText("On your lists");
   await expect(page.getByTestId("ManageAssetCode")).toHaveText("USDC");
   await expect(page.getByTestId("ManageAssetRowButton")).toHaveText("Add");
   await page.getByTestId("ManageAssetRowButton").click({ force: true });

--- a/extension/e2e-tests/addAsset.test.ts
+++ b/extension/e2e-tests/addAsset.test.ts
@@ -33,7 +33,7 @@ test("Adding unverified Soroban token", async ({ page, extensionId }) => {
   await page.getByTestId("add-asset").dispatchEvent("click");
   await expect(page.getByTestId("account-view")).toContainText("E2E");
 });
-test.only("Adding Soroban verified token", async ({ page, extensionId }) => {
+test("Adding Soroban verified token", async ({ page, extensionId }) => {
   test.slow();
   await loginToTestAccount({ page, extensionId });
 

--- a/extension/src/background/helpers/__tests__/migrations.test.ts
+++ b/extension/src/background/helpers/__tests__/migrations.test.ts
@@ -16,7 +16,7 @@ import {
 } from "constants/localStorageTypes";
 import * as DataStorage from "../dataStorage";
 import * as DataStorageAccess from "../dataStorageAccess";
-import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/token";
+import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/asset-list";
 
 class MockStorage {
   storage: Record<string, any>;

--- a/extension/src/background/helpers/account.ts
+++ b/extension/src/background/helpers/account.ts
@@ -15,7 +15,7 @@ import {
   LAST_USED_ACCOUNT,
 } from "constants/localStorageTypes";
 import { DEFAULT_NETWORKS, NetworkDetails } from "@shared/constants/stellar";
-import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/token";
+import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/asset-list";
 import { getSorobanRpcUrl } from "@shared/helpers/soroban/sorobanRpcUrl";
 import { isCustomNetwork } from "@shared/helpers/stellar";
 import { decodeString, encodeObject } from "helpers/urls";

--- a/extension/src/background/helpers/dataStorage.ts
+++ b/extension/src/background/helpers/dataStorage.ts
@@ -22,7 +22,7 @@ import {
   FUTURENET_NETWORK_DETAILS,
   SOROBAN_RPC_URLS,
 } from "@shared/constants/stellar";
-import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/token";
+import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/asset-list";
 import { dataStorageAccess, browserLocalStorage } from "./dataStorageAccess";
 
 // Session Storage Feature Flag - turn on when storage.session is supported

--- a/extension/src/background/messageListener/popupMessageListener.ts
+++ b/extension/src/background/messageListener/popupMessageListener.ts
@@ -126,7 +126,7 @@ import { STELLAR_EXPERT_MEMO_REQUIRED_ACCOUNTS_URL } from "background/constants/
 import {
   AssetsListKey,
   DEFAULT_ASSETS_LISTS,
-} from "@shared/constants/soroban/token";
+} from "@shared/constants/soroban/asset-list";
 import { getSdk } from "@shared/helpers/stellar";
 import { captureException } from "@sentry/browser";
 

--- a/extension/src/popup/components/manageAssets/AddAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/AddAsset/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import React, { useEffect, useCallback, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import { Networks, StellarToml, StrKey } from "stellar-sdk";
@@ -10,11 +9,14 @@ import { stellarSdkServer } from "@shared/api/helpers/stellarSdkServer";
 import { isSacContractExecutable } from "@shared/helpers/soroban/token";
 
 import { FormRows } from "popup/basics/Forms";
-import { settingsNetworkDetailsSelector, settingsSelector } from "popup/ducks/settings";
+import {
+  settingsNetworkDetailsSelector,
+  settingsSelector,
+} from "popup/ducks/settings";
 import { isMainnet, isTestnet } from "helpers/stellar";
 import { getNativeContractDetails } from "popup/helpers/searchAsset";
 import {
-  getAssetListForAsset,
+  getAssetListsForAsset,
   splitVerifiedAssetCurrency,
 } from "popup/helpers/assetList";
 import { isContractId } from "popup/helpers/soroban";
@@ -151,7 +153,7 @@ export const AddAsset = () => {
         setVerifiedAssetRows(verifiedAssets);
         setUnverifiedAssetRows(unverifiedAssets);
 
-        const assetListsForToken = await getAssetListForAsset({
+        const assetListsForToken = await getAssetListsForAsset({
           asset: token,
           assetsListsDetails: assetsLists,
           networkDetails,
@@ -216,7 +218,7 @@ export const AddAsset = () => {
               isSuspicious: isAssetSuspicious(
                 scannedAssets.results[`${record.code}-${record.issuer}`],
               ),
-            } as ManageAssetCurrency),
+            }) as ManageAssetCurrency,
         );
 
         const { verifiedAssets, unverifiedAssets } =

--- a/extension/src/popup/components/manageAssets/AddAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/AddAsset/index.tsx
@@ -18,8 +18,12 @@ import {
   splitVerifiedAssetCurrency,
 } from "popup/helpers/searchAsset";
 import { isContractId } from "popup/helpers/soroban";
-import { isAssetSuspicious, scanAsset, scanAssetBulk } from "popup/helpers/blockaid";
-import { AssetNotifcation } from "popup/components/AssetNotification";
+import {
+  isAssetSuspicious,
+  scanAsset,
+  scanAssetBulk,
+} from "popup/helpers/blockaid";
+
 import { SubviewHeader } from "popup/components/SubviewHeader";
 import { View } from "popup/basics/layout/View";
 import { publicKeySelector } from "popup/ducks/accountServices";
@@ -257,7 +261,7 @@ export const AddAsset = () => {
     setIsVerificationInfoShowing(isAllowListVerificationEnabled);
   }, [isAllowListVerificationEnabled]);
 
-  const hasAssets = verifiedAssetRows.length && unverifiedAssetRows.length;
+  const hasAssets = verifiedAssetRows.length || unverifiedAssetRows.length;
 
   return (
     <Formik initialValues={initialValues} onSubmit={() => {}}>
@@ -295,10 +299,6 @@ export const AddAsset = () => {
                   isSearching={isSearching}
                   resultsRef={ResultsRef}
                 >
-                  {hasAssets && isVerificationInfoShowing ? (
-                    <AssetNotifcation isVerified={isVerifiedToken} />
-                  ) : null}
-
                   {hasAssets ? (
                     <ManageAssetRows
                       header={null}

--- a/extension/src/popup/components/manageAssets/AddAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/AddAsset/index.tsx
@@ -13,6 +13,7 @@ import { FormRows } from "popup/basics/Forms";
 import { settingsNetworkDetailsSelector, settingsSelector } from "popup/ducks/settings";
 import { isMainnet, isTestnet } from "helpers/stellar";
 import {
+  getAssetListForAsset,
   getNativeContractDetails,
   splitVerifiedAssetCurrency,
 } from "popup/helpers/searchAsset";
@@ -56,7 +57,7 @@ export const AddAsset = () => {
   const [isVerifiedToken, setIsVerifiedToken] = useState(false);
   const [isVerificationInfoShowing, setIsVerificationInfoShowing] =
     useState(false);
-  const [verifiedLists] = useState([] as string[]);
+  const [verifiedLists, setVerifiedLists] = useState([] as string[]);
   const { assetsLists } = useSelector(settingsSelector);
 
   const ResultsRef = useRef<HTMLDivElement>(null);
@@ -145,9 +146,16 @@ export const AddAsset = () => {
           });
         setVerifiedAssetRows(verifiedAssets);
         setUnverifiedAssetRows(unverifiedAssets);
-        // whats this?
-        // setIsVerifiedToken(true);
-        // setVerifiedLists(verifiedTokens[0].verifiedLists);
+
+        const assetListsForToken = await getAssetListForAsset({
+          asset: token,
+          assetsListsDetails: assetsLists,
+          networkDetails,
+        });
+        setVerifiedLists(assetListsForToken);
+        if (assetListsForToken.length) {
+          setIsVerifiedToken(true);
+        }
       }
     } else {
       // Futurenet token lookup

--- a/extension/src/popup/components/manageAssets/AddAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/AddAsset/index.tsx
@@ -1,21 +1,27 @@
-import { Formik, Form, Field, FieldProps } from "formik";
-import debounce from "lodash/debounce";
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
 import React, { useEffect, useCallback, useRef, useState } from "react";
 import { useSelector } from "react-redux";
-import { useTranslation } from "react-i18next";
 import { Networks, StellarToml, StrKey } from "stellar-sdk";
-
+import { Formik, Form, Field, FieldProps } from "formik";
+import debounce from "lodash/debounce";
+import { useTranslation } from "react-i18next";
+import { getTokenDetails } from "@shared/api/internal";
 import { stellarSdkServer } from "@shared/api/helpers/stellarSdkServer";
+import { isSacContractExecutable } from "@shared/helpers/soroban/token";
 
 import { FormRows } from "popup/basics/Forms";
-import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
+import { settingsNetworkDetailsSelector, settingsSelector } from "popup/ducks/settings";
 import { isMainnet, isTestnet } from "helpers/stellar";
+import {
+  getNativeContractDetails,
+  splitVerifiedAssetCurrency,
+} from "popup/helpers/searchAsset";
 import { isContractId } from "popup/helpers/soroban";
-import { isAssetSuspicious, scanAssetBulk } from "popup/helpers/blockaid";
-import { useTokenLookup } from "popup/helpers/useTokenLookup";
+import { isAssetSuspicious, scanAsset, scanAssetBulk } from "popup/helpers/blockaid";
 import { AssetNotifcation } from "popup/components/AssetNotification";
 import { SubviewHeader } from "popup/components/SubviewHeader";
 import { View } from "popup/basics/layout/View";
+import { publicKeySelector } from "popup/ducks/accountServices";
 
 import { ManageAssetRows, ManageAssetCurrency } from "../ManageAssetRows";
 import { SearchInput, SearchCopy, SearchResults } from "../AssetResults";
@@ -37,26 +43,120 @@ interface AssetDomainToml {
 
 export const AddAsset = () => {
   const { t } = useTranslation();
+  const publicKey = useSelector(publicKeySelector);
   const networkDetails = useSelector(settingsNetworkDetailsSelector);
-  const [assetRows, setAssetRows] = useState([] as ManageAssetCurrency[]);
+  const [verifiedAssetRows, setVerifiedAssetRows] = useState(
+    [] as ManageAssetCurrency[],
+  );
+  const [unverifiedAssetRows, setUnverifiedAssetRows] = useState(
+    [] as ManageAssetCurrency[],
+  );
   const [isSearching, setIsSearching] = useState(false);
   const [hasNoResults, setHasNoResults] = useState(false);
   const [isVerifiedToken, setIsVerifiedToken] = useState(false);
   const [isVerificationInfoShowing, setIsVerificationInfoShowing] =
     useState(false);
-  const [verifiedLists, setVerifiedLists] = useState([] as string[]);
+  const [verifiedLists] = useState([] as string[]);
+  const { assetsLists } = useSelector(settingsSelector);
 
   const ResultsRef = useRef<HTMLDivElement>(null);
   const isAllowListVerificationEnabled =
     isMainnet(networkDetails) || isTestnet(networkDetails);
 
-  const { handleTokenLookup } = useTokenLookup({
-    setAssetRows,
-    setIsSearching,
-    setIsVerifiedToken,
-    setIsVerificationInfoShowing,
-    setVerifiedLists,
-  });
+  const handleTokenLookup = async (contractId: string) => {
+    // clear the UI while we work through the flow
+    setIsSearching(true);
+    setIsVerifiedToken(false);
+    setIsVerificationInfoShowing(false);
+    setVerifiedAssetRows([]);
+    setUnverifiedAssetRows([]);
+
+    const nativeContractDetails = getNativeContractDetails(networkDetails);
+
+    // step around verification for native contract and unverifiable networks
+
+    if (nativeContractDetails.contract === contractId) {
+      // override our rules for verification for XLM
+      setIsVerificationInfoShowing(false);
+      setVerifiedAssetRows([
+        {
+          code: nativeContractDetails.code,
+          issuer: contractId,
+          domain: nativeContractDetails.domain,
+        },
+      ]);
+      setIsSearching(false);
+      return;
+    }
+
+    const tokenLookup = async () => {
+      // lookup contract
+      setIsVerifiedToken(false);
+      let tokenDetailsResponse;
+
+      try {
+        tokenDetailsResponse = await getTokenDetails({
+          contractId,
+          publicKey,
+          networkDetails,
+        });
+      } catch (e) {
+        setVerifiedAssetRows([]);
+        setUnverifiedAssetRows([]);
+      }
+
+      const isSacContract = await isSacContractExecutable(
+        contractId,
+        networkDetails,
+      );
+
+      if (!tokenDetailsResponse) {
+        setVerifiedAssetRows([]);
+        setUnverifiedAssetRows([]);
+        return null;
+      }
+
+      const issuer = isSacContract
+        ? tokenDetailsResponse.name.split(":")[1] || ""
+        : contractId; // get the issuer name, if applicable ,
+      const scannedAsset = await scanAsset(
+        `${tokenDetailsResponse.symbol}-${issuer}`,
+        networkDetails,
+      );
+      return {
+        code: tokenDetailsResponse.symbol,
+        contract: contractId,
+        issuer,
+        domain: "",
+        name: tokenDetailsResponse.name,
+        isSuspicious: isAssetSuspicious(scannedAsset),
+      } as ManageAssetCurrency;
+    };
+
+    if (isAllowListVerificationEnabled) {
+      // usual binary case of a token being verified or unverified
+      const token = await tokenLookup();
+      if (token) {
+        const { verifiedAssets, unverifiedAssets } =
+          await splitVerifiedAssetCurrency({
+            networkDetails,
+            assets: [token],
+            assetsListsDetails: assetsLists,
+          });
+        setVerifiedAssetRows(verifiedAssets);
+        setUnverifiedAssetRows(unverifiedAssets);
+        // whats this?
+        // setIsVerifiedToken(true);
+        // setVerifiedLists(verifiedTokens[0].verifiedLists);
+      }
+    } else {
+      // Futurenet token lookup
+      const token = await tokenLookup();
+      setUnverifiedAssetRows(token ? [token] : []);
+    }
+    setIsSearching(false);
+    setIsVerificationInfoShowing(isAllowListVerificationEnabled);
+  };
 
   const handleIssuerLookup = async (issuer: string) => {
     let assetDomainToml = {} as AssetDomainToml;
@@ -76,7 +176,8 @@ export const AddAsset = () => {
     }
 
     if (!assetDomainToml.CURRENCIES) {
-      setAssetRows([]);
+      setVerifiedAssetRows([]);
+      setUnverifiedAssetRows([]);
     } else {
       const { networkPassphrase } = networkDetails;
 
@@ -96,19 +197,30 @@ export const AddAsset = () => {
           assetsToScan.push(`${currency.code}-${currency.issuer}`);
         });
         const scannedAssets = await scanAssetBulk(assetsToScan, networkDetails);
-        const scannedAssetRows = assetRecords.map((record: AssetRecord) => ({
-          ...record,
-          isSuspicious: isAssetSuspicious(
-            scannedAssets.results[`${record.code}-${record.issuer}`],
-          ),
-        }));
+        const scannedAssetRows = assetRecords.map(
+          (record: AssetRecord) =>
+            ({
+              ...record,
+              isSuspicious: isAssetSuspicious(
+                scannedAssets.results[`${record.code}-${record.issuer}`],
+              ),
+            } as ManageAssetCurrency),
+        );
 
-        setAssetRows(scannedAssetRows);
+        const { verifiedAssets, unverifiedAssets } =
+          await splitVerifiedAssetCurrency({
+            networkDetails,
+            assets: scannedAssetRows,
+            assetsListsDetails: assetsLists,
+          });
+        setVerifiedAssetRows(verifiedAssets);
+        setUnverifiedAssetRows(unverifiedAssets);
         // no need for verification on classic assets
         setIsVerificationInfoShowing(false);
       } else {
         // otherwise, discount all found results
-        setAssetRows([]);
+        setVerifiedAssetRows([]);
+        setUnverifiedAssetRows([]);
       }
     }
     setIsSearching(false);
@@ -122,15 +234,16 @@ export const AddAsset = () => {
       } else if (StrKey.isValidEd25519PublicKey(contractId)) {
         await handleIssuerLookup(contractId);
       } else {
-        setAssetRows([]);
+        setVerifiedAssetRows([]);
+        setUnverifiedAssetRows([]);
       }
     }, 500),
     [],
   );
 
   useEffect(() => {
-    setHasNoResults(!assetRows.length);
-  }, [assetRows]);
+    setHasNoResults(!verifiedAssetRows.length && !unverifiedAssetRows.length);
+  }, [verifiedAssetRows, unverifiedAssetRows]);
 
   useEffect(() => {
     setIsVerificationInfoShowing(isAllowListVerificationEnabled);
@@ -172,14 +285,17 @@ export const AddAsset = () => {
                   isSearching={isSearching}
                   resultsRef={ResultsRef}
                 >
-                  {assetRows.length && isVerificationInfoShowing ? (
+                  {verifiedAssetRows.length &&
+                  unverifiedAssetRows.length &&
+                  isVerificationInfoShowing ? (
                     <AssetNotifcation isVerified={isVerifiedToken} />
                   ) : null}
 
-                  {assetRows.length ? (
+                  {verifiedAssetRows.length && unverifiedAssetRows.length ? (
                     <ManageAssetRows
                       header={null}
-                      assetRows={assetRows}
+                      verifiedAssetRows={verifiedAssetRows}
+                      unverifiedAssetRows={unverifiedAssetRows}
                       isVerifiedToken={isVerifiedToken}
                       isVerificationInfoShowing={isVerificationInfoShowing}
                       verifiedLists={verifiedLists}

--- a/extension/src/popup/components/manageAssets/AddAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/AddAsset/index.tsx
@@ -257,6 +257,8 @@ export const AddAsset = () => {
     setIsVerificationInfoShowing(isAllowListVerificationEnabled);
   }, [isAllowListVerificationEnabled]);
 
+  const hasAssets = verifiedAssetRows.length && unverifiedAssetRows.length;
+
   return (
     <Formik initialValues={initialValues} onSubmit={() => {}}>
       {({ dirty }) => (
@@ -293,13 +295,11 @@ export const AddAsset = () => {
                   isSearching={isSearching}
                   resultsRef={ResultsRef}
                 >
-                  {verifiedAssetRows.length &&
-                  unverifiedAssetRows.length &&
-                  isVerificationInfoShowing ? (
+                  {hasAssets && isVerificationInfoShowing ? (
                     <AssetNotifcation isVerified={isVerifiedToken} />
                   ) : null}
 
-                  {verifiedAssetRows.length && unverifiedAssetRows.length ? (
+                  {hasAssets ? (
                     <ManageAssetRows
                       header={null}
                       verifiedAssetRows={verifiedAssetRows}

--- a/extension/src/popup/components/manageAssets/AddAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/AddAsset/index.tsx
@@ -12,11 +12,11 @@ import { isSacContractExecutable } from "@shared/helpers/soroban/token";
 import { FormRows } from "popup/basics/Forms";
 import { settingsNetworkDetailsSelector, settingsSelector } from "popup/ducks/settings";
 import { isMainnet, isTestnet } from "helpers/stellar";
+import { getNativeContractDetails } from "popup/helpers/searchAsset";
 import {
   getAssetListForAsset,
-  getNativeContractDetails,
   splitVerifiedAssetCurrency,
-} from "popup/helpers/searchAsset";
+} from "popup/helpers/assetList";
 import { isContractId } from "popup/helpers/soroban";
 import {
   isAssetSuspicious,

--- a/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
@@ -184,6 +184,7 @@ export const ChooseAsset = ({ balances }: ChooseAssetProps) => {
               >
                 {isManagingAssets ? (
                   <ManageAssetRows
+                    shouldSplitAssetsByVerificationStatus={false}
                     verifiedAssetRows={assetRows}
                     unverifiedAssetRows={[]}
                   />

--- a/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
@@ -183,7 +183,10 @@ export const ChooseAsset = ({ balances }: ChooseAssetProps) => {
                 ref={ManageAssetRowsWrapperRef}
               >
                 {isManagingAssets ? (
-                  <ManageAssetRows assetRows={assetRows} />
+                  <ManageAssetRows
+                    verifiedAssetRows={assetRows}
+                    unverifiedAssetRows={[]}
+                  />
                 ) : (
                   <SelectAssetRows assetRows={assetRows} />
                 )}

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Networks, StellarToml } from "stellar-sdk";
 import { useDispatch, useSelector } from "react-redux";
 import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
 import {
   AccountBalancesInterface,
   ActionStatus,
@@ -294,6 +295,7 @@ const AssetRows = ({
     isSuspicious?: boolean;
   }) => React.ReactNode;
 }) => {
+  const { t } = useTranslation();
   if (shouldSplitAssetsByVerificationStatus) {
     return (
       <>
@@ -301,8 +303,10 @@ const AssetRows = ({
           <InfoTooltip
             infoText={
               <span>
-                Freighter uses asset lists to verify assets before interactions.
-                You can define your own assets lists in Settings.
+                {t(
+                  "Freighter uses asset lists to verify assets before interactions.",
+                )}
+                {t("You can define your own assets lists in Settings.")}
               </span>
             }
             placement="bottom-start"
@@ -358,8 +362,9 @@ const AssetRows = ({
           <InfoTooltip
             infoText={
               <span>
-                These assets are not on any of your lists. Proceed with caution
-                before adding.
+                {t(
+                  "These assets are not on any of your lists. Proceed with caution before adding.",
+                )}
               </span>
             }
             placement="bottom-start"

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
@@ -466,7 +466,8 @@ export const ManageAssetRow = ({
   isSuspicious = false,
 }: AssetRowData) => {
   const canonicalAsset = getCanonicalFromAsset(code, issuer);
-  const assetCode = name || code;
+  // use the name unless the name is SAC format "code:issuer"
+  const assetCode = name && !name.includes(":") ? name : code;
   const truncatedAssetCode =
     assetCode.length > 20 ? truncateString(assetCode) : assetCode;
 

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
@@ -304,7 +304,12 @@ const AssetRows = ({
             }
             placement="bottom-start"
           >
-            <h5 className="ManageAssetRows__tooltip">On your lists</h5>
+            <h5
+              className="ManageAssetRows__tooltip"
+              data-testid="asset-on-list"
+            >
+              On your lists
+            </h5>
           </InfoTooltip>
         )}
         {verifiedAssetRows.map(
@@ -356,7 +361,12 @@ const AssetRows = ({
             }
             placement="bottom-start"
           >
-            <h5 className="ManageAssetRows__tooltip">Not on your lists</h5>
+            <h5
+              className="ManageAssetRows__tooltip"
+              data-testid="not-asset-on-list"
+            >
+              Not on your lists
+            </h5>
           </InfoTooltip>
         )}
         {unverifiedAssetRows.map(

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
@@ -78,6 +78,7 @@ export const ManageAssetRows = ({
   isVerificationInfoShowing,
   verifiedLists,
 }: ManageAssetRowsProps) => {
+  console.log(assetRows);
   const {
     accountBalances,
     submitStatus,

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
@@ -294,17 +294,19 @@ const AssetRows = ({
   if (shouldSplitAssetsByVerificationStatus) {
     return (
       <>
-        <InfoTooltip
-          infoText={
-            <span>
-              Freighter uses asset lists to verify assets before interactions.
-              You can define your own assets lists in Settings.
-            </span>
-          }
-          placement="bottom-start"
-        >
-          <h5 className="ManageAssetRows__tooltip">On your lists</h5>
-        </InfoTooltip>
+        {verifiedAssetRows.length > 0 && (
+          <InfoTooltip
+            infoText={
+              <span>
+                Freighter uses asset lists to verify assets before interactions.
+                You can define your own assets lists in Settings.
+              </span>
+            }
+            placement="bottom-start"
+          >
+            <h5 className="ManageAssetRows__tooltip">On your lists</h5>
+          </InfoTooltip>
+        )}
         {verifiedAssetRows.map(
           ({
             code = "",
@@ -344,17 +346,19 @@ const AssetRows = ({
             );
           },
         )}
-        <InfoTooltip
-          infoText={
-            <span>
-              These assets are not on any of your lists. Proceed with caution
-              before adding.
-            </span>
-          }
-          placement="bottom-start"
-        >
-          <h5 className="ManageAssetRows__tooltip">Not on your lists</h5>
-        </InfoTooltip>
+        {unverifiedAssetRows.length > 0 && (
+          <InfoTooltip
+            infoText={
+              <span>
+                These assets are not on any of your lists. Proceed with caution
+                before adding.
+              </span>
+            }
+            placement="bottom-start"
+          >
+            <h5 className="ManageAssetRows__tooltip">Not on your lists</h5>
+          </InfoTooltip>
+        )}
         {unverifiedAssetRows.map(
           ({
             code = "",

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
@@ -55,7 +55,6 @@ export interface NewAssetFlags {
 interface ManageAssetRowsProps {
   children?: React.ReactNode;
   header?: React.ReactNode;
-  // assetRows: ManageAssetCurrency[];
   verifiedAssetRows: ManageAssetCurrency[];
   unverifiedAssetRows: ManageAssetCurrency[];
   isVerifiedToken?: boolean;

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
@@ -55,7 +55,9 @@ export interface NewAssetFlags {
 interface ManageAssetRowsProps {
   children?: React.ReactNode;
   header?: React.ReactNode;
-  assetRows: ManageAssetCurrency[];
+  // assetRows: ManageAssetCurrency[];
+  verifiedAssetRows: ManageAssetCurrency[];
+  unverifiedAssetRows: ManageAssetCurrency[];
   isVerifiedToken?: boolean;
   isVerificationInfoShowing?: boolean;
   verifiedLists?: string[];
@@ -73,12 +75,12 @@ interface SuspiciousAssetData {
 export const ManageAssetRows = ({
   children,
   header,
-  assetRows,
+  verifiedAssetRows,
+  unverifiedAssetRows,
   isVerifiedToken,
   isVerificationInfoShowing,
   verifiedLists,
 }: ManageAssetRowsProps) => {
-  console.log(assetRows);
   const {
     accountBalances,
     submitStatus,
@@ -173,7 +175,69 @@ export const ManageAssetRows = ({
       <div className="ManageAssetRows__scrollbar">
         {header}
         <div className="ManageAssetRows__content">
-          {assetRows.map(
+          <h5>On your list</h5>
+          {verifiedAssetRows.map(
+            ({
+              code = "",
+              domain,
+              image = "",
+              issuer = "",
+              name = "",
+              contract = "",
+              isSuspicious,
+            }) => {
+              if (!accountBalances.balances) {
+                return null;
+              }
+              const isContract = isContractId(contract);
+              const canonicalAsset = getCanonicalFromAsset(code, issuer);
+              const isTrustlineActive = Object.keys(
+                accountBalances.balances,
+              ).some((balance) => balance === canonicalAsset);
+              const isActionPending =
+                submitStatus === ActionStatus.PENDING ||
+                accountBalanceStatus === ActionStatus.PENDING;
+              return (
+                <div
+                  className="ManageAssetRows__row"
+                  key={canonicalAsset}
+                  data-testid="ManageAssetRow"
+                >
+                  <ManageAssetRow
+                    code={code}
+                    issuer={issuer}
+                    image={image}
+                    domain={domain}
+                    name={name}
+                    isSuspicious={isSuspicious}
+                  />
+                  <ManageAssetRowButton
+                    code={code}
+                    contract={contract}
+                    issuer={issuer}
+                    image={image}
+                    domain={domain}
+                    isTrustlineActive={isTrustlineActive}
+                    isActionPending={isActionPending}
+                    isContract={isContract}
+                    isVerifiedToken={!!isVerifiedToken}
+                    isVerificationInfoShowing={!!isVerificationInfoShowing}
+                    setNewAssetFlags={setNewAssetFlags}
+                    setSuspiciousAssetData={setSuspiciousAssetData}
+                    setHandleAddToken={setHandleAddToken}
+                    setShowBlockedDomainWarning={setShowBlockedDomainWarning}
+                    assetSubmitting={assetSubmitting}
+                    setAssetSubmitting={setAssetSubmitting}
+                    setShowNewAssetWarning={setShowNewAssetWarning}
+                    setShowUnverifiedWarning={setShowUnverifiedWarning}
+                    recommendedFee={recommendedFee}
+                  />
+                </div>
+              );
+            },
+          )}
+          <h5>Not on your list</h5>
+          {unverifiedAssetRows.map(
             ({
               code = "",
               domain,

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/styles.scss
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/styles.scss
@@ -64,4 +64,10 @@
     font-size: var(--sds-fs-secondary);
     line-height: 1.375rem;
   }
+
+  &__tooltip {
+    color: var(--sds-clr-gray-11);
+    font-size: 14px;
+    font-weight: 500;
+  }
 }

--- a/extension/src/popup/components/manageAssets/SearchAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/SearchAsset/index.tsx
@@ -17,7 +17,7 @@ import {
   settingsSelector,
 } from "popup/ducks/settings";
 import { searchAsset } from "popup/helpers/searchAsset";
-import { splitVerifiedAssetCurrency } from "popup/helpers/searchAsset";
+import { splitVerifiedAssetCurrency } from "popup/helpers/assetList";
 import { isMainnet } from "helpers/stellar";
 import { isAssetSuspicious } from "popup/helpers/blockaid";
 

--- a/extension/src/popup/components/manageAssetsLists/AssetLists/index.tsx
+++ b/extension/src/popup/components/manageAssetsLists/AssetLists/index.tsx
@@ -7,7 +7,7 @@ import { ListNavLink, ListNavLinkWrapper } from "popup/basics/ListNavLink";
 import { ROUTES } from "popup/constants/routes";
 import { navigateTo } from "popup/helpers/navigate";
 import { NETWORKS } from "@shared/constants/stellar";
-import { AssetsListKey } from "@shared/constants/soroban/token";
+import { AssetsListKey } from "@shared/constants/soroban/asset-list";
 
 import { SubviewHeader } from "popup/components/SubviewHeader";
 import { NetworkIcon } from "popup/components/manageNetwork/NetworkIcon";

--- a/extension/src/popup/components/manageAssetsLists/ModifyAssetList/index.tsx
+++ b/extension/src/popup/components/manageAssetsLists/ModifyAssetList/index.tsx
@@ -9,7 +9,8 @@ import { captureException } from "@sentry/browser";
 import {
   DEFAULT_ASSETS_LISTS,
   AssetsListKey,
-} from "@shared/constants/soroban/token";
+  AssetListResponse,
+} from "@shared/constants/soroban/asset-list";
 import { ROUTES } from "popup/constants/routes";
 import { AppDispatch } from "popup/App";
 
@@ -116,7 +117,7 @@ export const ModifyAssetList = ({
       return;
     }
 
-    const resJson = await res.json();
+    const resJson: AssetListResponse = await res.json();
 
     // check against the SEP-0042 schema
     const validatedList = await schemaValidatedAssetList(resJson);

--- a/extension/src/popup/components/manageAssetsLists/ModifyAssetList/index.tsx
+++ b/extension/src/popup/components/manageAssetsLists/ModifyAssetList/index.tsx
@@ -147,7 +147,7 @@ export const ModifyAssetList = ({
         network === "public" ? "Mainnet" : "Testnet";
       setFetchErrorString(
         `The entered asset list belongs to "${getNetworkName(
-          resJson.network as string,
+          resJson.network,
         )}": Currently editing "${getNetworkName(
           selectedNetwork.toLowerCase(),
         )}" lists.`,

--- a/extension/src/popup/ducks/settings.ts
+++ b/extension/src/popup/ducks/settings.ts
@@ -27,7 +27,7 @@ import {
   AssetsListItem,
   AssetsLists,
   DEFAULT_ASSETS_LISTS,
-} from "@shared/constants/soroban/token";
+} from "@shared/constants/soroban/asset-list";
 
 import {
   Settings,

--- a/extension/src/popup/helpers/__tests__/searchAsset.test.js
+++ b/extension/src/popup/helpers/__tests__/searchAsset.test.js
@@ -66,8 +66,10 @@ describe("searchAsset", () => {
     });
   });
   it("schemaValidatedAssetList should return list if valid", async () => {
-    const v = await SearchAsset.schemaValidatedAssetList(validAssetList);
-    expect(v).toStrictEqual(validAssetList);
+    const { assets } = await SearchAsset.schemaValidatedAssetList(
+      validAssetList,
+    );
+    expect(assets).toStrictEqual(validAssetList.assets);
   });
   it("schemaValidatedAssetList should return empty list if schema fetch fails", async () => {
     jest.spyOn(global, "fetch").mockImplementation(() =>
@@ -75,11 +77,13 @@ describe("searchAsset", () => {
         ok: false,
       }),
     );
-    const v = await SearchAsset.schemaValidatedAssetList(validAssetList);
-    expect(v).toStrictEqual({ assets: [] });
+    const { assets } = await SearchAsset.schemaValidatedAssetList(
+      validAssetList,
+    );
+    expect(assets).toStrictEqual([]);
   });
   it("schemaValidatedAssetList should return empty list and errors if validation fails", async () => {
-    const v = await SearchAsset.schemaValidatedAssetList({
+    const { assets, errors } = await SearchAsset.schemaValidatedAssetList({
       // incorrect key
       title: "PiyalBasu Top 50",
 
@@ -101,9 +105,9 @@ describe("searchAsset", () => {
         },
       ],
     });
-    expect(v.assets).toStrictEqual([]);
+    expect(assets).toStrictEqual([]);
 
     // error for missing `name` and error for additional key `title`
-    expect(v.errors).toHaveLength(2);
+    expect(errors).toHaveLength(2);
   });
 });

--- a/extension/src/popup/helpers/assetList.ts
+++ b/extension/src/popup/helpers/assetList.ts
@@ -43,19 +43,19 @@ export const splitVerifiedAssetCurrency = async ({
   const [verifiedAssets, unverifiedAssets] = assets.reduce<
     [typeof assets, typeof assets]
   >(
-    ([inC, notInC], item) => {
+    ([inVerifiedList, notInVerifiedList], item) => {
       if (item.issuer && verifiedIds.has(item.issuer)) {
-        inC.push(item);
-        return [inC, notInC];
+        inVerifiedList.push(item);
+        return [inVerifiedList, notInVerifiedList];
       }
 
       if (item.contract && verifiedIds.has(item.contract)) {
-        inC.push(item);
-        return [inC, notInC];
+        inVerifiedList.push(item);
+        return [inVerifiedList, notInVerifiedList];
       }
 
-      notInC.push(item);
-      return [inC, notInC];
+      notInVerifiedList.push(item);
+      return [inVerifiedList, notInVerifiedList];
     },
     [[], []],
   );

--- a/extension/src/popup/helpers/assetList.ts
+++ b/extension/src/popup/helpers/assetList.ts
@@ -21,9 +21,7 @@ export const splitVerifiedAssetCurrency = async ({
     networkDetails,
   });
 
-  // eslint-disable-next-line no-restricted-syntax
   const validatedAssets = [] as AssetListReponseItem[];
-  // eslint-disable-next-line no-restricted-syntax
   for (const response of settledResponses) {
     if (response.status === "fulfilled") {
       // confirm that this list still adheres to the agreed upon schema
@@ -33,7 +31,6 @@ export const splitVerifiedAssetCurrency = async ({
   }
   // make a unique set of contract IDs and issuers
   const verifiedIds = new Set<string>();
-  // eslint-disable-next-line no-restricted-syntax
   for (const validAsset of validatedAssets) {
     if (!verifiedIds.has(validAsset.contract)) {
       verifiedIds.add(validAsset.contract);
@@ -83,9 +80,7 @@ export const getAssetListsForAsset = async ({
     networkDetails,
   });
 
-  // eslint-disable-next-line no-restricted-syntax
   const validatedAssets = {} as Record<string, AssetListReponseItem[]>;
-  // eslint-disable-next-line no-restricted-syntax
   for (const response of settledResponses) {
     if (response.status === "fulfilled") {
       // confirm that this list still adheres to the agreed upon schema

--- a/extension/src/popup/helpers/assetList.ts
+++ b/extension/src/popup/helpers/assetList.ts
@@ -69,7 +69,7 @@ export const splitVerifiedAssetCurrency = async ({
   };
 };
 
-export const getAssetListForAsset = async ({
+export const getAssetListsForAsset = async ({
   asset,
   assetsListsDetails,
   networkDetails,

--- a/extension/src/popup/helpers/assetList.ts
+++ b/extension/src/popup/helpers/assetList.ts
@@ -1,0 +1,105 @@
+import { NetworkDetails } from "@shared/constants/stellar";
+import {
+  AssetsLists,
+  AssetListReponseItem,
+} from "@shared/constants/soroban/asset-list";
+
+import { ManageAssetCurrency } from "popup/components/manageAssets/ManageAssetRows";
+import { getAssetLists, schemaValidatedAssetList } from "./searchAsset";
+
+export const splitVerifiedAssetCurrency = async ({
+  networkDetails,
+  assets,
+  assetsListsDetails,
+}: {
+  networkDetails: NetworkDetails;
+  assets: ManageAssetCurrency[];
+  assetsListsDetails: AssetsLists;
+}) => {
+  const settledResponses = await getAssetLists({
+    assetsListsDetails,
+    networkDetails,
+  });
+
+  // eslint-disable-next-line no-restricted-syntax
+  const validatedAssets = [] as AssetListReponseItem[];
+  // eslint-disable-next-line no-restricted-syntax
+  for (const responses of settledResponses) {
+    if (responses.status === "fulfilled") {
+      // confirm that this list still adheres to the agreed upon schema
+      const validatedList = await schemaValidatedAssetList(responses.value);
+      validatedAssets.push(...validatedList.assets);
+    }
+  }
+  // make a unique set of contract IDs and issuers
+  const verifiedIds = new Set<string>();
+  // eslint-disable-next-line no-restricted-syntax
+  for (const validAsset of validatedAssets) {
+    if (!verifiedIds.has(validAsset.contract)) {
+      verifiedIds.add(validAsset.contract);
+    }
+    if (!verifiedIds.has(validAsset.issuer)) {
+      verifiedIds.add(validAsset.issuer);
+    }
+  }
+
+  const [verifiedAssets, unverifiedAssets] = assets.reduce<
+    [typeof assets, typeof assets]
+  >(
+    ([inC, notInC], item) => {
+      if (item.issuer && verifiedIds.has(item.issuer)) {
+        inC.push(item);
+        return [inC, notInC];
+      }
+
+      if (item.contract && verifiedIds.has(item.contract)) {
+        inC.push(item);
+        return [inC, notInC];
+      }
+
+      notInC.push(item);
+      return [inC, notInC];
+    },
+    [[], []],
+  );
+
+  return {
+    verifiedAssets,
+    unverifiedAssets,
+  };
+};
+
+export const getAssetListForAsset = async ({
+  asset,
+  assetsListsDetails,
+  networkDetails,
+}: {
+  asset: ManageAssetCurrency;
+  assetsListsDetails: AssetsLists;
+  networkDetails: NetworkDetails;
+}) => {
+  const settledResponses = await getAssetLists({
+    assetsListsDetails,
+    networkDetails,
+  });
+
+  // eslint-disable-next-line no-restricted-syntax
+  const validatedAssets = {} as Record<string, AssetListReponseItem[]>;
+  // eslint-disable-next-line no-restricted-syntax
+  for (const responses of settledResponses) {
+    if (responses.status === "fulfilled") {
+      // confirm that this list still adheres to the agreed upon schema
+      const validatedList = await schemaValidatedAssetList(responses.value);
+      validatedAssets[responses.value.name] = validatedList.assets;
+    }
+  }
+
+  return Object.entries(validatedAssets)
+    .filter(([_, items]) =>
+      items.some(
+        ({ issuer, contract }) =>
+          asset.issuer === issuer || asset.contract === contract,
+      ),
+    )
+    .map(([name]) => name);
+};

--- a/extension/src/popup/helpers/assetList.ts
+++ b/extension/src/popup/helpers/assetList.ts
@@ -24,10 +24,10 @@ export const splitVerifiedAssetCurrency = async ({
   // eslint-disable-next-line no-restricted-syntax
   const validatedAssets = [] as AssetListReponseItem[];
   // eslint-disable-next-line no-restricted-syntax
-  for (const responses of settledResponses) {
-    if (responses.status === "fulfilled") {
+  for (const response of settledResponses) {
+    if (response.status === "fulfilled") {
       // confirm that this list still adheres to the agreed upon schema
-      const validatedList = await schemaValidatedAssetList(responses.value);
+      const validatedList = await schemaValidatedAssetList(response.value);
       validatedAssets.push(...validatedList.assets);
     }
   }

--- a/extension/src/popup/helpers/assetList.ts
+++ b/extension/src/popup/helpers/assetList.ts
@@ -86,11 +86,11 @@ export const getAssetListForAsset = async ({
   // eslint-disable-next-line no-restricted-syntax
   const validatedAssets = {} as Record<string, AssetListReponseItem[]>;
   // eslint-disable-next-line no-restricted-syntax
-  for (const responses of settledResponses) {
-    if (responses.status === "fulfilled") {
+  for (const response of settledResponses) {
+    if (response.status === "fulfilled") {
       // confirm that this list still adheres to the agreed upon schema
-      const validatedList = await schemaValidatedAssetList(responses.value);
-      validatedAssets[responses.value.name] = validatedList.assets;
+      const validatedList = await schemaValidatedAssetList(response.value);
+      validatedAssets[response.value.name] = validatedList.assets;
     }
   }
 

--- a/extension/src/popup/helpers/searchAsset.ts
+++ b/extension/src/popup/helpers/searchAsset.ts
@@ -238,7 +238,7 @@ export const splitVerifiedAssetCurrency = async ({
     if (responses.status === "fulfilled") {
       // confirm that this list still adheres to the agreed upon schema
       const validatedList = await schemaValidatedAssetList(responses.value);
-      validatedAssets.concat(validatedList.assets);
+      validatedAssets.push(...validatedList.assets);
     }
   }
   // make a unique set of contract IDs and issuers

--- a/extension/src/popup/helpers/searchAsset.ts
+++ b/extension/src/popup/helpers/searchAsset.ts
@@ -113,7 +113,6 @@ export const getAssetLists = async ({
     assetsListsDetails[network as AssetsListKey];
 
   const assetListsResponses = [] as AssetListResponse[];
-  // eslint-disable-next-line no-restricted-syntax
   for (const networkList of assetsListsDetailsByNetwork) {
     const { url, isEnabled } = networkList;
 
@@ -189,13 +188,11 @@ export const getVerifiedTokens = async ({
     }
   }
 
-  const promiseRes = await Promise.allSettled<Promise<AssetListResponse>>(
-    promiseArr,
-  );
+  const promiseRes =
+    await Promise.allSettled<Promise<AssetListResponse>>(promiseArr);
 
   const verifiedTokens = [] as VerifiedTokenRecord[];
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   let verifiedToken = {} as AssetListReponseItem;
   const verifiedLists: string[] = [];
 

--- a/extension/src/popup/helpers/soroban.ts
+++ b/extension/src/popup/helpers/soroban.ts
@@ -25,6 +25,7 @@ import {
   SorobanTokenInterface,
   TokenInvocationArgs,
 } from "@shared/constants/soroban/token";
+import { getSdk } from "@shared/helpers/stellar";
 
 export const SOROBAN_OPERATION_TYPES = [
   "invoke_host_function",
@@ -550,4 +551,25 @@ export const getCreateContractArgs = (hostFn: xdr.HostFunction) => {
     executable: argsV2.executable(),
     constructorArgs: argsV2.constructorArgs(),
   };
+};
+
+export const isSacContract = (
+  name: string,
+  contractId: string,
+  networkPassphrase: string,
+) => {
+  const Sdk = getSdk(networkPassphrase);
+  if (name.includes(":")) {
+    try {
+      return (
+        new Sdk.Asset(...(name.split(":") as [string, string])).contractId(
+          networkPassphrase,
+        ) === contractId
+      );
+    } catch (error) {
+      return false;
+    }
+  }
+
+  return false;
 };

--- a/extension/src/popup/locales/en/translation.json
+++ b/extension/src/popup/locales/en/translation.json
@@ -26,6 +26,7 @@
   "Add network": "Add network",
   "Add new list": "Add new list",
   "Add XLM": "Add XLM",
+  "Adding this token is not possible at the moment": "Adding this token is not possible at the moment.",
   "Address": "Address",
   "Addresses are uppercase and begin with letters “G“, “M“, or “C“": "Addresses are uppercase and begin with letters “G“, “M“, or “C“.",
   "Advanced settings": "Advanced settings",
@@ -54,6 +55,7 @@
   "Approve": "Approve",
   "Approve and continue": "Approve and continue",
   "Approve and review next": "Approve and review next",
+  "Approve Token": "Approve Token",
   "Approve using": "Approve using",
   "are required to add a new asset": "are required to add a new asset.",
   "Are you sure you want to delete this list?": "Are you sure you want to delete this list?",
@@ -66,6 +68,7 @@
   "Asset B": "Asset B",
   "Asset Code": "Asset Code",
   "Asset home domain doesn’t exist, TOML file format is invalid, or asset doesn't match currency description": "Asset home domain doesn’t exist, TOML file format is invalid, or asset doesn't match currency description",
+  "Asset info": "Asset info",
   "Asset Info": "Asset Info",
   "Asset lists": "Asset lists",
   "Asset not found": "Asset not found",
@@ -77,6 +80,7 @@
   "available": "available",
   "Back": "Back",
   "Balance ID": "Balance ID",
+  "Balance Info": "Balance Info",
   "Before we start with migration, please read": "Before we start with migration, please read",
   "Before You Add This Asset": "Before You Add This Asset",
   "Bump To": "Bump To",
@@ -188,6 +192,7 @@
   "Freighter uses asset lists to check assets you interact with": {
     " You can define your own assets lists in Settings": "Freighter uses asset lists to check assets you interact with. You can define your own assets lists in Settings."
   },
+  "Freighter uses asset lists to verify assets before interactions": "Freighter uses asset lists to verify assets before interactions.",
   "Friendbot URL": "Friendbot URL",
   "From": "From",
   "Function Name": "Function Name",
@@ -430,6 +435,7 @@
   "swapped": "swapped",
   "Swapped": "Swapped",
   "Switch to this network": "Switch to this network",
+  "Symbol": "Symbol",
   "Terms of Service": "Terms of Service",
   "Terms of Use": "Terms of Use",
   "The application is requesting a specific account": "The application is requesting a specific account",
@@ -442,11 +448,15 @@
   "The final amount is approximate and may change": "The final amount is approximate and may change",
   "The requester expects you to sign this auth entry on": "The requester expects you to sign this auth entry on",
   "The requester expects you to sign this message on": "The requester expects you to sign this message on",
+  "The token you’re trying to add is on": "The token you’re trying to add is on",
   "The transaction you’re trying to sign is on": "The transaction you’re trying to sign is on",
   "The website <1>{url}</1> does not use an SSL certificate": {
     " For additional safety Freighter only works with websites that provide an SSL certificate by default": {
       " You may enable connection to domains that do not use an SSL certificate in Settings &gt; Security &gt; Advanced Settings": "The website <1>{url}</1> does not use an SSL certificate. For additional safety Freighter only works with websites that provide an SSL certificate by default. You may enable connection to domains that do not use an SSL certificate in Settings &gt; Security &gt; Advanced Settings."
     }
+  },
+  "These assets are not on any of your lists": {
+    " Proceed with caution before adding": "These assets are not on any of your lists. Proceed with caution before adding."
   },
   "This asset has a balance": "This asset has a balance",
   "This asset has buying liabilities": "This asset has buying liabilities",
@@ -464,6 +474,9 @@
   },
   "This invocation authorizes the following transfers, please review the invocation tree and confirm that you want to proceed": "This invocation authorizes the following transfers, please review the invocation tree and confirm that you want to proceed.",
   "This is a relatively new asset": "This is a relatively new asset.",
+  "This is not a valid contract id": {
+    " Please try again with a different value": "This is not a valid contract id. Please try again with a different value."
+  },
   "This site was flagged as malicious": "This site was flagged as malicious",
   "This transaction could not be completed": "This transaction could not be completed.",
   "This transaction is expected to fail": "This transaction is expected to fail",
@@ -524,6 +537,7 @@
   "You can choose to merge your current account into the new accounts after the migration, which will effectively destroy your current account": {
     " Merging is optional and will allow you to send your current account’s funding lumens to the new accounts": "You can choose to merge your current account into the new accounts after the migration, which will effectively destroy your current account. Merging is optional and will allow you to send your current account’s funding lumens to the new accounts."
   },
+  "You can define your own assets lists in Settings": "You can define your own assets lists in Settings.",
   "You must have a balance of": "You must have a balance of",
   "You must have a buying liability of": "You must have a buying liability of",
   "You still have a balance of": "You still have a balance of",

--- a/extension/src/popup/locales/pt/translation.json
+++ b/extension/src/popup/locales/pt/translation.json
@@ -26,6 +26,7 @@
   "Add network": "Add network",
   "Add new list": "Add new list",
   "Add XLM": "Add XLM",
+  "Adding this token is not possible at the moment": "Adding this token is not possible at the moment.",
   "Address": "Address",
   "Addresses are uppercase and begin with letters “G“, “M“, or “C“": "Addresses are uppercase and begin with letters “G“, “M“, or “C“.",
   "Advanced settings": "Advanced settings",
@@ -54,6 +55,7 @@
   "Approve": "Approve",
   "Approve and continue": "Approve and continue",
   "Approve and review next": "Approve and review next",
+  "Approve Token": "Approve Token",
   "Approve using": "Approve using",
   "are required to add a new asset": "are required to add a new asset.",
   "Are you sure you want to delete this list?": "Are you sure you want to delete this list?",
@@ -66,6 +68,7 @@
   "Asset B": "Asset B",
   "Asset Code": "Asset Code",
   "Asset home domain doesn’t exist, TOML file format is invalid, or asset doesn't match currency description": "Asset home domain doesn’t exist, TOML file format is invalid, or asset doesn't match currency description",
+  "Asset info": "Asset info",
   "Asset Info": "Asset Info",
   "Asset lists": "Asset lists",
   "Asset not found": "Asset not found",
@@ -77,6 +80,7 @@
   "available": "available",
   "Back": "Back",
   "Balance ID": "Balance ID",
+  "Balance Info": "Balance Info",
   "Before we start with migration, please read": "Before we start with migration, please read",
   "Before You Add This Asset": "Before You Add This Asset",
   "Bump To": "Bump To",
@@ -188,6 +192,7 @@
   "Freighter uses asset lists to check assets you interact with": {
     " You can define your own assets lists in Settings": "Freighter uses asset lists to check assets you interact with. You can define your own assets lists in Settings."
   },
+  "Freighter uses asset lists to verify assets before interactions": "Freighter uses asset lists to verify assets before interactions.",
   "Friendbot URL": "Friendbot URL",
   "From": "From",
   "Function Name": "Function Name",
@@ -430,6 +435,7 @@
   "swapped": "swapped",
   "Swapped": "Swapped",
   "Switch to this network": "Switch to this network",
+  "Symbol": "Symbol",
   "Terms of Service": "Terms of Service",
   "Terms of Use": "Terms of Use",
   "The application is requesting a specific account": "The application is requesting a specific account",
@@ -442,11 +448,15 @@
   "The final amount is approximate and may change": "The final amount is approximate and may change",
   "The requester expects you to sign this auth entry on": "The requester expects you to sign this auth entry on",
   "The requester expects you to sign this message on": "The requester expects you to sign this message on",
+  "The token you’re trying to add is on": "The token you’re trying to add is on",
   "The transaction you’re trying to sign is on": "The transaction you’re trying to sign is on",
   "The website <1>{url}</1> does not use an SSL certificate": {
     " For additional safety Freighter only works with websites that provide an SSL certificate by default": {
       " You may enable connection to domains that do not use an SSL certificate in Settings &gt; Security &gt; Advanced Settings": "The website <1>{url}</1> does not use an SSL certificate. For additional safety Freighter only works with websites that provide an SSL certificate by default. You may enable connection to domains that do not use an SSL certificate in Settings &gt; Security &gt; Advanced Settings."
     }
+  },
+  "These assets are not on any of your lists": {
+    " Proceed with caution before adding": "These assets are not on any of your lists. Proceed with caution before adding."
   },
   "This asset has a balance": "This asset has a balance",
   "This asset has buying liabilities": "This asset has buying liabilities",
@@ -464,6 +474,9 @@
   },
   "This invocation authorizes the following transfers, please review the invocation tree and confirm that you want to proceed": "This invocation authorizes the following transfers, please review the invocation tree and confirm that you want to proceed.",
   "This is a relatively new asset": "This is a relatively new asset.",
+  "This is not a valid contract id": {
+    " Please try again with a different value": "This is not a valid contract id. Please try again with a different value."
+  },
   "This site was flagged as malicious": "This site was flagged as malicious",
   "This transaction could not be completed": "This transaction could not be completed.",
   "This transaction is expected to fail": "This transaction is expected to fail",
@@ -524,6 +537,7 @@
   "You can choose to merge your current account into the new accounts after the migration, which will effectively destroy your current account": {
     " Merging is optional and will allow you to send your current account’s funding lumens to the new accounts": "You can choose to merge your current account into the new accounts after the migration, which will effectively destroy your current account. Merging is optional and will allow you to send your current account’s funding lumens to the new accounts."
   },
+  "You can define your own assets lists in Settings": "You can define your own assets lists in Settings.",
   "You must have a balance of": "You must have a balance of",
   "You must have a buying liability of": "You must have a buying liability of",
   "You still have a balance of": "You still have a balance of",

--- a/extension/src/popup/views/ManageAssetsLists/index.tsx
+++ b/extension/src/popup/views/ManageAssetsLists/index.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 
 import { ROUTES } from "popup/constants/routes";
 import { NETWORKS } from "@shared/constants/stellar";
-import { AssetsListKey } from "@shared/constants/soroban/token";
+import { AssetsListKey } from "@shared/constants/soroban/asset-list";
 import { settingsSelector } from "popup/ducks/settings";
 import { PublicKeyRoute } from "popup/Router";
 

--- a/extension/src/popup/views/__tests__/ManageAssets.test.tsx
+++ b/extension/src/popup/views/__tests__/ManageAssets.test.tsx
@@ -181,6 +181,36 @@ jest.spyOn(SearchAsset, "searchAsset").mockImplementation(({ asset }) => {
     },
   });
 });
+
+jest
+  .spyOn(SearchAsset, "getAssetLists")
+  .mockImplementation(({ networkDetails }) => {
+    return Promise.resolve([
+      {
+        status: "fulfilled",
+        value: {
+          name: "Test Asset List",
+          description: "fake asset list for testing",
+          network: networkDetails.network,
+          version: "1",
+          provider: "test-provider",
+          assets: [
+            {
+              code: "USDC",
+              contract:
+                "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA",
+              decimals: 7,
+              domain: "centre.io",
+              icon: "",
+              issuer:
+                "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
 jest
   .spyOn(SearchAsset, "getVerifiedTokens")
   .mockImplementation(({ contractId }) => {
@@ -204,9 +234,14 @@ jest
 
 jest
   .spyOn(ApiInternal, "getTokenDetails")
-  .mockImplementation(() =>
-    Promise.resolve({ name: "foo", symbol: "baz", decimals: 7 }),
-  );
+  .mockImplementation(({ contractId }) => {
+    if (
+      contractId === "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA"
+    ) {
+      return Promise.resolve({ name: "USDC", symbol: "USDC", decimals: 7 });
+    }
+    return Promise.resolve({ name: "foo", symbol: "baz", decimals: 7 });
+  });
 
 jest
   .spyOn(SorobanHelpers, "isContractId")
@@ -304,6 +339,14 @@ const initView = async (
           networksList: DEFAULT_NETWORKS,
           isSorobanPublicEnabled: true,
           isRpcHealthy: true,
+          assetsLists: {
+            [configuredNetworkDetails.network]: [
+              {
+                url: "asset_list_url",
+                isEnabled: true,
+              },
+            ],
+          },
         },
         transactionSubmission: {
           ...transactionSubmissionInitialState,
@@ -796,19 +839,14 @@ describe.skip("Manage assets", () => {
     });
     await waitFor(async () => {
       const addedTrustlines = screen.queryAllByTestId("ManageAssetRow");
-      const verificationBadge = screen.getByTestId("asset-notification");
+      const verificationBadge = screen.getByTestId("asset-on-list");
 
-      expect(verificationBadge).toHaveTextContent(
-        "On your listsFreighter uses asset lists to check assets you interact with. You can define your own assets lists in Settings.",
-      );
+      expect(verificationBadge).toHaveTextContent("On your lists");
 
       expect(addedTrustlines.length).toBe(1);
       expect(
         within(addedTrustlines[0]).getByTestId("ManageAssetCode"),
       ).toHaveTextContent("USDC");
-      expect(
-        within(addedTrustlines[0]).getByTestId("ManageAssetDomain"),
-      ).toHaveTextContent("centre.io");
 
       const addAssetButton = within(addedTrustlines[0]).getByTestId(
         "ManageAssetRowButton",
@@ -845,19 +883,14 @@ describe.skip("Manage assets", () => {
     });
     await waitFor(async () => {
       const addedTrustlines = screen.queryAllByTestId("ManageAssetRow");
-      const verificationBadge = screen.getByTestId("asset-notification");
+      const verificationBadge = screen.getByTestId("not-asset-on-list");
 
-      expect(verificationBadge).toHaveTextContent(
-        "Not on your listsFreighter uses asset lists to check assets you interact with. You can define your own assets lists in Settings.",
-      );
+      expect(verificationBadge).toHaveTextContent("Not on your lists");
 
       expect(addedTrustlines.length).toBe(1);
       expect(
         within(addedTrustlines[0]).getByTestId("ManageAssetCode"),
       ).toHaveTextContent("foo");
-      expect(
-        within(addedTrustlines[0]).getByTestId("ManageAssetDomain"),
-      ).toHaveTextContent("Stellar Network");
 
       const addAssetButton = within(addedTrustlines[0]).getByTestId(
         "ManageAssetRowButton",


### PR DESCRIPTION
Closes #1553 

What
Splits assets by verification status on the add asset workflows

Notes:
`getAssetListForAsset` was introduced separately to `splitVerifiedAssetCurrency` because we will need to get asset lists for an asset separately from processing an asset list for [the next task to refactor our asset workflows](https://github.com/stellar/freighter/issues/1791). This sets us up to be able to use icons from the asset lists in that task.

Open questions:
What should happen if we fail to fetch one or all of the asset lists? Right now we silently fail but this will in effect label all assets as "Not on your list". Should we fallback to the unlabeled list in these cases?


<img width="377" alt="Screenshot 2025-02-07 at 3 06 08 PM" src="https://github.com/user-attachments/assets/da71de19-aa4c-408d-ada4-e1bd19b3eb69" />


<img width="378" alt="Screenshot 2025-02-07 at 3 07 39 PM" src="https://github.com/user-attachments/assets/2cb9600d-0c27-431f-adcc-d1fbec6410ae" />
