### PR TITLE
[BUG] restores memo in send flow, adds memo step to e2e test

### DIFF
--- a/extension/e2e-tests/sendPayment.test.ts
+++ b/extension/e2e-tests/sendPayment.test.ts
@@ -117,6 +117,7 @@ test("Send XLM payment to C address", async ({ page, extensionId }) => {
   await expect(page.getByTestId("SendSettingsTransactionFee")).toHaveText(
     /[0-9]/,
   );
+  await page.getByPlaceholder("Memo (optional)").fill("Test memo");
   await page.getByText("Review Send").click();
 
   await expect(page.getByText("Confirm Send")).toBeVisible({
@@ -136,6 +137,7 @@ test("Send XLM payment to C address", async ({ page, extensionId }) => {
 
   await expect(page.getByText("Sent XLM")).toBeVisible();
   await expect(page.getByTestId("asset-amount")).toContainText("0.001");
+  await expect(page.getByTestId("memo")).toContainText("Test memo");
 
   await page.getByTestId("BackButton").click({ force: true });
   await page.getByTestId("BottomNav-link-account").click({ force: true });

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
@@ -509,7 +509,10 @@ export const TransactionDetails = ({
             {showMemo && (
               <div className="TransactionDetails__row">
                 <div>{t("Memo")}</div>
-                <div className="TransactionDetails__row__right">
+                <div
+                  className="TransactionDetails__row__right"
+                  data-testid="memo"
+                >
                   {memo || t("None")}
                 </div>
               </div>

--- a/extension/src/popup/components/sendPayment/SendSettings/Settings/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendSettings/Settings/index.tsx
@@ -395,7 +395,10 @@ export const Settings = ({
                   type="submit"
                   variant="secondary"
                   data-testid="send-settings-btn-continue"
-                  onClick={goToNext}
+                  onClick={() => {
+                    submitForm();
+                    goToNext();
+                  }}
                 >
                   {t("Review")} {isSwap ? t("Swap") : t("Send")}
                 </Button>


### PR DESCRIPTION
What
Restores ability to add memo in send flow

Why
5.31.0 introduced a regression where the memo field is not properly added