### PR TITLE
waits for futurenet label on network selector

### DIFF
--- a/extension/e2e-tests/addAsset.test.ts
+++ b/extension/e2e-tests/addAsset.test.ts
@@ -71,7 +71,7 @@ test.skip("Adding Soroban verified token", async ({ page, extensionId }) => {
     timeout: 30000,
   });
 });
-test("Adding token on Futurenet", async ({ page, extensionId }) => {
+test.only("Adding token on Futurenet", async ({ page, extensionId }) => {
   test.slow();
   await loginToTestAccount({ page, extensionId });
 
@@ -86,7 +86,7 @@ test("Adding token on Futurenet", async ({ page, extensionId }) => {
   await page.getByTestId("BottomNav-link-account").click();
   await expect(page.getByTestId("network-selector-open")).toBeVisible();
   await expect(page.getByTestId("network-selector-open")).toHaveText(
-    "Future net",
+    "Future Net",
   );
 
   await page.getByTestId("account-options-dropdown").click();

--- a/extension/e2e-tests/addAsset.test.ts
+++ b/extension/e2e-tests/addAsset.test.ts
@@ -71,7 +71,7 @@ test.skip("Adding Soroban verified token", async ({ page, extensionId }) => {
     timeout: 30000,
   });
 });
-test("Adding token on Futurenet", async ({ page, extensionId }) => {
+test.only("Adding token on Futurenet", async ({ page, extensionId }) => {
   test.slow();
   await loginToTestAccount({ page, extensionId });
 
@@ -84,6 +84,10 @@ test("Adding token on Futurenet", async ({ page, extensionId }) => {
   await page.getByTestId("BackButton").click();
   await page.getByTestId("BackButton").click();
   await page.getByTestId("BottomNav-link-account").click();
+  await expect(page.getByTestId("network-selector-open")).toBeVisible();
+  await expect(page.getByTestId("network-selector-open")).toHaveText(
+    "Futurenet",
+  );
 
   await page.getByTestId("account-options-dropdown").click();
   await page.getByText("Manage Assets").click({ force: true });

--- a/extension/e2e-tests/addAsset.test.ts
+++ b/extension/e2e-tests/addAsset.test.ts
@@ -71,7 +71,7 @@ test.skip("Adding Soroban verified token", async ({ page, extensionId }) => {
     timeout: 30000,
   });
 });
-test.only("Adding token on Futurenet", async ({ page, extensionId }) => {
+test("Adding token on Futurenet", async ({ page, extensionId }) => {
   test.slow();
   await loginToTestAccount({ page, extensionId });
 

--- a/extension/e2e-tests/addAsset.test.ts
+++ b/extension/e2e-tests/addAsset.test.ts
@@ -86,7 +86,7 @@ test("Adding token on Futurenet", async ({ page, extensionId }) => {
   await page.getByTestId("BottomNav-link-account").click();
   await expect(page.getByTestId("network-selector-open")).toBeVisible();
   await expect(page.getByTestId("network-selector-open")).toHaveText(
-    "Futurenet",
+    "Future net",
   );
 
   await page.getByTestId("account-options-dropdown").click();


### PR DESCRIPTION
What
Adds an assertion to wait for the Futurenet label to be visible in the network selector after switching networks.

Why
This test can run fast enough to complete its steps before the network has changed, causing a race condition.