### PR TITLE
[REFACTOR] moves token list fetching out of get icons check

### DIFF
--- a/@shared/api/helpers/getIconFromTokenList.ts
+++ b/@shared/api/helpers/getIconFromTokenList.ts
@@ -1,32 +1,25 @@
 import {
   AssetListReponseItem,
-  AssetsLists,
+  AssetListResponse,
 } from "@shared/constants/soroban/asset-list";
 import { NetworkDetails } from "@shared/constants/stellar";
-import { getCombinedAssetListData } from "./token-list";
 import { getCanonicalFromAsset } from "@shared/helpers/stellar";
 
 export const getIconFromTokenLists = async ({
-  networkDetails,
   issuerId,
   contractId,
   code,
-  assetsLists,
+  assetsListsData,
 }: {
   networkDetails: NetworkDetails;
   issuerId?: string;
   contractId?: string;
   code: string;
-  assetsLists: AssetsLists;
+  assetsListsData: AssetListResponse[];
 }) => {
-  const assetListsData = await getCombinedAssetListData({
-    networkDetails,
-    assetsLists,
-  });
-
   let verifiedToken = {} as AssetListReponseItem;
   let canonicalAsset = undefined as string | undefined;
-  for (const data of assetListsData) {
+  for (const data of assetsListsData) {
     const list = data.assets;
     if (list) {
       for (const record of list) {

--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -13,6 +13,7 @@ import {
 import BigNumber from "bignumber.js";
 import { INDEXER_URL } from "@shared/constants/mercury";
 import {
+  AssetListResponse,
   AssetsListItem,
   AssetsLists,
 } from "@shared/constants/soroban/asset-list";
@@ -994,11 +995,11 @@ export const getTokenDetails = async ({
 export const getAssetIcons = async ({
   balances,
   networkDetails,
-  assetsLists,
+  assetsListsData,
 }: {
   balances: Balances;
   networkDetails: NetworkDetails;
-  assetsLists: AssetsLists;
+  assetsListsData: AssetListResponse[];
 }) => {
   const assetIcons = {} as { [code: string]: string };
 
@@ -1022,7 +1023,7 @@ export const getAssetIcons = async ({
             issuerId: key,
             contractId,
             code,
-            assetsLists,
+            assetsListsData,
           });
           if (tokenListIcon.icon && tokenListIcon.canonicalAsset) {
             icon = tokenListIcon.icon;

--- a/extension/src/helpers/hooks/useGetBalances.tsx
+++ b/extension/src/helpers/hooks/useGetBalances.tsx
@@ -18,6 +18,7 @@ import { storeBalanceMetricData } from "helpers/metrics";
 import { filterHiddenBalances, sortBalances } from "popup/helpers/account";
 import { AssetType } from "@shared/api/types/account-balance";
 import { settingsSelector } from "popup/ducks/settings";
+import { getCombinedAssetListData } from "@shared/api/helpers/token-list";
 
 export interface AccountBalances {
   balances: AssetType[];
@@ -71,11 +72,16 @@ function useGetBalances(
         payload.balances = sortBalances(data.balances);
       }
 
+      const assetsListsData = await getCombinedAssetListData({
+        networkDetails,
+        assetsLists,
+      });
+
       if (options.includeIcons) {
         const icons = await getAssetIcons({
           balances: data.balances,
           networkDetails,
-          assetsLists,
+          assetsListsData,
         });
         payload.icons = icons;
       }

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/hooks/useGetTxDetailsData.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/hooks/useGetTxDetailsData.tsx
@@ -28,6 +28,7 @@ import { getAccountBalances, getAssetIcons } from "@shared/api/internal";
 import { getBaseAccount, sortBalances } from "popup/helpers/account";
 import { isContractId } from "popup/helpers/soroban";
 import { settingsSelector } from "popup/ducks/settings";
+import { getCombinedAssetListData } from "@shared/api/helpers/token-list";
 
 export interface TxDetailsData {
   destAssetIconUrl: string;
@@ -219,12 +220,17 @@ function useGetTxDetailsData(
             )
           : ({} as AccountBalancesInterface);
 
+      const assetsListsData = await getCombinedAssetListData({
+        networkDetails,
+        assetsLists,
+      });
+
       const destIcons =
         destinationAccount && !isContractId(destinationAccount)
           ? await getAssetIcons({
               balances: destBalancesResult.balances,
               networkDetails,
-              assetsLists,
+              assetsListsData,
             })
           : {};
 

--- a/extension/src/popup/helpers/__tests__/getIconFromTokenLists.test.js
+++ b/extension/src/popup/helpers/__tests__/getIconFromTokenLists.test.js
@@ -20,7 +20,7 @@ describe("getIconFromTokenLists", () => {
       networkDetails: TESTNET_NETWORK_DETAILS,
       contractId: VERIFIED_TOKEN_CONTRACT,
       code: VERIFIED_TOKEN_CODE,
-      assetsLists: DEFAULT_ASSETS_LISTS,
+      assetsListsData: [validAssetList],
     });
     expect(icon).toEqual(EXPECTED_ICON_URL);
     expect(canonicalAsset).toEqual(
@@ -32,7 +32,7 @@ describe("getIconFromTokenLists", () => {
       networkDetails: TESTNET_NETWORK_DETAILS,
       issuerId: VERIFIED_TOKEN_ISSUER,
       code: VERIFIED_TOKEN_CODE,
-      assetsLists: DEFAULT_ASSETS_LISTS,
+      assetsListsData: [validAssetList],
     });
     expect(icon).toEqual(EXPECTED_ICON_URL);
     expect(canonicalAsset).toEqual(
@@ -44,7 +44,7 @@ describe("getIconFromTokenLists", () => {
       networkDetails: TESTNET_NETWORK_DETAILS,
       issuerId: TEST_PUBLIC_KEY,
       code: VERIFIED_TOKEN_CODE,
-      assetsLists: DEFAULT_ASSETS_LISTS,
+      assetsListsData: [validAssetList],
     });
     expect(icon).toBeUndefined();
     expect(canonicalAsset).toBeUndefined();

--- a/extension/src/popup/views/IntegrationTest.tsx
+++ b/extension/src/popup/views/IntegrationTest.tsx
@@ -53,7 +53,7 @@ import {
 import { Balances } from "@shared/api/types/backend-api";
 import { sendMessageToBackground } from "@shared/api/helpers/extensionMessaging";
 import { SERVICE_TYPES, DEV_SERVER } from "@shared/constants/services";
-import { AssetsLists } from "@shared/constants/soroban/asset-list";
+import { AssetListResponse } from "@shared/constants/soroban/asset-list";
 
 const testPublicKey =
   "GAM7OKWGYLITNSTD6335XNCBT6S2MZRT7UWQVZJHF5BQVMNF3YIKJTWY";
@@ -250,7 +250,7 @@ export const IntegrationTest = () => {
       res = await getAssetIcons({
         balances: testBalances,
         networkDetails: TESTNET_NETWORK_DETAILS,
-        assetsLists: {} as AssetsLists,
+        assetsListsData: [] as AssetListResponse[],
       });
       runAsserts("getAssetIcons", () => {
         assertEq(Object.keys(res as object).length > 0, true);

--- a/extension/src/popup/views/__tests__/Account.test.tsx
+++ b/extension/src/popup/views/__tests__/Account.test.tsx
@@ -17,6 +17,7 @@ import * as UseAssetDomain from "popup/helpers/useAssetDomain";
 import { INDEXER_URL } from "@shared/constants/mercury";
 import { SERVICE_TYPES } from "@shared/constants/services";
 import { Response } from "@shared/api/types";
+import * as TokenListHelpers from "@shared/api/helpers/token-list";
 
 import {
   Wrapper,
@@ -183,6 +184,10 @@ jest.spyOn(ApiInternal, "getAssetIcons").mockImplementation(() =>
       "http://domain.com/icon.png",
   }),
 );
+
+jest
+  .spyOn(TokenListHelpers, "getCombinedAssetListData")
+  .mockImplementation(() => Promise.resolve([]));
 
 describe("Account view", () => {
   afterAll(() => {

--- a/extension/src/popup/views/__tests__/AccountHistory.test.tsx
+++ b/extension/src/popup/views/__tests__/AccountHistory.test.tsx
@@ -6,6 +6,7 @@ import {
   DEFAULT_NETWORKS,
 } from "@shared/constants/stellar";
 import * as ApiInternal from "@shared/api/internal";
+import * as TokenListHelpers from "@shared/api/helpers/token-list";
 
 import {
   Wrapper,
@@ -34,6 +35,10 @@ jest.spyOn(ApiInternal, "getHiddenAssets").mockImplementation(() =>
 jest
   .spyOn(ApiInternal, "getAssetIcons")
   .mockImplementation(() => Promise.resolve({}));
+
+jest
+  .spyOn(TokenListHelpers, "getCombinedAssetListData")
+  .mockImplementation(() => Promise.resolve([]));
 
 describe("AccountHistory", () => {
   it("loads account history view with all transactions", async () => {

--- a/extension/src/popup/views/__tests__/SignTransaction.test.tsx
+++ b/extension/src/popup/views/__tests__/SignTransaction.test.tsx
@@ -14,6 +14,7 @@ import {
 import * as Stellar from "helpers/stellar";
 import { getTokenInvocationArgs } from "popup/helpers/soroban";
 import * as ApiInternal from "@shared/api/internal";
+import * as TokenListHelpers from "@shared/api/helpers/token-list";
 
 import { SignTransaction } from "../SignTransaction";
 import { Wrapper, mockBalances, mockAccounts } from "../../__testHelpers__";
@@ -34,6 +35,10 @@ jest
 jest
   .spyOn(ApiInternal, "getAssetIcons")
   .mockImplementation(() => Promise.resolve({}));
+
+jest
+  .spyOn(TokenListHelpers, "getCombinedAssetListData")
+  .mockImplementation(() => Promise.resolve([]));
 
 const defaultSettingsState = {
   networkDetails: {


### PR DESCRIPTION
What
Moves the fetching of assets list out of the icon check routine and into a parameter for the function

Why
This allows the parent caller of getAssetIcons to fetch the token list and pass it in, assuming that this will be done for every asset row which reduces the call to get the token list to 1 time for the whole list of assets.