### PR TITLE
[FIX] moves verified account check to the first step in the send and swap flows

### DIFF
--- a/extension/src/popup/views/SendPayment/index.tsx
+++ b/extension/src/popup/views/SendPayment/index.tsx
@@ -42,9 +42,9 @@ export const SendPayment = () => {
       case STEPS.PAYMENT_CONFIRM: {
         emitMetric(METRIC_NAMES.sendPaymentConfirm);
         return (
-          <PublicKeyRoute>
+          <VerifiedAccountRoute>
             <SendConfirm goBack={() => setActiveStep(STEPS.PAYMENT_SETTINGS)} />
-          </PublicKeyRoute>
+          </VerifiedAccountRoute>
         );
       }
       case STEPS.SET_PAYMENT_SLIPPAGE: {

--- a/extension/src/popup/views/SendPayment/index.tsx
+++ b/extension/src/popup/views/SendPayment/index.tsx
@@ -42,9 +42,9 @@ export const SendPayment = () => {
       case STEPS.PAYMENT_CONFIRM: {
         emitMetric(METRIC_NAMES.sendPaymentConfirm);
         return (
-          <VerifiedAccountRoute>
+          <PublicKeyRoute>
             <SendConfirm goBack={() => setActiveStep(STEPS.PAYMENT_SETTINGS)} />
-          </VerifiedAccountRoute>
+          </PublicKeyRoute>
         );
       }
       case STEPS.SET_PAYMENT_SLIPPAGE: {
@@ -110,12 +110,12 @@ export const SendPayment = () => {
       case STEPS.DESTINATION: {
         emitMetric(METRIC_NAMES.sendPaymentRecentAddress);
         return (
-          <PublicKeyRoute>
+          <VerifiedAccountRoute>
             <SendTo
               goBack={() => navigate(ROUTES.account)}
               goToNext={() => setActiveStep(STEPS.AMOUNT)}
             />
-          </PublicKeyRoute>
+          </VerifiedAccountRoute>
         );
       }
     }

--- a/extension/src/popup/views/Swap/index.tsx
+++ b/extension/src/popup/views/Swap/index.tsx
@@ -33,9 +33,9 @@ export const Swap = () => {
       case STEPS.SWAP_CONFIRM: {
         emitMetric(METRIC_NAMES.swapConfirm);
         return (
-          <PublicKeyRoute>
+          <VerifiedAccountRoute>
             <SendConfirm goBack={() => setActiveStep(STEPS.SWAP_SETTINGS)} />
-          </PublicKeyRoute>
+          </VerifiedAccountRoute>
         );
       }
       case STEPS.SET_SWAP_SLIPPAGE: {

--- a/extension/src/popup/views/Swap/index.tsx
+++ b/extension/src/popup/views/Swap/index.tsx
@@ -33,9 +33,9 @@ export const Swap = () => {
       case STEPS.SWAP_CONFIRM: {
         emitMetric(METRIC_NAMES.swapConfirm);
         return (
-          <VerifiedAccountRoute>
+          <PublicKeyRoute>
             <SendConfirm goBack={() => setActiveStep(STEPS.SWAP_SETTINGS)} />
-          </VerifiedAccountRoute>
+          </PublicKeyRoute>
         );
       }
       case STEPS.SET_SWAP_SLIPPAGE: {
@@ -76,13 +76,13 @@ export const Swap = () => {
       case STEPS.AMOUNT: {
         emitMetric(METRIC_NAMES.swapAmount);
         return (
-          <PublicKeyRoute>
+          <VerifiedAccountRoute>
             <SendAmount
               goBack={() => navigate(ROUTES.account)}
               goToNext={() => setActiveStep(STEPS.SWAP_SETTINGS)}
               goToChooseAsset={() => setActiveStep(STEPS.CHOOSE_ASSETS)}
             />
-          </PublicKeyRoute>
+          </VerifiedAccountRoute>
         );
       }
       case STEPS.CHOOSE_ASSETS: {


### PR DESCRIPTION
What
Moves private key check to the first step in the send/swap flows

Why
To avoid going backwards after settings data when a private key has been cleared