### PR TITLE
[FIX] Hardens validation for custom slippage input

### DIFF
--- a/extension/src/popup/components/__tests__/Slippage.test.tsx
+++ b/extension/src/popup/components/__tests__/Slippage.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { render, waitFor, screen, fireEvent } from "@testing-library/react";
+
+import { APPLICATION_STATE as ApplicationState } from "@shared/constants/applicationState";
+import { mockAccounts, Wrapper } from "popup/__testHelpers__";
+import { ROUTES } from "popup/constants/routes";
+import {
+  DEFAULT_NETWORKS,
+  TESTNET_NETWORK_DETAILS,
+} from "@shared/constants/stellar";
+import { SendSettingsSlippage } from "../sendPayment/SendSettings/Slippage";
+
+describe("Slippage component", () => {
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  it("only accepts numbers between 0 and 10", async () => {
+    render(
+      <Wrapper
+        routes={[ROUTES.sendPayment]}
+        state={{
+          auth: {
+            error: null,
+            applicationState: ApplicationState.PASSWORD_CREATED,
+            publicKey:
+              "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF",
+            allAccounts: mockAccounts,
+          },
+          settings: {
+            networkDetails: TESTNET_NETWORK_DETAILS,
+            networksList: DEFAULT_NETWORKS,
+          },
+          transactionSubmission: {
+            transactionData: {
+              allowedSlippage: "1",
+            },
+          },
+        }}
+      >
+        <SendSettingsSlippage previous={ROUTES.account} />
+      </Wrapper>,
+    );
+
+    await waitFor(() => screen.getByTestId("slippage-form"));
+    expect(screen.getByTestId("slippage-form")).toBeDefined();
+
+    const customInput = screen.getByTestId("custom-slippage-input");
+    fireEvent.change(customInput, { target: { value: "-5" } });
+    fireEvent.blur(customInput);
+    expect(await screen.findByText("must be at least 0%")).toBeInTheDocument();
+
+    fireEvent.change(customInput, { target: { value: "12" } });
+    fireEvent.blur(customInput);
+    expect(await screen.findByText("must be below 10%")).toBeInTheDocument();
+  });
+});

--- a/extension/src/popup/components/sendPayment/SendSettings/Slippage/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendSettings/Slippage/index.tsx
@@ -63,11 +63,16 @@ export const SendSettingsSlippage = ({ previous }: { previous: ROUTES }) => {
           navigateTo(previous, navigate);
         }}
         validationSchema={YupObject().shape({
-          customSlippage: YupNumber().max(10, `${t("must be below")} 10%`),
+          customSlippage: YupNumber()
+            .min(0, `${t("must be at least")} 0%`)
+            .max(10, `${t("must be below")} 10%`),
         })}
       >
         {({ setFieldValue, values, errors }) => (
-          <Form className="View__contentAndFooterWrapper">
+          <Form
+            className="View__contentAndFooterWrapper"
+            data-testid="slippage-form"
+          >
             <View.Content hasNoTopPadding>
               <div className="Slippage__cards">
                 <label className="Slippage--radio-label">
@@ -114,8 +119,11 @@ export const SendSettingsSlippage = ({ previous }: { previous: ROUTES }) => {
                 <Field name="customSlippage">
                   {({ field }: FieldProps) => (
                     <Input
+                      data-testid="custom-slippage-input"
                       fieldSize="md"
                       id="custom-input"
+                      min={0}
+                      max={10}
                       placeholder={`${t("Custom")} %`}
                       type="number"
                       {...field}


### PR DESCRIPTION
Closes #1833 

What?
Hardens custom slippage validation so that no negative values are allowed.
Addes unit test for slippage input.