### PR TITLE
[BUG] truncated long amounts in history items and detail views

### DIFF
--- a/extension/src/popup/components/accountHistory/HistoryItem/styles.scss
+++ b/extension/src/popup/components/accountHistory/HistoryItem/styles.scss
@@ -4,6 +4,7 @@
   cursor: pointer;
 
   &__row {
+    width: 100%;
     display: flex;
     flex: 1;
     flex-direction: row;
@@ -24,6 +25,13 @@
   &__amount {
     text-align: right;
     max-width: 45%;
+
+    .Badge {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: block;
+    }
   }
 
   &__icon {

--- a/extension/src/popup/components/accountHistory/TransactionDetail/styles.scss
+++ b/extension/src/popup/components/accountHistory/TransactionDetail/styles.scss
@@ -10,6 +10,10 @@
     font-weight: var(--font-weight-light);
     padding-bottom: 1.5rem;
     text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: block;
 
     &--isMalicious {
       color: var(--color-red-70);


### PR DESCRIPTION
What
Truncated long string in history item rows.

Why
Long strings cause an overflow
![Screenshot 2025-04-10 at 4 11 49 PM](https://github.com/user-attachments/assets/6cc65462-78b8-4083-ad75-d8a0c4a3d14d)
