### PR TITLE
[BUG] resets submission in store on failed results

### DIFF
--- a/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
 import { createPortal } from "react-dom";
 import get from "lodash/get";
@@ -45,7 +46,6 @@ import {
 import { Loading } from "popup/components/Loading";
 
 import "./styles.scss";
-import { useNavigate } from "react-router-dom";
 
 const SwapAssetsIcon = ({
   sourceCanon,
@@ -298,7 +298,6 @@ export const SubmitSuccess = ({ viewDetails }: { viewDetails: () => void }) => {
           onClick={() => {
             dispatch(resetSubmission());
             navigateTo(ROUTES.account, navigate);
-            dispatch(resetSubmission());
           }}
         >
           {t("Done")}
@@ -326,6 +325,7 @@ export const SubmitFail = () => {
   const isSwap = useIsSwap();
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const dispatch = useDispatch();
 
   useEffect(() => {
     emitMetric(METRIC_NAMES.sendPaymentError, { error });
@@ -509,6 +509,7 @@ export const SubmitFail = () => {
           variant="tertiary"
           size="md"
           onClick={() => {
+            dispatch(resetSubmission());
             navigateTo(ROUTES.account, navigate);
           }}
         >


### PR DESCRIPTION
What
Resets the submission values in the store when a user dismisses the SubmitFail component

Why
We were only resetting the store on successful submissions, so if you submitted a transaction that failed then the settings would be retained in the store and would be the initial state of the forms on the next time the user entered the send/swap flow.