### PR TITLE
[BUG] fallback to empty list for non existing assets list

### DIFF
--- a/@shared/api/helpers/token-list.ts
+++ b/@shared/api/helpers/token-list.ts
@@ -74,7 +74,7 @@ export const getCombinedAssetListData = async ({
     }
   }
 
-  const networkLists = assetsLists[network as AssetsListKey];
+  const networkLists = assetsLists[network as AssetsListKey] || [];
   const promiseArr = [];
   for (const networkList of networkLists) {
     const { url = "", isEnabled } = networkList;


### PR DESCRIPTION
What
Fallback to empty list when no asset list is defined in asset list map

Why
Networks without asset lists like futurenet were failing due to the assumption that there would be a list of asset lists.