### PR TITLE
freighter-api: return signature from signTransaction

### DIFF
--- a/@shared/api/external.ts
+++ b/@shared/api/external.ts
@@ -78,6 +78,7 @@ export const submitTransaction = async (
 ): Promise<{
   signedTransaction: string;
   signerAddress: string;
+  signature: string;
   error?: FreighterApiError;
 }> => {
   let network;
@@ -110,12 +111,18 @@ export const submitTransaction = async (
     return {
       signedTransaction: "",
       signerAddress: "",
+      signature: "",
       error: FreighterApiInternalError,
     };
   }
-  const { signedTransaction, signerAddress } = response;
+  const { signedTransaction, signerAddress, signature } = response;
 
-  return { signedTransaction, signerAddress, error: response?.apiError };
+  return {
+    signedTransaction,
+    signerAddress,
+    signature,
+    error: response?.apiError,
+  };
 };
 
 export const submitMessage = async (

--- a/@shared/api/types.ts
+++ b/@shared/api/types.ts
@@ -41,6 +41,7 @@ export interface Response {
   transactionXDR: string;
   signerAddress: string;
   signedTransaction: string;
+  signature: string;
   signedPayload: string | Buffer;
   signedBlob: Buffer | null;
   signedAuthEntry: Buffer | null;
@@ -146,6 +147,7 @@ export enum AccountType {
   HW = "HW",
   IMPORTED = "IMPORTED",
   FREIGHTER = "FREIGHTER",
+  UNKNOWN = "UNKNOWN",
 }
 
 export interface Preferences {

--- a/@stellar/freighter-api/src/__tests__/signTransaction.test.js
+++ b/@stellar/freighter-api/src/__tests__/signTransaction.test.js
@@ -15,6 +15,22 @@ describe("signTransaction", () => {
       signerAddress: "baz",
     });
   });
+  it("returns a transaction with signature", async () => {
+    const TEST_TRANSACTION = "AAA";
+    const TEST_SIGNATURE = "BBB";
+    extensionMessaging.sendMessageToContentScript = jest.fn().mockReturnValue({
+      signedTransaction: TEST_TRANSACTION,
+      signerAddress: "baz",
+      signature: TEST_SIGNATURE,
+    });
+    const transaction = await signTransaction();
+    expect(transaction).toEqual({
+      signedTxXdr: TEST_TRANSACTION,
+      signerAddress: "baz",
+      signature: TEST_SIGNATURE,
+    });
+  });
+
   it("returns a generic error", async () => {
     extensionMessaging.sendMessageToContentScript = jest
       .fn()
@@ -24,6 +40,7 @@ describe("signTransaction", () => {
     expect(transaction).toEqual({
       signedTxXdr: "",
       signerAddress: "",
+      signature: "",
       error: "baz",
     });
   });

--- a/@stellar/freighter-api/src/signTransaction.ts
+++ b/@stellar/freighter-api/src/signTransaction.ts
@@ -8,9 +8,9 @@ export const signTransaction = async (
   opts?: {
     networkPassphrase?: string;
     address?: string;
-  }
+  },
 ): Promise<
-  { signedTxXdr: string; signerAddress: string } & {
+  { signedTxXdr: string; signerAddress: string; signature: string } & {
     error?: FreighterApiError;
   }
 > => {
@@ -18,14 +18,25 @@ export const signTransaction = async (
     const req = await submitTransaction(transactionXdr, opts);
 
     if (req.error) {
-      return { signedTxXdr: "", signerAddress: "", error: req.error };
+      return {
+        signedTxXdr: "",
+        signerAddress: "",
+        signature: "",
+        error: req.error,
+      };
     }
 
     return {
       signedTxXdr: req.signedTransaction,
       signerAddress: req.signerAddress,
+      signature: req.signature,
     };
   }
 
-  return { signedTxXdr: "", signerAddress: "", error: FreighterApiNodeError };
+  return {
+    signedTxXdr: "",
+    signerAddress: "",
+    signature: "",
+    error: FreighterApiNodeError,
+  };
 };

--- a/docs/docs/guide/signXdr.md
+++ b/docs/docs/guide/signXdr.md
@@ -6,15 +6,25 @@ slug: /sign-xdr
 
 ## Signing XDR
 
-You trigger an "xdr signing" workflow by utilizing the [signTransaction API](https://docs.freighter.app/docs/playground/signTransaction).
-The API takes an xdr string and network options as input and triggers a modal where you can review transaction/operation details and sign the transaction. Freighter will return the signed transaction to the application that called the API after user confirmation.
+You trigger an "xdr signing" workflow by utilizing the
+[signTransaction API](https://docs.freighter.app/docs/playground/signTransaction).
+The API takes an xdr string and network options as input and triggers a modal
+where you can review transaction/operation details and sign the transaction.
+Freighter will return the signed transaction along with its signature to the
+application that called the API after user confirmation.
 
-You can serialize an assembled transaction to a base64 encoded xdr string using [the stellar-sdk](https://stellar.github.io/js-stellar-sdk/AssembledTransaction.html#toXDR).
+You can serialize an assembled transaction to a base64 encoded xdr string using
+[the stellar-sdk](https://stellar.github.io/js-stellar-sdk/AssembledTransaction.html#toXDR).
 
 ### Signing details
 
-During the transaction/operation review, you can review signing details at different fidelities.
+During the transaction/operation review, you can review signing details at
+different fidelities.
 
-- Summary: The first tab is the summary tab which lays out high level transaction/operation details.
-- Operation Details: The second tab exposes information about the operations in the transaction and optionally walks through the invocation chain and highlights authorizations.
-- Raw XDR: The last tab lets you copy the raw XDR to be used outside of Freighter.
+- Summary: The first tab is the summary tab which lays out high level
+  transaction/operation details.
+- Operation Details: The second tab exposes information about the operations in
+  the transaction and optionally walks through the invocation chain and
+  highlights authorizations.
+- Raw XDR: The last tab lets you copy the raw XDR to be used outside of
+  Freighter.

--- a/docs/docs/guide/usingFreighterWebApp.md
+++ b/docs/docs/guide/usingFreighterWebApp.md
@@ -3,7 +3,9 @@ id: usingFreighterWebApp
 title: Using Freighter in a web app
 ---
 
-We now have an extension installed on our machine and a library to interact with it. This library will provide you methods to send and receive data from a user's extension in your website or application.
+We now have an extension installed on our machine and a library to interact with
+it. This library will provide you methods to send and receive data from a user's
+extension in your website or application.
 
 ### Importing
 
@@ -32,7 +34,8 @@ Now let's dig into what functionality is available to you:
 
 #### `isConnected() -> <Promise<{ isConnected: boolean } & { error?: string; }>>`
 
-This function is useful for determining if a user in your application has Freighter installed.
+This function is useful for determining if a user in your application has
+Freighter installed.
 
 ```typescript
 import { isConnected } from "@stellar/freighter-api";
@@ -48,7 +51,8 @@ if (isAppConnected.isConnected) {
 
 #### `isAllowed() -> <Promise<{ isAllowed: boolean } & { error?: string; }>>`
 
-This function is useful for determining if a user has previously authorized your app to receive data from Freighter.
+This function is useful for determining if a user has previously authorized your
+app to receive data from Freighter.
 
 ```typescript
 import { isAllowed } from "@stellar/freighter-api";
@@ -64,7 +68,11 @@ if (isAppAllowed.isAllowed) {
 
 #### `setAllowed() -> <Promise<{ isAllowed: boolean } & { error?: string; }>>`
 
-If a user has never interacted with your app before, this function will prompt the user to provide your app privileges to receive user data. If and when the user accepts, this function will resolve with a boolean of `true` indicating the app is now on the extension's "Allow list". This means the extension can immediately provide user data without any user action.
+If a user has never interacted with your app before, this function will prompt
+the user to provide your app privileges to receive user data. If and when the
+user accepts, this function will resolve with a boolean of `true` indicating the
+app is now on the extension's "Allow list". This means the extension can
+immediately provide user data without any user action.
 
 ```typescript
 import { setAllowed } from "@stellar/freighter-api";
@@ -80,9 +88,14 @@ if (isAppAllowed.isAllowed) {
 
 #### `requestAccess() -> <Promise<{ address: string }  & { error?: string; }>>`
 
-If a user has never interacted with your app before, this function will prompt the user to provide your app privileges to receive the user's public key. If and when the user accepts, this function will resolve with an object containing the public key. Otherwise, it will provide an error.
+If a user has never interacted with your app before, this function will prompt
+the user to provide your app privileges to receive the user's public key. If and
+when the user accepts, this function will resolve with an object containing the
+public key. Otherwise, it will provide an error.
 
-If the user has authorized your application previously, it will be on the extension's "Allow list", meaning the extension can immediately provide the public key without any user action.
+If the user has authorized your application previously, it will be on the
+extension's "Allow list", meaning the extension can immediately provide the
+public key without any user action.
 
 ```typescript
 import {
@@ -118,7 +131,9 @@ const result = retrievePublicKey();
 
 This is a more lightweight version of `requestAccess` above.
 
-If the user has authorized your application previously and Freighter is connected, Freighter will simply return the public key. If either one of the above is not true, it will return an empty string.
+If the user has authorized your application previously and Freighter is
+connected, Freighter will simply return the public key. If either one of the
+above is not true, it will return an empty string.
 
 ```typescript
 import { getAddress } from "@stellar/freighter-api";
@@ -140,7 +155,9 @@ const result = retrievePublicKey();
 
 #### `getNetwork() -> <Promise<{ network: string; networkPassphrase: string } & { error?: string; }>>`
 
-This function is useful for determining what network the user has configured Freighter to use. Freighter will be configured to either `PUBLIC`, `TESTNET`, `FUTURENET`, or `STANDALONE` (for custom networks).
+This function is useful for determining what network the user has configured
+Freighter to use. Freighter will be configured to either `PUBLIC`, `TESTNET`,
+`FUTURENET`, or `STANDALONE` (for custom networks).
 
 ```typescript
 import {
@@ -177,7 +194,11 @@ const result = retrieveNetwork();
 
 #### `getNetworkDetails() -> <Promise<{ network: string; networkUrl: string; networkPassphrase: string; sorobanRpcUrl?: string; } & { error?: string; }>>`
 
-Similar to `getNetwork()`, this function retrieves network information from Freighter. However, while `getNetwork()` returns only the network name (such as "PUBLIC" or "TESTNET"), `getNetworkDetails()` provides comprehensive network configuration including the full network URL, network passphrase, and Soroban RPC URL when available.
+Similar to `getNetwork()`, this function retrieves network information from
+Freighter. However, while `getNetwork()` returns only the network name (such as
+"PUBLIC" or "TESTNET"), `getNetworkDetails()` provides comprehensive network
+configuration including the full network URL, network passphrase, and Soroban
+RPC URL when available.
 
 ```typescript
 import {
@@ -204,41 +225,76 @@ const checkNetworks = async () => {
 };
 ```
 
-Use this method when you need detailed network configuration information, particularly when working with Soroban smart contracts or when the specific network endpoints are required.
+Use this method when you need detailed network configuration information,
+particularly when working with Soroban smart contracts or when the specific
+network endpoints are required.
 
 ### signTransaction
 
-#### `signTransaction(xdr: string, opts?: { network?: string, networkPassphrase?: string, address?: string }) -> <Promise<{ signedTxXdr: string; signerAddress: string; } & { error?: string; }>>`
+#### `signTransaction(xdr: string, opts?: { network?: string, networkPassphrase?: string, address?: string }) -> <Promise<{ signedTxXdr: string; signerAddress: string; signature: string; } & { error?: string; }>>`
 
-This function accepts a transaction XDR string as the first parameter, which it will decode, sign as the user, and then return the signed transaction to your application.
+This function accepts a transaction XDR string as the first parameter, which it
+will decode, sign as the user, and then return the signed transaction along with
+its signature to your application.
 
-The user will need to provide their password if the extension does not currently have their private key. Once the user has provided their password, the extension will have access to the user private key for 5 minutes. The user must then review the transaction details and accept within those 5 minutes for the transaction to be signed.
+The user will need to provide their password if the extension does not currently
+have their private key. Once the user has provided their password, the extension
+will have access to the user private key for 5 minutes. The user must then
+review the transaction details and accept within those 5 minutes for the
+transaction to be signed.
 
-_NOTE:_ The user must provide a valid transaction XDR string for the extension to properly sign.
+_NOTE:_ The user must provide a valid transaction XDR string for the extension
+to properly sign.
 
-The second parameter is an optional `opts` object where you can specify the network you are intending the transaction to be signed on. This `network` name maps to the Networks enum in js-stellar-sdk. Freighter will use this network name to derive the network passphrase from js-stellar-sdk.
+The second parameter is an optional `opts` object where you can specify the
+network you are intending the transaction to be signed on. This `network` name
+maps to the Networks enum in js-stellar-sdk. Freighter will use this network
+name to derive the network passphrase from js-stellar-sdk.
 
-If the passphrase you need can't be found in js-stellar-sdk, you can simply pass a custom `networkPassphrase` for Freighter to use. In the event both are passed, Freighter will default to using `network` to derive the passphrase from js-stellar-sdk and ignore `networkPassphrase`.
+If the passphrase you need can't be found in js-stellar-sdk, you can simply pass
+a custom `networkPassphrase` for Freighter to use. In the event both are passed,
+Freighter will default to using `network` to derive the passphrase from
+js-stellar-sdk and ignore `networkPassphrase`.
 
-These 2 configurations are useful in the case that the user's Freighter is configured to the wrong network. Freighter will be able to throw a blocking error message communicating that you intended this transaction to be signed on a different network.
+These 2 configurations are useful in the case that the user's Freighter is
+configured to the wrong network. Freighter will be able to throw a blocking
+error message communicating that you intended this transaction to be signed on a
+different network.
 
-You can also use this `opts` to specify which account's signature you’re requesting. If Freighter has the public key requested, it will switch to that account. If not, it will alert the user that they do not have the requested account.
+You can also use this `opts` to specify which account's signature you’re
+requesting. If Freighter has the public key requested, it will switch to that
+account. If not, it will alert the user that they do not have the requested
+account.
 
 ### signAuthEntry
 
 #### `signAuthEntry(authEntryXdr: string, opts: { address: string }) -> <Promise<{ signedAuthEntry: Buffer | null; signerAddress: string } & { error?: string; }>>`
 
-This function accepts an [authorization entry preimage](https://github.com/stellar/js-stellar-base/blob/a9567e5843760bfb6a8b786592046aee4c9d38b2/types/next.d.ts#L6895) as the first parameter and it returns a signed hash of the same authorization entry, which can be added to the [address credentials](https://github.com/stellar/js-stellar-base/blob/a9567e5843760bfb6a8b786592046aee4c9d38b2/types/next.d.ts#L6614) of the same entry. The [`authorizeEntry` helper](https://github.com/stellar/js-stellar-base/blob/e3d6fc3351e7d242b374c7c6057668366364a279/src/auth.js#L97) in stellar base is a good example of how this works.
+This function accepts an
+[authorization entry preimage](https://github.com/stellar/js-stellar-base/blob/a9567e5843760bfb6a8b786592046aee4c9d38b2/types/next.d.ts#L6895)
+as the first parameter and it returns a signed hash of the same authorization
+entry, which can be added to the
+[address credentials](https://github.com/stellar/js-stellar-base/blob/a9567e5843760bfb6a8b786592046aee4c9d38b2/types/next.d.ts#L6614)
+of the same entry. The
+[`authorizeEntry` helper](https://github.com/stellar/js-stellar-base/blob/e3d6fc3351e7d242b374c7c6057668366364a279/src/auth.js#L97)
+in stellar base is a good example of how this works.
 
-The second parameter is an optional `opts` object where you can specify which account's signature you’re requesting. If Freighter has the public key requested, it will switch to that account. If not, it will alert the user that they do not have the requested account.
+The second parameter is an optional `opts` object where you can specify which
+account's signature you’re requesting. If Freighter has the public key
+requested, it will switch to that account. If not, it will alert the user that
+they do not have the requested account.
 
 ### signMessage
 
 #### `signMessage(message: string, opts: { address: string }) -> <Promise<{ signedMessage: string | null; signerAddress: string; } & { error?: string; }>>`
 
-This function accepts a string as the first parameter, which it will decode, sign as the user, and return a base64 encoded string of the signed contents.
+This function accepts a string as the first parameter, which it will decode,
+sign as the user, and return a base64 encoded string of the signed contents.
 
-The second parameter is an optional `opts` object where you can specify which account's signature you’re requesting. If Freighter has the public key requested, it will switch to that account. If not, it will alert the user that they do not have the requested account.
+The second parameter is an optional `opts` object where you can specify which
+account's signature you’re requesting. If Freighter has the public key
+requested, it will switch to that account. If not, it will alert the user that
+they do not have the requested account.
 
 ```typescript
 import {
@@ -269,7 +325,7 @@ const retrievedPublicKey = retrievePublicKey();
 const userSignTransaction = async (
   xdr: string,
   network: string,
-  signWith: string
+  signWith: string,
 ) => {
   const signedTransactionRes = await signTransaction(xdr, {
     network,
@@ -287,7 +343,9 @@ const xdr = ""; // replace this with an xdr string of the transaction you want t
 const userSignedTransaction = userSignTransaction(xdr, "TESTNET");
 ```
 
-freighter-api will return a signed transaction xdr. Below is an example of how you might submit this signed transaction to Horizon using `stellar-sdk` (https://github.com/stellar/js-stellar-sdk):
+freighter-api will return a signed transaction xdr. Below is an example of how
+you might submit this signed transaction to Horizon using `stellar-sdk`
+(https://github.com/stellar/js-stellar-sdk):
 
 ```typescript
 import { Server, TransactionBuilder } from "stellar-sdk";
@@ -295,7 +353,7 @@ import { Server, TransactionBuilder } from "stellar-sdk";
 const userSignTransaction = async (
   xdr: string,
   network: string,
-  signWith: string
+  signWith: string,
 ) => {
   const signedTransactionRes = await signTransaction(xdr, {
     network,
@@ -319,7 +377,7 @@ const server = new Server(SERVER_URL);
 
 const transactionToSubmit = TransactionBuilder.fromXDR(
   userSignedTransaction,
-  SERVER_URL
+  SERVER_URL,
 );
 
 const response = await server.submitTransaction(transactionToSubmit);
@@ -329,9 +387,16 @@ const response = await server.submitTransaction(transactionToSubmit);
 
 #### `addToken({ contractId: string, networkPassphrase?: string }) -> <Promise<{ contractId: string } & { error?: string; }>>`
 
-This function allows you to trigger an "add token" workflow to add a Soroban token to the user's Freighter wallet. It takes a contract ID as a required parameter and an optional network passphrase. If the network passphrase is omitted, it defaults to Pubnet's passphrase.
+This function allows you to trigger an "add token" workflow to add a Soroban
+token to the user's Freighter wallet. It takes a contract ID as a required
+parameter and an optional network passphrase. If the network passphrase is
+omitted, it defaults to Pubnet's passphrase.
 
-When called, Freighter will load the token details (symbol, name, decimals, and balance) from the contract and display them in a modal popup for user review. The user can then verify the token's legitimacy and approve adding it to their wallet. After approval, Freighter will track the token's balance and display it alongside other account balances.
+When called, Freighter will load the token details (symbol, name, decimals, and
+balance) from the contract and display them in a modal popup for user review.
+The user can then verify the token's legitimacy and approve adding it to their
+wallet. After approval, Freighter will track the token's balance and display it
+alongside other account balances.
 
 ```typescript
 import { isConnected, addToken } from "@stellar/freighter-api";
@@ -352,7 +417,7 @@ const addSorobanToken = async () => {
   }
 
   console.log(
-    `Successfully added token with contract ID: ${result.contractId}`
+    `Successfully added token with contract ID: ${result.contractId}`,
   );
 };
 ```
@@ -366,11 +431,17 @@ The function returns a Promise that resolves to an object containing either:
 
 #### `WatchWalletChanges -> new WatchWalletChanges(timeout?: number)`
 
-The class `WatchWalletChanges` provides methods to watch changes from Freighter. To use this class, first instantiate with an optional `timeout` param to determine how often you want to check for changes in the wallet. The default is `3000` ms.
+The class `WatchWalletChanges` provides methods to watch changes from Freighter.
+To use this class, first instantiate with an optional `timeout` param to
+determine how often you want to check for changes in the wallet. The default is
+`3000` ms.
 
 ##### `WatchWalletChanges.watch(callback: ({ address: string; network: string; networkPassphrase; string }) => void)`
 
-The `watch()` method starts polling the extension for updates. By passing a callback into the method, you can access Freighter's `address`, `network`, and `networkPassphrase`. This method will only emit results when something has changed.
+The `watch()` method starts polling the extension for updates. By passing a
+callback into the method, you can access Freighter's `address`, `network`, and
+`networkPassphrase`. This method will only emit results when something has
+changed.
 
 ##### `WatchWalletChanges.stop()`
 

--- a/docs/docs/playground/components/SignTransactionDemo.tsx
+++ b/docs/docs/playground/components/SignTransactionDemo.tsx
@@ -8,12 +8,13 @@ export const SignTransactionDemo = () => {
   const [publicKey, setPublicKey] = useState("");
   const [transactionResult, setTransactionResult] = useState("");
   const [signerAddressResult, setSignerAddressResult] = useState("");
+  const [signatureResult, setSignatureResult] = useState("");
 
   const xdrOnChangeHandler = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setTransactionXdr(e.currentTarget.value);
   };
   const networkPassphraseOnChangeHandler = (
-    e: React.ChangeEvent<HTMLInputElement>
+    e: React.ChangeEvent<HTMLInputElement>,
   ) => {
     setNetworkPassphrase(e.currentTarget.value);
   };
@@ -34,6 +35,7 @@ export const SignTransactionDemo = () => {
     } else {
       setTransactionResult(signedTransaction.signedTxXdr);
       setSignerAddressResult(signedTransaction.signerAddress);
+      setSignatureResult(signedTransaction.signature || "");
     }
   };
   return (
@@ -55,6 +57,8 @@ export const SignTransactionDemo = () => {
         <PlaygroundTextarea readOnly value={transactionResult} />
         Signer address:
         <PlaygroundInput readOnly value={signerAddressResult} />
+        Signature:
+        <PlaygroundTextarea readOnly value={signatureResult} />
       </div>
       <button type="button" onClick={btnHandler}>
         Sign Transaction XDR

--- a/docs/docs/playground/components/SignTransactionDemo.tsx
+++ b/docs/docs/playground/components/SignTransactionDemo.tsx
@@ -35,7 +35,7 @@ export const SignTransactionDemo = () => {
     } else {
       setTransactionResult(signedTransaction.signedTxXdr);
       setSignerAddressResult(signedTransaction.signerAddress);
-      setSignatureResult(signedTransaction.signature || "");
+      setSignatureResult(signedTransaction.signature);
     }
   };
   return (

--- a/docs/docs/playground/signTransaction.mdx
+++ b/docs/docs/playground/signTransaction.mdx
@@ -3,7 +3,7 @@ id: signTransaction
 title: signTransaction
 ---
 
-#### `signTransaction(xdr: string, opts?: { network?: string, networkPassphrase?: string, address?: string }) -> <Promise<{ signedTxXdr: string; signerAddress: string; } & { error?: string; }>>`
+#### `signTransaction(xdr: string, opts?: { network?: string, networkPassphrase?: string, address?: string }) -> <Promise<{ signedTxXdr: string; signerAddress: string; signature: string; } & { error?: string; }>>`
 
 import { SignTransactionDemo } from "./components/SignTransactionDemo";
 

--- a/extension/src/background/messageListener/freighterApiMessageListener.ts
+++ b/extension/src/background/messageListener/freighterApiMessageListener.ts
@@ -343,13 +343,18 @@ export const freighterApiMessageListener = (
             }),
           );
         }
-        const response = (signedTransaction: string, signerAddress: string) => {
+        const response = (
+          signedTransaction: string,
+          signerAddress: string,
+          signature: string,
+        ) => {
           if (signedTransaction) {
             if (!isDomainListedAllowed) {
               allowList.push(punycodedDomain);
               localStore.setItem(ALLOWLIST_ID, allowList.join());
             }
-            resolve({ signedTransaction, signerAddress });
+
+            resolve({ signedTransaction, signerAddress, signature });
           }
 
           resolve({

--- a/extension/src/helpers/metrics.ts
+++ b/extension/src/helpers/metrics.ts
@@ -148,28 +148,27 @@ export const emitMetric = async (name: string, body?: any) => {
     return;
   }
 
-let metricsData: MetricsData;
+  let metricsData: MetricsData;
 
-try {
-  const storedData = localStorage.getItem(METRICS_DATA);
-  if (storedData) {
-    metricsData = JSON.parse(storedData);
-  } else {
-    throw new Error("No metrics data found in localStorage");
+  try {
+    const storedData = localStorage.getItem(METRICS_DATA);
+    if (storedData) {
+      metricsData = JSON.parse(storedData);
+    } else {
+      throw new Error("No metrics data found in localStorage");
+    }
+  } catch {
+    // Fallback to default values if parsing fails or data is missing
+    metricsData = {
+      accountType: AccountType.UNKNOWN,
+      hwExists: false,
+      importedExists: false,
+      hwFunded: false,
+      importedFunded: false,
+      freighterFunded: false,
+      unfundedFreighterAccounts: [],
+    };
   }
-} catch {
-  // Fallback to default values if parsing fails or data is missing
-  metricsData = {
-    accountType: AccountType.Unknown,
-    hwExists: false,
-    importedExists: false,
-    hwFunded: false,
-    importedFunded: false,
-    freighterFunded: false,
-    unfundedFreighterAccounts: [],
-  };
-}
-
 
   cache.push({
     event_type: name,


### PR DESCRIPTION
Closes https://github.com/stellar/freighter/issues/1525

This PR makes the `signTransaction` API returns the `signature` (in `hex` format) along with the `signedTxXdr` and `signerAddress` values so that the API will look like this:
```
signTransaction = async (
  transactionXdr: string,
  opts?: {
    networkPassphrase?: string;
    address?: string;
  },
): Promise<
  { signedTxXdr: string; signerAddress: string; signature: string } & {
    error?: FreighterApiError;
  }
> => {
```