### PR TITLE
Bugfix/fix incorrect bal in swap

### DIFF
--- a/extension/e2e-tests/sendPayment.test.ts
+++ b/extension/e2e-tests/sendPayment.test.ts
@@ -20,6 +20,163 @@ test("Swap doesn't throw error when account is unfunded", async ({
     "Swap XLM",
   );
 });
+test("Swap shows correct balances for assets", async ({
+  page,
+  extensionId,
+}) => {
+  await page.route("*/**/account-balances/*", async (route) => {
+    const json = {
+      balances: {
+        "FOO:GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5": {
+          token: {
+            type: "credit_alphanum12",
+            code: "FOO",
+            issuer: {
+              key: "GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5",
+            },
+          },
+          sellingLiabilities: "0",
+          buyingLiabilities: "0",
+          total: "100",
+          limit: "922337203685.4775807",
+          available: "100",
+          blockaidData: {
+            result_type: "Benign",
+            malicious_score: "0.0",
+            attack_types: {},
+            chain: "stellar",
+            address:
+              "FOO-GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5",
+            metadata: {
+              external_links: {},
+            },
+            fees: {},
+            features: [],
+            trading_limits: {},
+            financial_stats: {
+              top_holders: [],
+            },
+          },
+        },
+        "BAZ:GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5": {
+          token: {
+            type: "credit_alphanum12",
+            code: "BAZ",
+            issuer: {
+              key: "GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5",
+            },
+          },
+          sellingLiabilities: "0",
+          buyingLiabilities: "0",
+          total: "10",
+          limit: "922337203685.4775807",
+          available: "10",
+          blockaidData: {
+            result_type: "Benign",
+            malicious_score: "0.0",
+            attack_types: {},
+            chain: "stellar",
+            address:
+              "BAZ-GBHNGLLIE3KWGKCHIKMHJ5HVZHYIK7WTBE4QF5PLAKL4CJGSEU7HZIW5",
+            metadata: {
+              external_links: {},
+            },
+            fees: {},
+            features: [
+              {
+                feature_id: "HIGH_REPUTATION_TOKEN",
+                type: "Benign",
+                description: "Token with verified high reputation",
+              },
+            ],
+            trading_limits: {},
+            financial_stats: {
+              top_holders: [],
+            },
+          },
+        },
+        native: {
+          token: {
+            type: "native",
+            code: "XLM",
+          },
+          total: "999",
+          available: "999",
+          sellingLiabilities: "0",
+          buyingLiabilities: "0",
+          minimumBalance: "8",
+          blockaidData: {
+            result_type: "Benign",
+            malicious_score: "0.0",
+            attack_types: {},
+            chain: "stellar",
+            address: "",
+            metadata: {
+              type: "",
+            },
+            fees: {},
+            features: [],
+            trading_limits: {},
+            financial_stats: {},
+          },
+        },
+        "PBT:CAZXRTOKNUQ2JQQF3NCRU7GYMDJNZ2NMQN6IGN4FCT5DWPODMPVEXSND": {
+          token: {
+            code: "PBT",
+            issuer: {
+              key: "CAZXRTOKNUQ2JQQF3NCRU7GYMDJNZ2NMQN6IGN4FCT5DWPODMPVEXSND",
+            },
+          },
+          contractId:
+            "CAZXRTOKNUQ2JQQF3NCRU7GYMDJNZ2NMQN6IGN4FCT5DWPODMPVEXSND",
+          symbol: "PBT",
+          decimals: 5,
+          total: "9899700",
+          available: "9899700",
+          blockaidData: {
+            result_type: "Benign",
+            malicious_score: "0.0",
+            attack_types: {},
+            chain: "stellar",
+            address:
+              "PBT-CAZXRTOKNUQ2JQQF3NCRU7GYMDJNZ2NMQN6IGN4FCT5DWPODMPVEXSND",
+            metadata: {
+              external_links: {},
+            },
+            fees: {},
+            features: [],
+            trading_limits: {},
+            financial_stats: {
+              top_holders: [],
+            },
+          },
+        },
+      },
+      isFunded: true,
+      subentryCount: 14,
+      error: {
+        horizon: null,
+        soroban: null,
+      },
+    };
+    await route.fulfill({ json });
+  });
+  test.slow();
+  await login({ page, extensionId });
+
+  await page.getByTestId("BottomNav-link-swap").click();
+  await expect(page.getByTestId("AppHeaderPageTitle")).toContainText(
+    "Swap XLM",
+  );
+  await page.getByText("From").click();
+  await expect(page.getByTestId("AppHeaderPageTitle")).toContainText(
+    "Your assets",
+  );
+  await expect(page.getByText("100 FOO")).toBeVisible();
+  await expect(page.getByText("10 BAZ")).toBeVisible();
+  await expect(page.getByText("98.997 PBT")).toBeVisible();
+  await expect(page.getByText("999 XLM")).toBeVisible();
+});
 test("Send doesn't throw error when account is unfunded", async ({
   page,
   extensionId,

--- a/extension/src/popup/components/__tests__/AssetDetail.test.tsx
+++ b/extension/src/popup/components/__tests__/AssetDetail.test.tsx
@@ -192,4 +192,71 @@ describe("AssetDetail", () => {
     await waitFor(() => screen.getByTestId("AssetDetail__list"));
     expect(screen.getByTestId("AssetDetail__list")).not.toBeEmptyDOMElement();
   });
+  it("should display all balances", async () => {
+    const props = {
+      accountBalances: {
+        balances: [
+          {
+            available: new BigNumber(10),
+            token: { type: "native", code: "XLM" },
+            total: new BigNumber(10),
+          },
+          {
+            available: new BigNumber(10),
+            token: {
+              type: "credit_alphanum12",
+              code: "FOO",
+              issuer: {
+                key: "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF",
+              },
+            },
+            total: new BigNumber(10),
+          },
+          {
+            available: new BigNumber(100),
+            token: {
+              type: "credit_alphanum12",
+              code: "BAZ",
+              issuer: {
+                key: "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF",
+              },
+            },
+            total: new BigNumber(100),
+          },
+        ],
+      } as any,
+      assetOperations: [] as any,
+      publicKey: "G1",
+      url: "example.com",
+      networkDetails: TESTNET_NETWORK_DETAILS,
+      selectedAsset:
+        "BAZ:GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF",
+      setSelectedAsset: () => null,
+      setIsDetailViewShowing: () => null,
+      subentryCount: 0,
+    };
+
+    render(
+      <Wrapper
+        routes={[ROUTES.account]}
+        state={{
+          auth: {
+            error: null,
+            applicationState: ApplicationState.PASSWORD_CREATED,
+            publicKey: "G1",
+            allAccounts: mockAccounts,
+          },
+          settings: {
+            networkDetails: TESTNET_NETWORK_DETAILS,
+          },
+        }}
+      >
+        <AssetDetail {...props} />
+      </Wrapper>,
+    );
+    await waitFor(() => screen.getByTestId("asset-detail-available-copy"));
+    expect(screen.getByTestId("asset-detail-available-copy")).toHaveTextContent(
+      "100 BAZ",
+    );
+  });
 });

--- a/extension/src/popup/components/account/AssetDetail/index.tsx
+++ b/extension/src/popup/components/account/AssetDetail/index.tsx
@@ -52,7 +52,7 @@ import {
   WarningMessageVariant,
 } from "popup/components/WarningMessages";
 import { AccountBalances } from "helpers/hooks/useGetBalances";
-import { getBalanceByIssuer } from "popup/helpers/balance";
+import { getBalanceByAsset } from "popup/helpers/balance";
 import {
   AssetType,
   LiquidityPoolShareAsset,
@@ -94,8 +94,8 @@ export const AssetDetail = ({
   const canonical = getAssetFromCanonical(selectedAsset);
   const isSorobanAsset = canonical.issuer && isSorobanIssuer(canonical.issuer);
 
-  const selectedBalance = getBalanceByIssuer(
-    canonical.issuer,
+  const selectedBalance = getBalanceByAsset(
+    canonical,
     accountBalances.balances,
   ) as Exclude<AssetType, LiquidityPoolShareAsset | SorobanAsset>;
   const isSuspicious = isAssetSuspicious(selectedBalance.blockaidData);

--- a/extension/src/popup/components/manageAssets/SelectAssetRows/index.tsx
+++ b/extension/src/popup/components/manageAssets/SelectAssetRows/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { Asset } from "stellar-sdk";
 
 import { AppDispatch } from "popup/App";
 import {
@@ -20,7 +21,7 @@ import {
 } from "helpers/stellar";
 import { AccountBalances } from "helpers/hooks/useGetBalances";
 import { getTokenBalance, isContractId } from "popup/helpers/soroban";
-import { isSorobanBalance, getBalanceByIssuer } from "popup/helpers/balance";
+import { isSorobanBalance, getBalanceByAsset } from "popup/helpers/balance";
 import { formatAmount } from "popup/helpers/formatters";
 import { useIsSoroswapEnabled, useIsSwap } from "popup/helpers/useIsSwap";
 
@@ -44,22 +45,26 @@ export const SelectAssetRows = ({
   const isSoroswapEnabled = useIsSoroswapEnabled();
   const isSwap = useIsSwap();
 
-  const getAccountBalance = (issuer: string) => {
+  const getAccountBalance = (
+    canonical: Asset | { code: string; issuer: string },
+  ) => {
     if (!balances) {
       return "";
     }
-    const balance = getBalanceByIssuer(issuer, balances.balances);
+    const balance = getBalanceByAsset(canonical, balances.balances);
     if (balance) {
       return balance.total.toString();
     }
     return "";
   };
 
-  const getTokenBalanceFromCanonical = (issuer: string) => {
+  const getTokenBalanceFromCanonical = (
+    canonical: Asset | { code: string; issuer: string },
+  ) => {
     if (!balances) {
       return "";
     }
-    const balance = getBalanceByIssuer(issuer, balances.balances);
+    const balance = getBalanceByAsset(canonical, balances.balances);
     if (balance && isSorobanBalance(balance)) {
       return getTokenBalance(balance);
     }
@@ -138,8 +143,8 @@ export const SelectAssetRows = ({
                 {!hideBalances && (
                   <div>
                     {isContract
-                      ? getTokenBalanceFromCanonical(issuer)
-                      : formatAmount(getAccountBalance(issuer))}{" "}
+                      ? getTokenBalanceFromCanonical({ code, issuer })
+                      : formatAmount(getAccountBalance({ code, issuer }))}{" "}
                     {code}
                   </div>
                 )}

--- a/extension/src/popup/helpers/balance.ts
+++ b/extension/src/popup/helpers/balance.ts
@@ -36,12 +36,20 @@ export const findAssetBalance = (
       "token" in balance && "issuer" in balance.token
         ? balance.token.issuer.key
         : "";
-    return balanceIssuer === asset.issuer;
+    const balanceCode =
+      "token" in balance && "code" in balance.token ? balance.token.code : "";
+    return balanceIssuer === asset.issuer && balanceCode === asset.code;
   }) as Exclude<AssetType, LiquidityPoolShareAsset> | undefined;
 };
 
-export const getBalanceByIssuer = (issuer: string, balances: AssetType[]) =>
-  balances.find((balance) => {
+export const getBalanceByAsset = (
+  asset: Asset | { issuer: string; code: string },
+  balances: AssetType[],
+) => {
+  const code = asset.code;
+  const issuer = asset.issuer;
+
+  return balances.find((balance) => {
     if ("token" in balance && "type" in balance.token && !issuer) {
       return balance.token.type === "native";
     }
@@ -53,9 +61,11 @@ export const getBalanceByIssuer = (issuer: string, balances: AssetType[]) =>
     return (
       "token" in balance &&
       "issuer" in balance.token &&
-      balance.token.issuer.key === issuer
+      balance.token.issuer.key === issuer &&
+      balance.token.code === code
     );
   });
+};
 
 /*
   Attempts to match a balance to a related contract ID, expects a token or SAC contract ID.

--- a/extension/src/popup/views/Account/index.tsx
+++ b/extension/src/popup/views/Account/index.tsx
@@ -38,7 +38,7 @@ import { useGetAccountData, RequestState } from "./hooks/useGetAccountData";
 
 import "popup/metrics/authServices";
 import "./styles.scss";
-import { getBalanceByIssuer } from "popup/helpers/balance";
+import { getBalanceByAsset } from "popup/helpers/balance";
 
 export const Account = () => {
   const { t } = useTranslation();
@@ -97,7 +97,7 @@ export const Account = () => {
   const totalBalanceUsd = Object.keys(tokenPrices).reduce((prev, curr) => {
     const balances = accountData.data?.balances.balances!;
     const asset = getAssetFromCanonical(curr);
-    const priceBalance = getBalanceByIssuer(asset.issuer, balances);
+    const priceBalance = getBalanceByAsset(asset, balances);
     if (!priceBalance) {
       return prev;
     }


### PR DESCRIPTION
Closes #1995 

This fix makes sure to check both asset code and issuer when fetching and rendering balances in the asset selector in Send/Swap. It also makes sure to take this into account when determining if a trustline is active or not