### PR TITLE
[FIX] Don't use custom tokens for token prices

### DIFF
--- a/@shared/api/helpers/soroban.ts
+++ b/@shared/api/helpers/soroban.ts
@@ -5,6 +5,7 @@ import {
   ScInt,
   SorobanRpc,
   contract,
+  StrKey,
 } from "stellar-sdk";
 import { XdrReader } from "@stellar/js-xdr";
 
@@ -577,4 +578,13 @@ const isTokenSpec = (spec: Record<string, any>) => {
 export const getIsTokenSpec = async (contractId: string, serverUrl: string) => {
   const spec = await getContractSpec(contractId, serverUrl);
   return isTokenSpec(spec);
+};
+
+export const isContractId = (contractId: string) => {
+  try {
+    StrKey.decodeContract(contractId);
+    return true;
+  } catch (error) {
+    return false;
+  }
 };

--- a/@shared/helpers/stellar.ts
+++ b/@shared/helpers/stellar.ts
@@ -30,7 +30,7 @@ export const isCustomNetwork = (networkDetails: NetworkDetails) => {
 };
 
 export function getBalanceIdentifier(
-  balance: StellarSdk.Horizon.HorizonApi.BalanceLine
+  balance: StellarSdk.Horizon.HorizonApi.BalanceLine,
 ): string {
   if ("asset_issuer" in balance && !balance.asset_issuer) {
     return "native";
@@ -63,7 +63,7 @@ export const defaultBlockaidScanAssetResult: BlockAidScanAssetResult = {
 
 export const makeDisplayableBalances = async (
   accountDetails: StellarSdk.Horizon.ServerApi.AccountRecord,
-  isMainnet: boolean
+  isMainnet: boolean,
 ) => {
   const { balances, subentry_count, num_sponsored, num_sponsoring } =
     accountDetails;
@@ -101,7 +101,7 @@ export const makeDisplayableBalances = async (
 
     if ("selling_liabilities" in balance) {
       sellingLiabilities = new BigNumber(
-        balance.selling_liabilities
+        balance.selling_liabilities,
       ).toString();
       available = total.minus(sellingLiabilities);
     }
@@ -173,4 +173,25 @@ export const makeDisplayableBalances = async (
   }
 
   return displayableBalances;
+};
+
+export const isSorobanIssuer = (issuer: string) => !issuer.startsWith("G");
+
+export const getAssetFromCanonical = (canonical: string) => {
+  if (canonical === "native") {
+    return StellarSdk.Asset.native();
+  }
+  if (canonical.includes(":")) {
+    const [code, issuer] = canonical.split(":");
+
+    if (isSorobanIssuer(issuer)) {
+      return {
+        code,
+        issuer,
+      };
+    }
+    return new StellarSdk.Asset(code, issuer);
+  }
+
+  throw new Error(`invalid asset canonical id: ${canonical}`);
 };

--- a/extension/src/helpers/stellar.ts
+++ b/extension/src/helpers/stellar.ts
@@ -1,13 +1,13 @@
 import BigNumber from "bignumber.js";
-import { Asset, Networks } from "stellar-sdk";
+import { Networks } from "stellar-sdk";
 import isEqual from "lodash/isEqual";
 
-import { isSorobanIssuer } from "popup/helpers/account";
 import {
   FUTURENET_NETWORK_DETAILS,
   NETWORK_URLS,
   NetworkDetails,
 } from "@shared/constants/stellar";
+export { getAssetFromCanonical } from "@shared/helpers/stellar";
 
 import { TransactionInfo } from "types/transactions";
 import { parsedSearchParam, getUrlHostname } from "./urls";
@@ -59,25 +59,6 @@ export const getTransactionInfo = (search: string) => {
     isDomainListedAllowed,
     flaggedKeys,
   };
-};
-
-export const getAssetFromCanonical = (canonical: string) => {
-  if (canonical === "native") {
-    return Asset.native();
-  }
-  if (canonical.includes(":")) {
-    const [code, issuer] = canonical.split(":");
-
-    if (isSorobanIssuer(issuer)) {
-      return {
-        code,
-        issuer,
-      };
-    }
-    return new Asset(code, issuer);
-  }
-
-  throw new Error(`invalid asset canonical id: ${canonical}`);
 };
 
 export const getCanonicalFromAsset = (

--- a/extension/src/popup/components/account/AccountAssets/index.tsx
+++ b/extension/src/popup/components/account/AccountAssets/index.tsx
@@ -314,7 +314,7 @@ export const AccountAssets = ({
                   valueAddlProperties={{
                     "data-testid": `asset-amount-${canonicalAsset}`,
                   }}
-                  value={`$ ${formatAmount(
+                  value={`$${formatAmount(
                     roundUsdValue(
                       new BigNumber(assetPrice.currentPrice)
                         .multipliedBy(rb.total)

--- a/extension/src/popup/helpers/account.ts
+++ b/extension/src/popup/helpers/account.ts
@@ -9,6 +9,7 @@ import {
 } from "@shared/api/types";
 import { NetworkDetails } from "@shared/constants/stellar";
 import { SorobanTokenInterface } from "@shared/constants/soroban/token";
+export { isSorobanIssuer } from "@shared/helpers/stellar";
 
 import {
   getAssetFromCanonical,
@@ -21,7 +22,7 @@ export const LP_IDENTIFIER = ":lp";
 
 export const sortBalances = (
   balances: Balances,
-  sorobanBalances?: TokenBalances
+  sorobanBalances?: TokenBalances,
 ): AssetType[] => {
   const collection = [] as any[];
   const lpBalances = [] as any[];
@@ -52,13 +53,13 @@ export const getIsPayment = (type: Horizon.HorizonApi.OperationResponseType) =>
 
 export const getIsSupportedSorobanOp = (
   operation: HorizonOperation,
-  networkDetails: NetworkDetails
+  networkDetails: NetworkDetails,
 ) => {
   const attrs = getAttrsFromSorobanHorizonOp(operation, networkDetails);
   return (
     !!attrs &&
     Object.values(SorobanTokenInterface).includes(
-      attrs.fnName as SorobanTokenInterface
+      attrs.fnName as SorobanTokenInterface,
     )
   );
 };
@@ -68,7 +69,7 @@ export const getIsSwap = (operation: HorizonOperation) =>
 
 export const getIsDustPayment = (
   publicKey: string,
-  operation: HorizonOperation
+  operation: HorizonOperation,
 ) =>
   getIsPayment(operation.type) &&
   "asset_type" in operation &&
@@ -234,7 +235,7 @@ export const getIssuerFromBalance = (balance: AssetType) => {
 
 export const isNetworkUrlValid = (
   networkUrl: string,
-  isHttpAllowed: boolean
+  isHttpAllowed: boolean,
 ) => {
   let isValid = true;
 
@@ -250,7 +251,7 @@ export const isNetworkUrlValid = (
 export const displaySorobanId = (
   fullStr: string,
   strLen: number,
-  separator = "..."
+  separator = "...",
 ) => {
   if (fullStr.length <= strLen) {
     return fullStr;
@@ -267,5 +268,3 @@ export const displaySorobanId = (
     fullStr.substring(fullStr.length - backChars)
   );
 };
-
-export const isSorobanIssuer = (issuer: string) => !issuer.startsWith("G");

--- a/extension/src/popup/views/Account/index.tsx
+++ b/extension/src/popup/views/Account/index.tsx
@@ -70,8 +70,13 @@ export const defaultAccountBalances = {
 export const Account = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch<AppDispatch>();
-  const { accountBalances, assetIcons, accountBalanceStatus, tokenPrices } =
-    useSelector(transactionSubmissionSelector);
+  const {
+    accountBalances,
+    assetIcons,
+    accountBalanceStatus,
+    tokenPrices,
+    tokenPricesError,
+  } = useSelector(transactionSubmissionSelector);
   const navigate = useNavigate();
   const accountStatus = useSelector(accountStatusSelector);
   const [isAccountFriendbotFunded, setIsAccountFriendbotFunded] =
@@ -259,7 +264,7 @@ export const Account = () => {
                 containerAddlClasses="AccountView__total-usd-balance-container"
                 valueAddlClasses="AccountView__total-usd-balance"
                 value={
-                  arePricesSupported
+                  arePricesSupported && !tokenPricesError
                     ? `$${formatAmount(
                         roundUsdValue(totalBalanceUsd.toString()),
                       )}`


### PR DESCRIPTION
What
Excludes custom tokens from `getTokenPrices`.
Moves some helpers into the shared helpers for use in API layer, re-exports in extension helpers for convenience.
Returns composite response from `getAccountBalances` to be able to represent `tokenPricesError ` from that thunk.
Does not show total balance if there is a `tokenPricesError `