### PR TITLE
Bugfix/change scan tx endpoint to post

### DIFF
--- a/extension/src/popup/helpers/blockaid.ts
+++ b/extension/src/popup/helpers/blockaid.ts
@@ -76,14 +76,22 @@ export const useScanTx = () => {
         setLoading(false);
         return null;
       }
+      const options = {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          url: encodeURIComponent(url),
+          tx_xdr: xdr,
+          network: networkDetails.network,
+        }),
+      };
+
       const response = await fetchJson<{
         data: BlockAidScanTxResult;
         error: string | null;
-      }>(
-        `${INDEXER_URL}/scan-tx?url=${encodeURIComponent(
-          url,
-        )}&tx_xdr=${encodeURIComponent(xdr)}&network=${networkDetails.network}`,
-      );
+      }>(`${INDEXER_URL}/scan-tx`, options);
 
       setData(response.data);
       emitMetric(METRIC_NAMES.blockaidTxScan, { response: response.data });


### PR DESCRIPTION
Closes #1963 and Freighter-BE #239

Changes the endpoint to use POST instead of GET. Also, removes `encodeURIComponent` which was malforming some tx xdr's