### PR TITLE
[FIX] temporarily removes getRpcHealth check in message listener

### DIFF
--- a/extension/src/background/messageListener/popupMessageListener.ts
+++ b/extension/src/background/messageListener/popupMessageListener.ts
@@ -77,7 +77,6 @@ import {
   getIsExperimentalModeEnabled,
   getIsHashSigningEnabled,
   getIsHardwareWalletActive,
-  getIsRpcHealthy,
   getUserNotification,
   getSavedNetworks,
   getNetworkDetails,
@@ -766,7 +765,7 @@ export const popupMessageListener = (request: Request, sessionStore: Store) => {
     await localStore.setItem(NETWORK_ID, networkDetails);
     await subscribeAccount(pubKey);
 
-    const isRpcHealthy = await getIsRpcHealthy(networkDetails);
+    const isRpcHealthy = true;
 
     return { networkDetails, isRpcHealthy };
   };
@@ -1505,7 +1504,7 @@ export const popupMessageListener = (request: Request, sessionStore: Store) => {
     await localStore.setItem(IS_HIDE_DUST_ENABLED_ID, isHideDustEnabled);
 
     const networkDetails = await getNetworkDetails();
-    const isRpcHealthy = await getIsRpcHealthy(networkDetails);
+    const isRpcHealthy = true;
     const featureFlags = await getFeatureFlags();
 
     return {
@@ -1565,9 +1564,8 @@ export const popupMessageListener = (request: Request, sessionStore: Store) => {
 
     const isDataSharingAllowed =
       (await localStore.getItem(DATA_SHARING_ID)) ?? true;
-    const networkDetails = await getNetworkDetails();
     const featureFlags = await getFeatureFlags();
-    const isRpcHealthy = await getIsRpcHealthy(networkDetails);
+    const isRpcHealthy = true;
     const userNotification = await getUserNotification();
     const isHashSigningEnabled = await getIsHashSigningEnabled();
     const assetsLists = await getAssetsLists();


### PR DESCRIPTION
What
Removes the calls to `getRpcHealth` in order to improve loading latency on the accounts view
Leaves the plumbing in place for rpcHealth because we plan to either fix the rpc health check latency or re-design the application of the notification in order to not delay the main line loading of the page.

Improves loading of the accounts page from `~5s` -> `~1-2ms`