### PR TITLE
[CHORE] upgrades node to version 22 in all actions

### DIFF
--- a/.github/workflows/deployFreighterApiBeta.yml
+++ b/.github/workflows/deployFreighterApiBeta.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build package
         uses: actions/setup-node@v4
         with:
-          node-version: "21"
+          node-version: 22
       - name: Version npm package
         run: |
           cd @stellar/freighter-api

--- a/.github/workflows/submitBeta.yml
+++ b/.github/workflows/submitBeta.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build extension
         uses: actions/setup-node@v4
         with:
-          node-version: "21"
+          node-version: 22
       - run: yarn setup && yarn build:freighter-api && yarn build:extension:production
       - name: Use BETA icons
         run: |

--- a/.github/workflows/submitProduction.yml
+++ b/.github/workflows/submitProduction.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build extension
         uses: actions/setup-node@v4
         with:
-          node-version: "21"
+          node-version: 22
       - run: yarn setup && yarn build:freighter-api && yarn build:extension:production --env AMPLITUDE_KEY="${{ secrets.AMPLITUDE_KEY }}" SENTRY_KEY="${{ secrets.SENTRY_KEY }}"
       - name: Install zip
         uses: montudor/action-zip@0852c26906e00f8a315c704958823928d8018b28 #v1.0.0

--- a/.github/workflows/submitSafari.yml
+++ b/.github/workflows/submitSafari.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build extension
         uses: actions/setup-node@v4
         with:
-          node-version: "21"
+          node-version: 22
       - run: yarn setup && yarn build:freighter-api && yarn build:extension:production --env AMPLITUDE_KEY="${{ secrets.AMPLITUDE_KEY }}" SENTRY_KEY="${{ secrets.SENTRY_KEY }}"
       - name: Convert extension to Xcode project
         run: xcrun safari-web-extension-converter ./extension/build --project-location $GYM_PROJECT --macos-only


### PR DESCRIPTION
In order to release [5.28.1](https://github.com/stellar/freighter/pull/1868) we need to upgrade to node 22 in actions in order to align with the upgrades in that change set.