### PR TITLE
Fix/replace alert

### DIFF
--- a/extension/src/popup/components/WarningMessages/index.tsx
+++ b/extension/src/popup/components/WarningMessages/index.tsx
@@ -2,7 +2,6 @@ import React, { useState, useRef, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { createPortal } from "react-dom";
 import {
-  Alert,
   Button,
   Card,
   Icon,
@@ -1437,18 +1436,31 @@ export const BlockaidWarningModal = ({
   const isAsset = !!address;
 
   const WarningInfoBlock = ({ hasArrow = false }: { hasArrow?: boolean }) => (
-    <Alert
-      placement="inline"
-      variant={isWarning ? "warning" : "error"}
-      title={header}
+    <div
+      className={`ScamAssetWarning__box ${
+        isWarning ? "ScamAssetWarning__box--isWarning" : ""
+      }`}
+      data-testid="ScamAssetWarning__box"
     >
-      <BlockaidByLine
-        hasArrow={hasArrow}
-        handleClick={() => setIsModalActive(true)}
-        requestId={requestId}
-        address={address}
-      />
-    </Alert>
+      <div className="ScamAssetWarning__box__content">
+        <div className="Icon">
+          <img
+            className="ScamAssetWarning__box__icon"
+            src={isWarning ? IconWarningBlockaidYellow : IconWarningBlockaid}
+            alt="icon warning blockaid"
+          />
+        </div>
+        <div className="ScamAssetWarning__alert">
+          <div className="ScamAssetWarning__description">{header}</div>
+          <BlockaidByLine
+            hasArrow={hasArrow}
+            handleClick={() => setIsModalActive(true)}
+            requestId={requestId}
+            address={address}
+          />
+        </div>
+      </div>
+    </div>
   );
 
   const truncatedDescription = (desc: string) => {

--- a/extension/src/popup/components/WarningMessages/index.tsx
+++ b/extension/src/popup/components/WarningMessages/index.tsx
@@ -1404,7 +1404,7 @@ export const BlockaidAssetScanLabel = ({
 
   return (
     <BlockaidWarningModal
-      header={`This asset was flagged as ${blockaidData.result_type}`}
+      header={`This asset was flagged as ${blockaidData.result_type.toLowerCase()}`}
       description={blockaidData.features?.map((f) => f.description) || []}
       isWarning={isWarning}
       address={blockaidData.address}

--- a/extension/src/popup/components/WarningMessages/index.tsx
+++ b/extension/src/popup/components/WarningMessages/index.tsx
@@ -1440,7 +1440,7 @@ export const BlockaidWarningModal = ({
       className={`ScamAssetWarning__box ${
         isWarning ? "ScamAssetWarning__box--isWarning" : ""
       }`}
-      data-testid="ScamAssetWarning__box"
+      data-testid="BlockaidWarningModal__alert"
     >
       <div className="ScamAssetWarning__box__content">
         <div className="Icon">

--- a/extension/src/popup/components/WarningMessages/styles.scss
+++ b/extension/src/popup/components/WarningMessages/styles.scss
@@ -8,6 +8,7 @@
 }
 
 .BlockaidByLine {
+  color: var(--sds-clr-gray-11);
   display: flex;
   font-size: var(--sds-fs-secondary);
   justify-content: space-between;
@@ -189,6 +190,10 @@
   .View__inset {
     background: none;
     padding: 0.5rem;
+  }
+
+  &__alert {
+    flex-grow: 2;
   }
 
   &__box {

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/styles.scss
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/styles.scss
@@ -145,7 +145,6 @@
   &__warnings {
     display: flex;
     flex-flow: column;
-    gap: 0.5rem;
     margin-top: 1.5rem;
 
     .WarningMessage__infoBlock {


### PR DESCRIPTION
Closes #1846 

Until the new `<Alert />` component gets moved to SDS, we'll need to do some custom styling to match the existing design

<img width="362" alt="Screenshot 2025-02-11 at 7 09 39 PM" src="https://github.com/user-attachments/assets/02d51c29-0470-4f6a-ac28-6984417709d7" />
