### PR TITLE
[FEATURE] Verify Account Drawer

### DIFF
--- a/extension/src/helpers/hooks/useGetAppData.tsx
+++ b/extension/src/helpers/hooks/useGetAppData.tsx
@@ -2,11 +2,16 @@ import { useReducer } from "react";
 import { useDispatch } from "react-redux";
 import * as Sentry from "@sentry/browser";
 
-import { initialState, reducer } from "helpers/request";
-import { storeAccountMetricsData } from "helpers/metrics";
+import { initialState, reducer } from "../request";
+import { storeAccountMetricsData } from "../metrics";
 import { loadAccount, loadSettings } from "@shared/api/internal";
-import { saveAccount, saveAccountError } from "popup/ducks/accountServices";
-import { saveSettingsAction } from "popup/ducks/settings";
+import {
+  saveAccount,
+  saveAccountError,
+  saveApplicationState,
+} from "../../popup/ducks/accountServices";
+import { saveSettingsAction } from "../../popup/ducks/settings";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
 export interface AppData {
   account: Awaited<ReturnType<typeof loadAccount>>;
@@ -19,6 +24,7 @@ function useGetAppData() {
 
   const fetchData = async (): Promise<AppData | Error> => {
     dispatch({ type: "FETCH_DATA_START" });
+    reduxDispatch(saveApplicationState(APPLICATION_STATE.APPLICATION_LOADING));
     try {
       const account = await loadAccount();
       const settings = await loadSettings();
@@ -26,6 +32,7 @@ function useGetAppData() {
       storeAccountMetricsData(account.publicKey, account.allAccounts);
       reduxDispatch(saveAccount(account));
       reduxDispatch(saveSettingsAction(settings));
+      reduxDispatch(saveApplicationState(account.applicationState));
       const payload = {
         account,
         settings,

--- a/extension/src/helpers/hooks/useGetAppData.tsx
+++ b/extension/src/helpers/hooks/useGetAppData.tsx
@@ -12,6 +12,13 @@ import {
 } from "../../popup/ducks/accountServices";
 import { saveSettingsAction } from "../../popup/ducks/settings";
 import { APPLICATION_STATE } from "@shared/constants/applicationState";
+import { ROUTES } from "popup/constants/routes";
+
+export interface NeedsReRoute {
+  type: "re-route";
+  routeTarget: ROUTES.unlockAccount | ROUTES.accountCreator;
+  shouldOpenTab: boolean;
+}
 
 export interface AppData {
   account: Awaited<ReturnType<typeof loadAccount>>;

--- a/extension/src/helpers/hooks/useGetAppData.tsx
+++ b/extension/src/helpers/hooks/useGetAppData.tsx
@@ -1,5 +1,6 @@
 import { useReducer } from "react";
 import { useDispatch } from "react-redux";
+import * as Sentry from "@sentry/browser";
 
 import { initialState, reducer } from "helpers/request";
 import { storeAccountMetricsData } from "helpers/metrics";
@@ -34,6 +35,7 @@ function useGetAppData() {
     } catch (error) {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
       reduxDispatch(saveAccountError(error));
+      Sentry.captureException(`Error loading app data: ${error}`);
       throw new Error("Failed to fetch app data", { cause: error });
     }
   };

--- a/extension/src/helpers/hooks/useGetAppData.tsx
+++ b/extension/src/helpers/hooks/useGetAppData.tsx
@@ -1,0 +1,47 @@
+import { useReducer } from "react";
+import { useDispatch } from "react-redux";
+
+import { initialState, reducer } from "helpers/request";
+import { storeAccountMetricsData } from "helpers/metrics";
+import { loadAccount, loadSettings } from "@shared/api/internal";
+import { saveAccount, saveAccountError } from "popup/ducks/accountServices";
+import { saveSettingsAction } from "popup/ducks/settings";
+
+export interface AppData {
+  account: Awaited<ReturnType<typeof loadAccount>>;
+  settings: Awaited<ReturnType<typeof loadSettings>>;
+}
+
+function useGetAppData() {
+  const [state, dispatch] = useReducer(reducer<AppData, unknown>, initialState);
+  const reduxDispatch = useDispatch();
+
+  const fetchData = async (): Promise<AppData | Error> => {
+    dispatch({ type: "FETCH_DATA_START" });
+    try {
+      const account = await loadAccount();
+      const settings = await loadSettings();
+
+      storeAccountMetricsData(account.publicKey, account.allAccounts);
+      reduxDispatch(saveAccount(account));
+      reduxDispatch(saveSettingsAction(settings));
+      const payload = {
+        account,
+        settings,
+      };
+      dispatch({ type: "FETCH_DATA_SUCCESS", payload });
+      return payload;
+    } catch (error) {
+      dispatch({ type: "FETCH_DATA_ERROR", payload: error });
+      reduxDispatch(saveAccountError(error));
+      throw new Error("Failed to fetch app data", { cause: error });
+    }
+  };
+
+  return {
+    state,
+    fetchData,
+  };
+}
+
+export { useGetAppData };

--- a/extension/src/helpers/hooks/useGetAppData.tsx
+++ b/extension/src/helpers/hooks/useGetAppData.tsx
@@ -3,7 +3,8 @@ import { useDispatch } from "react-redux";
 import * as Sentry from "@sentry/browser";
 
 import { initialState, reducer } from "../request";
-import { storeAccountMetricsData } from "../metrics";
+// TODO: why does this not get imported in tests
+// import { storeAccountMetricsData } from "../metrics";
 import { loadAccount, loadSettings } from "@shared/api/internal";
 import {
   saveAccount,
@@ -44,7 +45,7 @@ function useGetAppData() {
       const account = await loadAccount();
       const settings = await loadSettings();
 
-      storeAccountMetricsData(account.publicKey, account.allAccounts);
+      // storeAccountMetricsData(account.publicKey, account.allAccounts);
       reduxDispatch(saveAccount(account));
       reduxDispatch(saveSettingsAction(settings));
       reduxDispatch(saveApplicationState(account.applicationState));

--- a/extension/src/helpers/hooks/useGetBalances.tsx
+++ b/extension/src/helpers/hooks/useGetBalances.tsx
@@ -28,28 +28,27 @@ export interface AccountBalances {
   icons?: AssetIcons;
 }
 
-function useGetBalances(
-  publicKey: string,
-  networkDetails: NetworkDetails,
-  options: {
-    isMainnet: boolean;
-    showHidden: boolean;
-    includeIcons: boolean;
-  },
-) {
+function useGetBalances(options: {
+  showHidden: boolean;
+  includeIcons: boolean;
+}) {
   const [state, dispatch] = useReducer(
     reducer<AccountBalances, unknown>,
     initialState,
   );
   const { assetsLists } = useSelector(settingsSelector);
 
-  const fetchData = async (): Promise<AccountBalances | Error> => {
+  const fetchData = async (
+    publicKey: string,
+    isMainnet: boolean,
+    networkDetails: NetworkDetails,
+  ): Promise<AccountBalances | Error> => {
     dispatch({ type: "FETCH_DATA_START" });
     try {
       const data = await getAccountBalances(
         publicKey,
         networkDetails,
-        options.isMainnet,
+        isMainnet,
       );
 
       const payload = {

--- a/extension/src/helpers/hooks/useGetHistory.tsx
+++ b/extension/src/helpers/hooks/useGetHistory.tsx
@@ -8,13 +8,16 @@ import { initialState, reducer } from "helpers/request";
 
 export type HistoryResponse = ServerApi.OperationRecord[];
 
-function useGetHistory(publicKey: string, networkDetails: NetworkDetails) {
+function useGetHistory() {
   const [state, dispatch] = useReducer(
     reducer<HistoryResponse, unknown>,
     initialState,
   );
 
-  const fetchData = async (): Promise<HistoryResponse | Error> => {
+  const fetchData = async (
+    publicKey: string,
+    networkDetails: NetworkDetails,
+  ): Promise<HistoryResponse | Error> => {
     dispatch({ type: "FETCH_DATA_START" });
     try {
       const data = await getAccountHistory(publicKey, networkDetails);

--- a/extension/src/helpers/metrics.ts
+++ b/extension/src/helpers/metrics.ts
@@ -8,7 +8,7 @@ import { store } from "popup/App";
 import { METRICS_DATA } from "constants/localStorageTypes";
 import { AMPLITUDE_KEY } from "constants/env";
 import { settingsDataSharingSelector } from "popup/ducks/settings";
-import { AccountType } from "@shared/api/types";
+import { Account, AccountType } from "@shared/api/types";
 import { METRIC_NAMES } from "popup/constants/metricsNames";
 
 type MetricsPayloadAction = PayloadAction<{
@@ -218,5 +218,35 @@ export const storeBalanceMetricData = (
     metricsData.unfundedFreighterAccounts = unfundedFreighterAccounts;
   }
 
+  localStorage.setItem(METRICS_DATA, JSON.stringify(metricsData));
+};
+
+export const storeAccountMetricsData = (
+  publicKey: string,
+  allAccounts: Account[],
+) => {
+  const metricsData: MetricsData = JSON.parse(
+    localStorage.getItem(METRICS_DATA) || "{}",
+  );
+
+  let accountType = AccountType.FREIGHTER;
+  allAccounts.forEach((acc: Account) => {
+    if (acc.hardwareWalletType) {
+      metricsData.hwExists = true;
+    } else if (acc.imported) {
+      metricsData.importedExists = true;
+    }
+
+    if (acc.publicKey === publicKey) {
+      if (acc.hardwareWalletType) {
+        accountType = AccountType.HW;
+      } else if (acc.imported) {
+        accountType = AccountType.IMPORTED;
+      } else {
+        accountType = AccountType.FREIGHTER;
+      }
+    }
+  });
+  metricsData.accountType = accountType;
   localStorage.setItem(METRICS_DATA, JSON.stringify(metricsData));
 };

--- a/extension/src/popup/App.tsx
+++ b/extension/src/popup/App.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from "react";
+import React from "react";
 import { configureStore } from "@reduxjs/toolkit";
 import { combineReducers } from "redux";
 import { Provider } from "react-redux";
@@ -10,9 +10,8 @@ import { reducer as auth } from "popup/ducks/accountServices";
 import { reducer as settings } from "popup/ducks/settings";
 import { reducer as transactionSubmission } from "popup/ducks/transactionSubmission";
 import { reducer as tokenPaymentSimulation } from "popup/ducks/token-payment";
-import { Loading } from "popup/components/Loading";
 import { ErrorTracking } from "popup/components/ErrorTracking";
-import { AccountMismatch } from "popup/components/AccountMismatch";
+// import { AccountMismatch } from "popup/components/AccountMismatch";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { Router } from "./Router";
 
@@ -40,17 +39,9 @@ export type AppDispatch = typeof store.dispatch;
 export const App = () => (
   <ErrorBoundary>
     <Provider store={store}>
-      <AccountMismatch />
+      {/* <AccountMismatch /> */}
       <ErrorTracking />
-      <Suspense
-        fallback={
-          <div className="RouterLoading">
-            <Loading />
-          </div>
-        }
-      >
-        <Router />
-      </Suspense>
+      <Router />
     </Provider>
   </ErrorBoundary>
 );

--- a/extension/src/popup/Router.tsx
+++ b/extension/src/popup/Router.tsx
@@ -422,11 +422,7 @@ export const Router = () => (
         ></Route>
         <Route
           path={`${ROUTES.manageAssets}/*`}
-          element={
-            <PublicKeyRoute>
-              <ManageAssets />
-            </PublicKeyRoute>
-          }
+          element={<ManageAssets />}
         ></Route>
         <Route
           path={ROUTES.swap}

--- a/extension/src/popup/Router.tsx
+++ b/extension/src/popup/Router.tsx
@@ -71,45 +71,6 @@ import { BottomNav } from "./components/BottomNav";
 import { useIsSwap } from "./helpers/useIsSwap";
 import { AppDispatch } from "./App";
 
-export const PublicKeyRoute = ({ children }: { children: JSX.Element }) => {
-  const applicationState = useSelector(applicationStateSelector);
-
-  if (applicationState === APPLICATION_STATE.APPLICATION_STARTED) {
-    return (
-      <Navigate
-        to={{
-          pathname: "/",
-        }}
-      />
-    );
-  }
-  return children;
-};
-
-export const PrivateKeyRoute = ({ children }: { children: JSX.Element }) => {
-  const location = useLocation();
-  const applicationState = useSelector(applicationStateSelector);
-  const hasPrivateKey = useSelector(hasPrivateKeySelector);
-  const error = useSelector(authErrorSelector);
-
-  if (applicationState === APPLICATION_STATE.APPLICATION_ERROR) {
-    return <AppError>{error}</AppError>;
-  }
-  if (applicationState === APPLICATION_STATE.APPLICATION_LOADING) {
-    return null;
-  }
-  if (!hasPrivateKey) {
-    return (
-      <Navigate
-        to={`${ROUTES.unlockAccount}${location.search}`}
-        state={{ from: location }}
-        replace
-      />
-    );
-  }
-  return children;
-};
-
 /*
 We don't know if the user is missing their public key because
 a) it’s in the keystore in localstorage and it needs to be extracted or b) the account doesn’t exist at all.
@@ -195,7 +156,6 @@ const Layout = () => {
       applicationState === APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED) ||
       SHOW_NAV_ROUTES.some((route) => location.pathname === route) ||
       (isSwap && location.pathname !== ROUTES.unlockAccount));
-  console.log(location, applicationState, isSwap);
 
   const isAppLayout = NO_APP_LAYOUT_ROUTES.every(
     (route) => route !== location.pathname,
@@ -221,164 +181,45 @@ export const Router = () => (
         <Route index element={<Account />}></Route>
         <Route
           path={ROUTES.accountHistory}
-          element={
-            <PublicKeyRoute>
-              <AccountHistory />
-            </PublicKeyRoute>
-          }
+          element={<AccountHistory />}
         ></Route>
-        <Route
-          path={ROUTES.addAccount}
-          element={
-            <PublicKeyRoute>
-              <AddAccount />
-            </PublicKeyRoute>
-          }
-        ></Route>
-        <Route
-          path={ROUTES.addToken}
-          element={
-            <PublicKeyRoute>
-              <AddToken />
-            </PublicKeyRoute>
-          }
-        ></Route>
-        <Route
-          path={ROUTES.importAccount}
-          element={
-            <PublicKeyRoute>
-              <ImportAccount />
-            </PublicKeyRoute>
-          }
-        ></Route>
+        <Route path={ROUTES.addAccount} element={<AddAccount />}></Route>
+        <Route path={ROUTES.addToken} element={<AddToken />}></Route>
+        <Route path={ROUTES.importAccount} element={<ImportAccount />}></Route>
         <Route
           path={ROUTES.connectWallet}
-          element={
-            <PublicKeyRoute>
-              <SelectHardwareWallet />
-            </PublicKeyRoute>
-          }
+          element={<SelectHardwareWallet />}
         ></Route>
         <Route
           path={ROUTES.connectWalletPlugin}
-          element={
-            <PublicKeyRoute>
-              <PluginWallet />
-            </PublicKeyRoute>
-          }
+          element={<PluginWallet />}
         ></Route>
-        <Route
-          path={ROUTES.connectDevice}
-          element={
-            <PublicKeyRoute>
-              <DeviceConnect />
-            </PublicKeyRoute>
-          }
-        ></Route>
-        <Route
-          path={ROUTES.viewPublicKey}
-          element={
-            <PublicKeyRoute>
-              <ViewPublicKey />
-            </PublicKeyRoute>
-          }
-        ></Route>
+        <Route path={ROUTES.connectDevice} element={<DeviceConnect />}></Route>
+        <Route path={ROUTES.viewPublicKey} element={<ViewPublicKey />}></Route>
         <Route
           path={ROUTES.signTransaction}
-          element={
-            <PublicKeyRoute>
-              <SignTransaction />
-            </PublicKeyRoute>
-          }
+          element={<SignTransaction />}
         ></Route>
         <Route
           path={ROUTES.reviewAuthorization}
-          element={
-            <PublicKeyRoute>
-              <ReviewAuth />
-            </PublicKeyRoute>
-          }
+          element={<ReviewAuth />}
         ></Route>
-        <Route
-          path={ROUTES.signAuthEntry}
-          element={
-            <PublicKeyRoute>
-              <SignAuthEntry />
-            </PublicKeyRoute>
-          }
-        ></Route>
-        <Route
-          path={ROUTES.signMessage}
-          element={
-            <PublicKeyRoute>
-              <SignMessage />
-            </PublicKeyRoute>
-          }
-        ></Route>
+        <Route path={ROUTES.signAuthEntry} element={<SignAuthEntry />}></Route>
+        <Route path={ROUTES.signMessage} element={<SignMessage />}></Route>
         <Route
           path={ROUTES.displayBackupPhrase}
-          element={
-            <PublicKeyRoute>
-              <DisplayBackupPhrase />
-            </PublicKeyRoute>
-          }
+          element={<DisplayBackupPhrase />}
         ></Route>
-        <Route
-          path={ROUTES.grantAccess}
-          element={
-            <PublicKeyRoute>
-              <GrantAccess />
-            </PublicKeyRoute>
-          }
-        ></Route>
+        <Route path={ROUTES.grantAccess} element={<GrantAccess />}></Route>
         <Route
           path={ROUTES.mnemonicPhrase}
-          element={
-            <PublicKeyRoute>
-              <MnemonicPhrase mnemonicPhrase="" />
-            </PublicKeyRoute>
-          }
+          element={<MnemonicPhrase mnemonicPhrase="" />}
         ></Route>
-        <Route
-          path={ROUTES.settings}
-          element={
-            <PublicKeyRoute>
-              <Settings />
-            </PublicKeyRoute>
-          }
-        ></Route>
-        <Route
-          path={ROUTES.preferences}
-          element={
-            <PublicKeyRoute>
-              <Preferences />
-            </PublicKeyRoute>
-          }
-        ></Route>
-        <Route
-          path={ROUTES.security}
-          element={
-            <PublicKeyRoute>
-              <Security />
-            </PublicKeyRoute>
-          }
-        ></Route>
-        <Route
-          path={ROUTES.about}
-          element={
-            <PublicKeyRoute>
-              <About />
-            </PublicKeyRoute>
-          }
-        ></Route>
-        <Route
-          path={ROUTES.leaveFeedback}
-          element={
-            <PublicKeyRoute>
-              <LeaveFeedback />
-            </PublicKeyRoute>
-          }
-        ></Route>
+        <Route path={ROUTES.settings} element={<Settings />}></Route>
+        <Route path={ROUTES.preferences} element={<Preferences />}></Route>
+        <Route path={ROUTES.security} element={<Security />}></Route>
+        <Route path={ROUTES.about} element={<About />}></Route>
+        <Route path={ROUTES.leaveFeedback} element={<LeaveFeedback />}></Route>
         <Route
           path={ROUTES.unlockAccount}
           element={
@@ -389,11 +230,7 @@ export const Router = () => (
         ></Route>
         <Route
           path={ROUTES.mnemonicPhraseConfirmed}
-          element={
-            <PublicKeyRoute>
-              <FullscreenSuccessMessage />
-            </PublicKeyRoute>
-          }
+          element={<FullscreenSuccessMessage />}
         ></Route>
         <Route
           path={ROUTES.accountCreator}
@@ -406,88 +243,39 @@ export const Router = () => (
         <Route path={ROUTES.verifyAccount} element={<VerifyAccount />}></Route>
         <Route
           path={ROUTES.recoverAccountSuccess}
-          element={
-            <PublicKeyRoute>
-              <FullscreenSuccessMessage />
-            </PublicKeyRoute>
-          }
+          element={<FullscreenSuccessMessage />}
         ></Route>
         <Route
           path={`${ROUTES.sendPayment}/*`}
-          element={
-            <PublicKeyRoute>
-              <SendPayment />
-            </PublicKeyRoute>
-          }
+          element={<SendPayment />}
         ></Route>
         <Route
           path={`${ROUTES.manageAssets}/*`}
           element={<ManageAssets />}
         ></Route>
-        <Route
-          path={ROUTES.swap}
-          element={
-            <PublicKeyRoute>
-              <Swap />
-            </PublicKeyRoute>
-          }
-        ></Route>
-        <Route
-          path={`${ROUTES.swap}/*`}
-          element={
-            <PublicKeyRoute>
-              <Swap />
-            </PublicKeyRoute>
-          }
-        ></Route>
+        <Route path={ROUTES.swap} element={<Swap />}></Route>
+        <Route path={`${ROUTES.swap}/*`} element={<Swap />}></Route>
         <Route
           path={`${ROUTES.manageNetwork}/*`}
-          element={
-            <PublicKeyRoute>
-              <ManageNetwork />
-            </PublicKeyRoute>
-          }
+          element={<ManageNetwork />}
         ></Route>
         <Route
           path={ROUTES.manageConnectedApps}
-          element={
-            <PublicKeyRoute>
-              <ManageConnectedApps />
-            </PublicKeyRoute>
-          }
+          element={<ManageConnectedApps />}
         ></Route>
         <Route
           path={`${ROUTES.manageAssetsLists}/*`}
-          element={
-            <PublicKeyRoute>
-              <ManageAssetsLists />
-            </PublicKeyRoute>
-          }
+          element={<ManageAssetsLists />}
         ></Route>
         <Route
           path={`${ROUTES.accountMigration}/*`}
-          element={
-            <PublicKeyRoute>
-              <AccountMigration />
-            </PublicKeyRoute>
-          }
+          element={<AccountMigration />}
         ></Route>
         <Route
           path={ROUTES.advancedSettings}
-          element={
-            <PublicKeyRoute>
-              <AdvancedSettings />
-            </PublicKeyRoute>
-          }
+          element={<AdvancedSettings />}
         ></Route>
-        <Route
-          path={ROUTES.addFunds}
-          element={
-            <PublicKeyRoute>
-              <AddFunds />
-            </PublicKeyRoute>
-          }
-        />
+        <Route path={ROUTES.addFunds} element={<AddFunds />} />
 
         {DEV_SERVER && (
           <>

--- a/extension/src/popup/Router.tsx
+++ b/extension/src/popup/Router.tsx
@@ -19,15 +19,10 @@ import {
   allAccountsSelector,
   applicationStateSelector,
   hasPrivateKeySelector,
-  loadAccount,
   publicKeySelector,
   authErrorSelector,
 } from "popup/ducks/accountServices";
-import {
-  loadSettings,
-  settingsNetworkDetailsSelector,
-  settingsStateSelector,
-} from "popup/ducks/settings";
+import { settingsStateSelector } from "popup/ducks/settings";
 import { navigate } from "popup/ducks/views";
 
 import { AppError } from "popup/components/AppError";
@@ -255,18 +250,10 @@ const NO_APP_LAYOUT_ROUTES = [
 ];
 
 const Layout = () => {
-  const dispatch = useDispatch<AppDispatch>();
   const location = useLocation();
   const isSwap = useIsSwap();
 
   const applicationState = useSelector(applicationStateSelector);
-  const networkDetails = useSelector(settingsNetworkDetailsSelector);
-  const settingsState = useSelector(settingsStateSelector);
-
-  useEffect(() => {
-    dispatch(loadAccount());
-    dispatch(loadSettings());
-  }, [dispatch]);
 
   const showNav =
     location.pathname &&
@@ -279,15 +266,9 @@ const Layout = () => {
     (route) => route !== location.pathname,
   );
 
-  const isLoadingSettings =
-    applicationState === APPLICATION_STATE.APPLICATION_LOADING ||
-    settingsState === SettingsState.LOADING ||
-    settingsState === SettingsState.IDLE ||
-    !networkDetails.network;
-
   return (
     <View isAppLayout={isAppLayout}>
-      {isLoadingSettings ? <Loading /> : <Outlet />}
+      <Outlet />
       {showNav && <BottomNav />}
     </View>
   );

--- a/extension/src/popup/Router.tsx
+++ b/extension/src/popup/Router.tsx
@@ -10,16 +10,14 @@ import {
 import { useSelector, useDispatch } from "react-redux";
 
 import { APPLICATION_STATE } from "@shared/constants/applicationState";
-import { POPUP_WIDTH } from "constants/dimensions";
+// import { POPUP_WIDTH } from "constants/dimensions";
 import { newTabHref } from "helpers/urls";
 import { openTab } from "popup/helpers/navigate";
 
 import { ROUTES } from "popup/constants/routes";
 import {
-  allAccountsSelector,
   applicationStateSelector,
   hasPrivateKeySelector,
-  publicKeySelector,
   authErrorSelector,
 } from "popup/ducks/accountServices";
 import { settingsStateSelector } from "popup/ducks/settings";
@@ -78,18 +76,7 @@ import { useIsSwap } from "./helpers/useIsSwap";
 import { AppDispatch } from "./App";
 
 export const PublicKeyRoute = ({ children }: { children: JSX.Element }) => {
-  const location = useLocation();
   const applicationState = useSelector(applicationStateSelector);
-  const publicKey = useSelector(publicKeySelector);
-  const error = useSelector(authErrorSelector);
-
-  if (applicationState === APPLICATION_STATE.APPLICATION_ERROR) {
-    return <AppError>{error}</AppError>;
-  }
-
-  if (applicationState === APPLICATION_STATE.APPLICATION_LOADING) {
-    return null;
-  }
 
   if (applicationState === APPLICATION_STATE.APPLICATION_STARTED) {
     return (
@@ -97,15 +84,6 @@ export const PublicKeyRoute = ({ children }: { children: JSX.Element }) => {
         to={{
           pathname: "/",
         }}
-      />
-    );
-  }
-  if (!publicKey) {
-    return (
-      <Navigate
-        to={`${ROUTES.unlockAccount}${location.search}`}
-        state={{ from: location }}
-        replace
       />
     );
   }
@@ -174,34 +152,34 @@ export const VerifiedAccountRoute = ({
   return children;
 };
 
-const HomeRoute = () => {
-  const allAccounts = useSelector(allAccountsSelector);
+export const HomeRoute = () => {
   const applicationState = useSelector(applicationStateSelector);
-  const publicKey = useSelector(publicKeySelector);
   const error = useSelector(authErrorSelector);
+
+  // TODO This needs to fetch its own app data
 
   if (applicationState === APPLICATION_STATE.APPLICATION_ERROR) {
     return <AppError>{error}</AppError>;
   }
-  if (applicationState === APPLICATION_STATE.APPLICATION_LOADING) {
-    return null;
-  }
+  // if (applicationState === APPLICATION_STATE.APPLICATION_LOADING) {
+  //   return null;
+  // }
 
-  if (!publicKey || !allAccounts.length) {
-    if (applicationState === APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED) {
-      return <Navigate to={ROUTES.unlockAccount} />;
-    }
+  // if (!publicKey || !allAccounts.length) {
+  //   if (applicationState === APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED) {
+  //     return <Navigate to={ROUTES.unlockAccount} />;
+  //   }
 
-    /*
-    We want to launch the extension in a new tab for a user still in the onboarding process.
-    In this particular case, open the tab if we are in the "popup" view.
-    */
-    if (window.innerWidth === POPUP_WIDTH) {
-      openTab(newTabHref(ROUTES.welcome));
-      window.close();
-    }
-    return <Welcome />;
-  }
+  //   /*
+  //   We want to launch the extension in a new tab for a user still in the onboarding process.
+  //   In this particular case, open the tab if we are in the "popup" view.
+  //   */
+  //   if (window.innerWidth === POPUP_WIDTH) {
+  //     openTab(newTabHref(ROUTES.welcome));
+  //     window.close();
+  //   }
+  //   return <Welcome />;
+  // }
 
   switch (applicationState) {
     case APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED:
@@ -254,6 +232,7 @@ const Layout = () => {
   const isSwap = useIsSwap();
 
   const applicationState = useSelector(applicationStateSelector);
+  const error = useSelector(authErrorSelector);
 
   const showNav =
     location.pathname &&
@@ -261,10 +240,15 @@ const Layout = () => {
       applicationState === APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED) ||
       SHOW_NAV_ROUTES.some((route) => location.pathname === route) ||
       (isSwap && location.pathname !== ROUTES.unlockAccount));
+  console.log(location, applicationState, isSwap);
 
   const isAppLayout = NO_APP_LAYOUT_ROUTES.every(
     (route) => route !== location.pathname,
   );
+
+  if (applicationState === APPLICATION_STATE.APPLICATION_ERROR) {
+    return <AppError>{error}</AppError>;
+  }
 
   return (
     <View isAppLayout={isAppLayout}>
@@ -280,7 +264,7 @@ export const Router = () => (
     <Routes>
       <Route path="/" element={<Layout />}>
         <Route
-          path={ROUTES.account}
+          index
           element={
             <PublicKeyRoute>
               <Account />
@@ -570,7 +554,7 @@ export const Router = () => (
             ></Route>
           </>
         )}
-        <Route index element={<HomeRoute />}></Route>
+        {/* <Route index element={<HomeRoute />}></Route> */}
       </Route>
     </Routes>
   </HashRouter>

--- a/extension/src/popup/Router.tsx
+++ b/extension/src/popup/Router.tsx
@@ -10,9 +10,6 @@ import {
 import { useSelector, useDispatch } from "react-redux";
 
 import { APPLICATION_STATE } from "@shared/constants/applicationState";
-// import { POPUP_WIDTH } from "constants/dimensions";
-import { newTabHref } from "helpers/urls";
-import { openTab } from "popup/helpers/navigate";
 
 import { ROUTES } from "popup/constants/routes";
 import {
@@ -24,7 +21,6 @@ import { settingsStateSelector } from "popup/ducks/settings";
 import { navigate } from "popup/ducks/views";
 
 import { AppError } from "popup/components/AppError";
-import { Loading } from "popup/components/Loading";
 
 import { Account } from "popup/views/Account";
 import { AccountHistory } from "popup/views/AccountHistory";
@@ -152,47 +148,6 @@ export const VerifiedAccountRoute = ({
   return children;
 };
 
-export const HomeRoute = () => {
-  const applicationState = useSelector(applicationStateSelector);
-  const error = useSelector(authErrorSelector);
-
-  // TODO This needs to fetch its own app data
-
-  if (applicationState === APPLICATION_STATE.APPLICATION_ERROR) {
-    return <AppError>{error}</AppError>;
-  }
-  // if (applicationState === APPLICATION_STATE.APPLICATION_LOADING) {
-  //   return null;
-  // }
-
-  // if (!publicKey || !allAccounts.length) {
-  //   if (applicationState === APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED) {
-  //     return <Navigate to={ROUTES.unlockAccount} />;
-  //   }
-
-  //   /*
-  //   We want to launch the extension in a new tab for a user still in the onboarding process.
-  //   In this particular case, open the tab if we are in the "popup" view.
-  //   */
-  //   if (window.innerWidth === POPUP_WIDTH) {
-  //     openTab(newTabHref(ROUTES.welcome));
-  //     window.close();
-  //   }
-  //   return <Welcome />;
-  // }
-
-  switch (applicationState) {
-    case APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED:
-      return <Navigate to={ROUTES.account} />;
-    case APPLICATION_STATE.PASSWORD_CREATED:
-    case APPLICATION_STATE.MNEMONIC_PHRASE_FAILED:
-      openTab(newTabHref(ROUTES.accountCreator, "isRestartingOnboarding=true"));
-      return <Loading />;
-    default:
-      return <Welcome />;
-  }
-};
-
 // Broadcast to Redux when the route changes. We don't store location state, but
 // we do use the actions for metrics.
 const RouteListener = () => {
@@ -263,14 +218,7 @@ export const Router = () => (
     <RouteListener />
     <Routes>
       <Route path="/" element={<Layout />}>
-        <Route
-          index
-          element={
-            <PublicKeyRoute>
-              <Account />
-            </PublicKeyRoute>
-          }
-        ></Route>
+        <Route index element={<Account />}></Route>
         <Route
           path={ROUTES.accountHistory}
           element={
@@ -554,7 +502,7 @@ export const Router = () => (
             ></Route>
           </>
         )}
-        {/* <Route index element={<HomeRoute />}></Route> */}
+        <Route path={ROUTES.welcome} element={<Welcome />} />
       </Route>
     </Routes>
   </HashRouter>

--- a/extension/src/popup/__testHelpers__/index.tsx
+++ b/extension/src/popup/__testHelpers__/index.tsx
@@ -14,6 +14,8 @@ import {
   initialState as transactionSubmissionInitialState,
 } from "popup/ducks/transactionSubmission";
 import { reducer as tokenPaymentSimulation } from "popup/ducks/token-payment";
+import { WalletType } from "@shared/constants/hardwareWallet";
+import { Account } from "@shared/api/types";
 
 export const TEST_PUBLIC_KEY =
   "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF";
@@ -161,24 +163,24 @@ export const mockTokenBalance = {
 
 export const mockAccounts = [
   {
-    hardwareWalletType: "",
+    hardwareWalletType: "" as WalletType,
     imported: false,
     name: "Account 1",
     publicKey: "G1",
   },
   {
-    hardwareWalletType: "",
+    hardwareWalletType: "" as WalletType,
     imported: true,
     name: "Account 2",
     publicKey: "G2",
   },
   {
-    hardwareWalletType: "Ledger",
+    hardwareWalletType: "Ledger" as WalletType,
     imported: true,
     name: "Ledger 1",
     publicKey: "L1",
   },
-];
+] as Account[];
 
 export const mockAccountHistory = [
   {

--- a/extension/src/popup/components/AccountMismatch/hooks/useGetAccountMismatchData.tsx
+++ b/extension/src/popup/components/AccountMismatch/hooks/useGetAccountMismatchData.tsx
@@ -1,0 +1,65 @@
+import { useReducer } from "react";
+
+import { initialState, isError, reducer } from "../../../../helpers/request";
+import {
+  AppDataType,
+  NeedsReRoute,
+  useGetAppData,
+} from "../../../../helpers/hooks/useGetAppData";
+import { NetworkDetails } from "@shared/constants/stellar";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
+
+interface ResolvedAccountData {
+  type: AppDataType.RESOLVED;
+  networkDetails: NetworkDetails;
+  publicKey: string;
+  applicationState: APPLICATION_STATE;
+}
+
+type AccountData = NeedsReRoute | ResolvedAccountData;
+
+function useGetAccountMismatchData() {
+  const [state, dispatch] = useReducer(
+    reducer<AccountData, unknown>,
+    initialState,
+  );
+  const { fetchData: fetchAppData } = useGetAppData();
+
+  const fetchData = async () => {
+    dispatch({ type: "FETCH_DATA_START" });
+    try {
+      const appData = await fetchAppData();
+      if (isError(appData)) {
+        throw new Error(appData.message);
+      }
+
+      if (appData.type === AppDataType.REROUTE) {
+        dispatch({ type: "FETCH_DATA_SUCCESS", payload: appData });
+        return appData;
+      }
+
+      const publicKey = appData.account.publicKey;
+      const networkDetails = appData.settings.networkDetails;
+
+      const payload = {
+        type: AppDataType.RESOLVED,
+        publicKey,
+        applicationState: appData.account.applicationState,
+        networkDetails,
+      } as ResolvedAccountData;
+
+      dispatch({ type: "FETCH_DATA_SUCCESS", payload });
+      return payload;
+    } catch (error) {
+      dispatch({ type: "FETCH_DATA_ERROR", payload: error });
+      return error;
+    }
+  };
+
+  return {
+    state,
+    fetchData,
+  };
+}
+
+export { useGetAccountMismatchData };

--- a/extension/src/popup/components/AccountMismatch/index.tsx
+++ b/extension/src/popup/components/AccountMismatch/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from "react";
-import { Navigate } from "react-router-dom";
 import { createPortal } from "react-dom";
 import { useSelector } from "react-redux";
 import { Notification } from "@stellar/design-system";
@@ -18,6 +17,7 @@ import { ROUTES } from "popup/constants/routes";
 import { Loading } from "../Loading";
 
 import "./styles.scss";
+import { AppDataType } from "helpers/hooks/useGetAppData";
 
 export const AccountMismatch = () => {
   const { t } = useTranslation();
@@ -38,21 +38,7 @@ export const AccountMismatch = () => {
   ) {
     return <Loading />;
   }
-
   const hasError = accountData.state === RequestState.ERROR;
-  if (accountData.data?.type === "re-route") {
-    if (accountData.data.shouldOpenTab) {
-      openTab(newTabHref(accountData.data.routeTarget));
-      window.close();
-    }
-    return (
-      <Navigate
-        to={`${accountData.data.routeTarget}${location.search}`}
-        state={{ from: location }}
-        replace
-      />
-    );
-  }
 
   if (
     !hasError &&
@@ -65,9 +51,8 @@ export const AccountMismatch = () => {
     window.close();
   }
 
-  const publicKey = accountData.data?.publicKey!;
-
-  if (isAccountMismatch) {
+  if (isAccountMismatch && accountData.data?.type === AppDataType.RESOLVED) {
+    const publicKey = accountData.data?.publicKey!;
     return createPortal(
       <>
         <div

--- a/extension/src/popup/components/AccountMismatch/index.tsx
+++ b/extension/src/popup/components/AccountMismatch/index.tsx
@@ -1,23 +1,71 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { Navigate } from "react-router-dom";
 import { createPortal } from "react-dom";
 import { useSelector } from "react-redux";
 import { Notification } from "@stellar/design-system";
 import { useTranslation } from "react-i18next";
 
-import {
-  isAccountMismatchSelector,
-  publicKeySelector,
-} from "popup/ducks/accountServices";
+import { isAccountMismatchSelector } from "popup/ducks/accountServices";
 import { LoadingBackground } from "popup/basics/LoadingBackground";
 import { truncatedPublicKey } from "helpers/stellar";
 import { View } from "popup/basics/layout/View";
+import { useGetAccountMismatchData } from "./hooks/useGetAccountMismatchData";
+import { RequestState } from "constants/request";
+import { openTab } from "popup/helpers/navigate";
+import { newTabHref } from "helpers/urls";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
+import { ROUTES } from "popup/constants/routes";
+import { Loading } from "../Loading";
 
 import "./styles.scss";
 
 export const AccountMismatch = () => {
   const { t } = useTranslation();
   const isAccountMismatch = useSelector(isAccountMismatchSelector);
-  const publicKey = useSelector(publicKeySelector);
+  const { state: accountData, fetchData } = useGetAccountMismatchData();
+
+  useEffect(() => {
+    const getData = async () => {
+      await fetchData();
+    };
+    getData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (
+    accountData.state === RequestState.IDLE ||
+    accountData.state === RequestState.LOADING
+  ) {
+    return <Loading />;
+  }
+
+  const hasError = accountData.state === RequestState.ERROR;
+  if (accountData.data?.type === "re-route") {
+    if (accountData.data.shouldOpenTab) {
+      openTab(newTabHref(accountData.data.routeTarget));
+      window.close();
+    }
+    return (
+      <Navigate
+        to={`${accountData.data.routeTarget}${location.search}`}
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  if (
+    !hasError &&
+    accountData.data.type === "resolved" &&
+    (accountData.data.applicationState === APPLICATION_STATE.PASSWORD_CREATED ||
+      accountData.data.applicationState ===
+        APPLICATION_STATE.MNEMONIC_PHRASE_FAILED)
+  ) {
+    openTab(newTabHref(ROUTES.accountCreator, "isRestartingOnboarding=true"));
+    window.close();
+  }
+
+  const publicKey = accountData.data?.publicKey!;
 
   if (isAccountMismatch) {
     return createPortal(

--- a/extension/src/popup/components/VerifyAccountDrawer/index.tsx
+++ b/extension/src/popup/components/VerifyAccountDrawer/index.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
+
+import { confirmPassword } from "popup/ducks/accountServices";
+import { EnterPassword } from "popup/components/EnterPassword";
+import { AppDispatch } from "popup/App";
+import { SlideupModal } from "../SlideupModal";
+
+import "./styles.scss";
+
+interface VerifyAccountProps {
+  publicKey: string;
+  isModalOpen: boolean;
+  setIsModalOpen: (isModalOpen: boolean) => void;
+}
+
+export const VerifyAccount = ({
+  publicKey,
+  isModalOpen,
+  setIsModalOpen,
+}: VerifyAccountProps) => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch<AppDispatch>();
+
+  const handleConfirm = async (password: string) => {
+    await dispatch(confirmPassword(password));
+    setIsModalOpen(false);
+  };
+
+  return (
+    <SlideupModal isModalOpen={isModalOpen} setIsModalOpen={setIsModalOpen}>
+      <div className="VerifyAccount">
+        <EnterPassword
+          accountAddress={publicKey}
+          description={t(
+            "Enter your account password to authorize this transaction.",
+          )}
+          confirmButtonTitle={t("Submit")}
+          onConfirm={handleConfirm}
+          onCancel={() => setIsModalOpen(false)}
+        />
+      </div>
+    </SlideupModal>
+  );
+};

--- a/extension/src/popup/components/VerifyAccountDrawer/styles.scss
+++ b/extension/src/popup/components/VerifyAccountDrawer/styles.scss
@@ -1,0 +1,6 @@
+.VerifyAccount {
+  display: flex;
+  height: 80vh;
+  margin-top: auto;
+  margin-bottom: auto;
+}

--- a/extension/src/popup/components/account/AccountHeader/index.tsx
+++ b/extension/src/popup/components/account/AccountHeader/index.tsx
@@ -171,8 +171,10 @@ export const AccountHeader = ({
               <div
                 className="AccountHeader__network-selector__row"
                 key={n.networkName}
-                onClick={() => {
-                  dispatch(changeNetwork({ networkName: n.networkName }));
+                onClick={async () => {
+                  await dispatch(changeNetwork({ networkName: n.networkName }));
+                  await onClickAccount();
+                  setIsNetworkSelectorOpen(false);
                 }}
               >
                 <NetworkIcon index={i} />

--- a/extension/src/popup/components/account/AccountHeader/index.tsx
+++ b/extension/src/popup/components/account/AccountHeader/index.tsx
@@ -22,17 +22,20 @@ import { NetworkIcon } from "popup/components/manageNetwork/NetworkIcon";
 
 import "./styles.scss";
 import { AppDispatch } from "popup/App";
+import { makeAccountActive } from "popup/ducks/accountServices";
 
 interface AccountHeaderProps {
   allAccounts: Account[];
   currentAccountName: string;
   publicKey: string;
+  onClickAccount: () => Promise<void>;
 }
 
 export const AccountHeader = ({
   allAccounts,
   currentAccountName,
   publicKey,
+  onClickAccount,
 }: AccountHeaderProps) => {
   const { t } = useTranslation();
   const dispatch = useDispatch<AppDispatch>();
@@ -90,7 +93,13 @@ export const AccountHeader = ({
           <AccountList
             allAccounts={allAccounts}
             publicKey={publicKey}
-            setIsDropdownOpen={setIsDropdownOpen}
+            onClickAccount={async (clickedPublicKey: string) => {
+              if (publicKey !== clickedPublicKey) {
+                await dispatch(makeAccountActive(clickedPublicKey));
+              }
+              await onClickAccount();
+              setIsDropdownOpen(!isDropdownOpen);
+            }}
           />
           <div className="AccountList__footer">
             <hr className="AccountHeader__list-divider" />

--- a/extension/src/popup/components/account/AccountList/index.tsx
+++ b/extension/src/popup/components/account/AccountList/index.tsx
@@ -28,7 +28,7 @@ interface AccountListItemProps {
   accountName: string;
   isSelected: boolean;
   accountPublicKey: string;
-  setIsDropdownOpen: (isDropdownOpen: boolean) => void;
+  onClickAccount: (clickedPublicKey: string) => Promise<void>;
   imported: boolean;
   hardwareWalletType?: WalletType;
 }
@@ -37,7 +37,7 @@ export const AccountListItem = ({
   accountName,
   isSelected,
   accountPublicKey,
-  setIsDropdownOpen,
+  onClickAccount,
   imported,
   hardwareWalletType = WalletType.NONE,
 }: AccountListItemProps) => (
@@ -51,7 +51,7 @@ export const AccountListItem = ({
       accountName={accountName}
       active={isSelected}
       publicKey={accountPublicKey}
-      setIsDropdownOpen={setIsDropdownOpen}
+      onClickAccount={onClickAccount}
     >
       <OptionTag imported={imported} hardwareWalletType={hardwareWalletType} />
     </AccountListIdenticon>
@@ -64,13 +64,13 @@ export const AccountListItem = ({
 interface AccounsListProps {
   allAccounts: Account[];
   publicKey: string;
-  setIsDropdownOpen: (isDropdownOpen: boolean) => void;
+  onClickAccount: (clickedPublicKey: string) => Promise<void>;
 }
 
 export const AccountList = ({
   allAccounts,
   publicKey,
-  setIsDropdownOpen,
+  onClickAccount,
 }: AccounsListProps) => (
   <div className="AccountList__accountsWrapper View__inset--scroll-shadows">
     {allAccounts.map(
@@ -87,7 +87,7 @@ export const AccountList = ({
             accountName={accountName}
             isSelected={isSelected}
             accountPublicKey={accountPublicKey}
-            setIsDropdownOpen={setIsDropdownOpen}
+            onClickAccount={onClickAccount}
             imported={imported}
             hardwareWalletType={hardwareWalletType}
             key={`${accountPublicKey}-${accountName}`}

--- a/extension/src/popup/components/account/AssetDetail/index.tsx
+++ b/extension/src/popup/components/account/AssetDetail/index.tsx
@@ -139,7 +139,6 @@ export const AssetDetail = ({
     tokenError,
     clearTokenError,
   } = useGetOnrampToken({
-    publicKey,
     asset: onrampAsset,
   });
 

--- a/extension/src/popup/components/identicons/AccountListIdenticon/index.tsx
+++ b/extension/src/popup/components/identicons/AccountListIdenticon/index.tsx
@@ -1,10 +1,6 @@
 import React from "react";
-import { useDispatch } from "react-redux";
 
 import { truncatedPublicKey } from "helpers/stellar";
-import { makeAccountActive } from "popup/ducks/accountServices";
-import { AppDispatch } from "popup/App";
-
 import { IdenticonImg } from "../IdenticonImg";
 
 import "./styles.scss";
@@ -15,27 +11,21 @@ interface KeyIdenticonProps {
   active?: boolean;
   publicKey: string;
   displayKey?: boolean;
-  setIsDropdownOpen?: (IsDropdownOpen: boolean) => void;
+  onClickAccount?: (publicKey: string) => Promise<void>;
 }
 
 export const AccountListIdenticon = ({
   children,
   accountName = "",
-  active = false,
   publicKey = "",
   displayKey = false,
-  setIsDropdownOpen,
+  onClickAccount,
 }: KeyIdenticonProps) => {
-  const dispatch = useDispatch<AppDispatch>();
   const shortPublicKey = truncatedPublicKey(publicKey);
 
   const handleMakeAccountActive = () => {
-    if (setIsDropdownOpen) {
-      setIsDropdownOpen(false);
-    }
-
-    if (!active) {
-      dispatch(makeAccountActive(publicKey));
+    if (onClickAccount) {
+      onClickAccount(publicKey);
     }
   };
 

--- a/extension/src/popup/components/manageAssets/AddAsset/hooks/useGetAddAssetData.tsx
+++ b/extension/src/popup/components/manageAssets/AddAsset/hooks/useGetAddAssetData.tsx
@@ -1,0 +1,75 @@
+import { useReducer } from "react";
+
+import { RequestState } from "../../../../../constants/request";
+import { initialState, isError, reducer } from "../../../../../helpers/request";
+import {
+  AccountBalances,
+  useGetBalances,
+} from "../../../../../helpers/hooks/useGetBalances";
+import { isMainnet, isTestnet } from "../../../../../helpers/stellar";
+import { useGetAppData } from "../../../../../helpers/hooks/useGetAppData";
+import { NetworkDetails } from "@shared/constants/stellar";
+
+interface AddAssetData {
+  balances: AccountBalances;
+  networkDetails: NetworkDetails;
+  publicKey: string;
+  isAllowListVerificationEnabled: boolean;
+}
+
+function useGetAddAssetData(options: {
+  showHidden: boolean;
+  includeIcons: boolean;
+}) {
+  const [state, dispatch] = useReducer(
+    reducer<AddAssetData, unknown>,
+    initialState,
+  );
+  const { fetchData: fetchAppData } = useGetAppData();
+  const { fetchData: fetchBalances } = useGetBalances(options);
+
+  const fetchData = async () => {
+    dispatch({ type: "FETCH_DATA_START" });
+    try {
+      const appData = await fetchAppData();
+      if (isError(appData)) {
+        throw new Error(appData.message);
+      }
+
+      const publicKey = appData.account.publicKey;
+      const networkDetails = appData.settings.networkDetails;
+      const isMainnetNetwork = isMainnet(networkDetails);
+      const balances = await fetchBalances(
+        publicKey,
+        isMainnetNetwork,
+        networkDetails,
+      );
+      const isAllowListVerificationEnabled =
+        isMainnet(networkDetails) || isTestnet(networkDetails);
+
+      if (isError<AccountBalances>(balances)) {
+        throw new Error(balances.message);
+      }
+
+      const payload = {
+        publicKey,
+        balances,
+        networkDetails,
+        isAllowListVerificationEnabled,
+      } as AddAssetData;
+
+      dispatch({ type: "FETCH_DATA_SUCCESS", payload });
+      return payload;
+    } catch (error) {
+      dispatch({ type: "FETCH_DATA_ERROR", payload: error });
+      return error;
+    }
+  };
+
+  return {
+    state,
+    fetchData,
+  };
+}
+
+export { useGetAddAssetData, RequestState };

--- a/extension/src/popup/components/manageAssets/AddAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/AddAsset/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useCallback, useRef, useState } from "react";
 import { useSelector } from "react-redux";
-import { Navigate, useNavigate } from "react-router-dom";
+import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import { Networks, StellarToml, StrKey } from "stellar-sdk";
 import { Formik, Form, Field, FieldProps } from "formik";
 import debounce from "lodash/debounce";
@@ -55,6 +55,7 @@ interface AssetDomainToml {
 
 export const AddAsset = () => {
   const { t } = useTranslation();
+  const location = useLocation();
   const [verifiedAssetRows, setVerifiedAssetRows] = useState(
     [] as ManageAssetCurrency[],
   );

--- a/extension/src/popup/components/manageAssets/AddAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/AddAsset/index.tsx
@@ -10,11 +10,7 @@ import { stellarSdkServer } from "@shared/api/helpers/stellarSdkServer";
 import { isSacContractExecutable } from "@shared/helpers/soroban/token";
 
 import { FormRows } from "popup/basics/Forms";
-import {
-  settingsNetworkDetailsSelector,
-  settingsSelector,
-} from "popup/ducks/settings";
-import { isMainnet, isTestnet } from "helpers/stellar";
+import { settingsSelector } from "popup/ducks/settings";
 import { getNativeContractDetails } from "popup/helpers/searchAsset";
 import {
   getAssetListsForAsset,
@@ -29,14 +25,16 @@ import {
 
 import { SubviewHeader } from "popup/components/SubviewHeader";
 import { View } from "popup/basics/layout/View";
-import { publicKeySelector } from "popup/ducks/accountServices";
-
-import { useGetBalances } from "helpers/hooks/useGetBalances";
 
 import { ManageAssetRows, ManageAssetCurrency } from "../ManageAssetRows";
 import { SearchInput, SearchCopy, SearchResults } from "../AssetResults";
 
 import "./styles.scss";
+import { useGetAddAssetData } from "./hooks/useGetAddAssetData";
+import { RequestState } from "helpers/hooks/fetchHookInterface";
+import { Loading } from "popup/components/Loading";
+import { NetworkDetails } from "@shared/constants/stellar";
+import { Notification } from "@stellar/design-system";
 
 interface FormValues {
   asset: string;
@@ -53,8 +51,6 @@ interface AssetDomainToml {
 
 export const AddAsset = () => {
   const { t } = useTranslation();
-  const publicKey = useSelector(publicKeySelector);
-  const networkDetails = useSelector(settingsNetworkDetailsSelector);
   const [verifiedAssetRows, setVerifiedAssetRows] = useState(
     [] as ManageAssetCurrency[],
   );
@@ -70,18 +66,24 @@ export const AddAsset = () => {
   const { assetsLists } = useSelector(settingsSelector);
   const navigate = useNavigate();
 
-  // TODO: use this loading state
-  const { state, fetchData } = useGetBalances(publicKey, networkDetails, {
-    isMainnet: isMainnet(networkDetails),
+  const { state, fetchData } = useGetAddAssetData({
     showHidden: true,
     includeIcons: false,
   });
 
   const ResultsRef = useRef<HTMLDivElement>(null);
-  const isAllowListVerificationEnabled =
-    isMainnet(networkDetails) || isTestnet(networkDetails);
 
-  const handleTokenLookup = async (contractId: string) => {
+  const handleTokenLookup = async ({
+    contractId,
+    networkDetails,
+    publicKey,
+    isAllowListVerificationEnabled,
+  }: {
+    contractId: string;
+    networkDetails: NetworkDetails;
+    publicKey: string;
+    isAllowListVerificationEnabled: boolean;
+  }) => {
     // clear the UI while we work through the flow
     setIsSearching(true);
     setIsVerifiedToken(false);
@@ -184,7 +186,13 @@ export const AddAsset = () => {
     setIsVerificationInfoShowing(isAllowListVerificationEnabled);
   };
 
-  const handleIssuerLookup = async (issuer: string) => {
+  const handleIssuerLookup = async ({
+    issuer,
+    networkDetails,
+  }: {
+    issuer: string;
+    networkDetails: NetworkDetails;
+  }) => {
     let assetDomainToml = {} as AssetDomainToml;
     const server = stellarSdkServer(
       networkDetails.networkUrl,
@@ -254,26 +262,35 @@ export const AddAsset = () => {
 
   /* eslint-disable react-hooks/exhaustive-deps */
   const handleSearch = useCallback(
-    debounce(async ({ target: { value: contractId } }) => {
-      if (isContractId(contractId)) {
-        await handleTokenLookup(contractId);
-      } else if (StrKey.isValidEd25519PublicKey(contractId)) {
-        await handleIssuerLookup(contractId);
-      } else {
-        setVerifiedAssetRows([]);
-        setUnverifiedAssetRows([]);
-      }
-    }, 500),
+    debounce(
+      async (
+        { target: { value: contractId } },
+        publicKey: string,
+        networkDetails: NetworkDetails,
+        isAllowListVerificationEnabled: boolean,
+      ) => {
+        if (isContractId(contractId)) {
+          await handleTokenLookup({
+            contractId,
+            publicKey,
+            networkDetails,
+            isAllowListVerificationEnabled,
+          });
+        } else if (StrKey.isValidEd25519PublicKey(contractId)) {
+          await handleIssuerLookup({ issuer: contractId, networkDetails });
+        } else {
+          setVerifiedAssetRows([]);
+          setUnverifiedAssetRows([]);
+        }
+      },
+      500,
+    ),
     [],
   );
 
   useEffect(() => {
     setHasNoResults(!verifiedAssetRows.length && !unverifiedAssetRows.length);
   }, [verifiedAssetRows, unverifiedAssetRows]);
-
-  useEffect(() => {
-    setIsVerificationInfoShowing(isAllowListVerificationEnabled);
-  }, [isAllowListVerificationEnabled]);
 
   useEffect(() => {
     const getData = async () => {
@@ -283,19 +300,38 @@ export const AddAsset = () => {
   }, []);
 
   const hasAssets = verifiedAssetRows.length || unverifiedAssetRows.length;
-  useEffect(() => {
-    const getData = async () => {
-      await fetchData();
-    };
-    getData();
-  }, []);
+
+  if (
+    state.state === RequestState.IDLE ||
+    state.state === RequestState.LOADING
+  ) {
+    return <Loading />;
+  }
+
+  if (state.state === RequestState.ERROR) {
+    return (
+      <div className="AddAsset__fetch-fail">
+        <Notification
+          variant="error"
+          title={t("Failed to fetch your account data.")}
+        >
+          {t("Your account data could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
 
   return (
     <Formik initialValues={initialValues} onSubmit={() => {}}>
       {({ dirty }) => (
         <Form
           onChange={(e) => {
-            handleSearch(e);
+            handleSearch(
+              e,
+              state.data.publicKey,
+              state.data.networkDetails,
+              state.data.isAllowListVerificationEnabled,
+            );
             setHasNoResults(false);
           }}
         >
@@ -332,7 +368,7 @@ export const AddAsset = () => {
                   {hasAssets ? (
                     <ManageAssetRows
                       header={null}
-                      balances={state.data!}
+                      balances={state.data.balances}
                       verifiedAssetRows={verifiedAssetRows}
                       unverifiedAssetRows={unverifiedAssetRows}
                       isVerifiedToken={isVerifiedToken}

--- a/extension/src/popup/components/manageAssets/AssetVisibility/index.tsx
+++ b/extension/src/popup/components/manageAssets/AssetVisibility/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { Navigate, useNavigate } from "react-router-dom";
+import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { Loader } from "@stellar/design-system";
@@ -27,6 +27,7 @@ import { ROUTES } from "popup/constants/routes";
 
 export const AssetVisibility = () => {
   const { t } = useTranslation();
+  const location = useLocation();
   const navigate = useNavigate();
   const dispatch = useDispatch<AppDispatch>();
   const isSorobanSuported = useSelector(settingsSorobanSupportedSelector);

--- a/extension/src/popup/components/manageAssets/AssetVisibility/index.tsx
+++ b/extension/src/popup/components/manageAssets/AssetVisibility/index.tsx
@@ -6,13 +6,12 @@ import { Loader } from "@stellar/design-system";
 
 import { View } from "popup/basics/layout/View";
 import { SubviewHeader } from "popup/components/SubviewHeader";
-import {
-  settingsNetworkDetailsSelector,
-  settingsSorobanSupportedSelector,
-} from "popup/ducks/settings";
-import { isMainnet } from "helpers/stellar";
-import { publicKeySelector } from "popup/ducks/accountServices";
+import { settingsSorobanSupportedSelector } from "popup/ducks/settings";
 
+import {
+  AssetVisibility as AssetVisibilityType,
+  IssuerKey,
+} from "@shared/api/types";
 import { RequestState } from "constants/request";
 import { resetSubmission } from "popup/ducks/transactionSubmission";
 import { useGetAssetData } from "./hooks/useGetAssetData";
@@ -27,16 +26,13 @@ export const AssetVisibility = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch<AppDispatch>();
   const isSorobanSuported = useSelector(settingsSorobanSupportedSelector);
-  const publicKey = useSelector(publicKeySelector);
-  const networkDetails = useSelector(settingsNetworkDetailsSelector);
 
   const ManageAssetRowsWrapperRef = useRef<HTMLDivElement>(null);
   const {
     state: domainState,
     fetchData,
     changeAssetVisibility,
-  } = useGetAssetData(publicKey, networkDetails, {
-    isMainnet: isMainnet(networkDetails),
+  } = useGetAssetData({
     showHidden: true,
     includeIcons: true,
   });
@@ -79,7 +75,19 @@ export const AssetVisibility = () => {
               <ToggleAssetRows
                 assetRows={domainState.data!.domains}
                 hiddenAssets={domainState.data!.hiddenAssets}
-                changeAssetVisibility={changeAssetVisibility}
+                changeAssetVisibility={async ({
+                  issuer,
+                  visibility,
+                }: {
+                  issuer: IssuerKey;
+                  visibility: AssetVisibilityType;
+                }) => {
+                  return await changeAssetVisibility({
+                    issuer,
+                    visibility,
+                    publicKey: domainState.data!.publicKey,
+                  });
+                }}
               />
             </div>
           </div>

--- a/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
@@ -5,17 +5,12 @@ import { Button, Icon, Loader } from "@stellar/design-system";
 import { useTranslation } from "react-i18next";
 
 import { ROUTES } from "popup/constants/routes";
-import {
-  settingsNetworkDetailsSelector,
-  settingsSorobanSupportedSelector,
-} from "popup/ducks/settings";
+import { settingsSorobanSupportedSelector } from "popup/ducks/settings";
 import { SubviewHeader } from "popup/components/SubviewHeader";
 import { View } from "popup/basics/layout/View";
-import { publicKeySelector } from "popup/ducks/accountServices";
 
 import { RequestState } from "constants/request";
 import { useGetAssetDomainsWithBalances } from "helpers/hooks/useGetAssetDomainsWithBalances";
-import { isMainnet } from "helpers/stellar";
 
 import { ManageAssetRows } from "../ManageAssetRows";
 import { SelectAssetRows } from "../SelectAssetRows";
@@ -31,20 +26,13 @@ export const ChooseAsset = ({
 }) => {
   const { t } = useTranslation();
   const isSorobanSuported = useSelector(settingsSorobanSupportedSelector);
-  const publicKey = useSelector(publicKeySelector);
-  const networkDetails = useSelector(settingsNetworkDetailsSelector);
 
   const ManageAssetRowsWrapperRef = useRef<HTMLDivElement>(null);
 
-  const { state: domainState, fetchData } = useGetAssetDomainsWithBalances(
-    publicKey,
-    networkDetails,
-    {
-      isMainnet: isMainnet(networkDetails),
-      showHidden: false,
-      includeIcons: true,
-    },
-  );
+  const { state: domainState, fetchData } = useGetAssetDomainsWithBalances({
+    showHidden: false,
+    includeIcons: true,
+  });
 
   const isLoading =
     domainState.state === RequestState.IDLE ||

--- a/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link, Navigate } from "react-router-dom";
 import { Button, Icon, Loader } from "@stellar/design-system";
 import { useTranslation } from "react-i18next";
 
@@ -16,6 +16,9 @@ import { ManageAssetRows } from "../ManageAssetRows";
 import { SelectAssetRows } from "../SelectAssetRows";
 
 import "./styles.scss";
+import { openTab } from "popup/helpers/navigate";
+import { newTabHref } from "helpers/urls";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
 export const ChooseAsset = ({
   goBack,
@@ -54,6 +57,32 @@ export const ChooseAsset = ({
         </div>
       </View.Content>
     );
+  }
+
+  const hasError = domainState.state === RequestState.ERROR;
+  if (domainState.data?.type === "re-route") {
+    if (domainState.data.shouldOpenTab) {
+      openTab(newTabHref(domainState.data.routeTarget));
+      window.close();
+    }
+    return (
+      <Navigate
+        to={`${domainState.data.routeTarget}${location.search}`}
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  if (
+    !hasError &&
+    domainState.data.type === "resolved" &&
+    (domainState.data.applicationState === APPLICATION_STATE.PASSWORD_CREATED ||
+      domainState.data.applicationState ===
+        APPLICATION_STATE.MNEMONIC_PHRASE_FAILED)
+  ) {
+    openTab(newTabHref(ROUTES.accountCreator, "isRestartingOnboarding=true"));
+    window.close();
   }
 
   return (

--- a/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import { useSelector } from "react-redux";
-import { Link, Navigate } from "react-router-dom";
+import { Link, Navigate, useLocation } from "react-router-dom";
 import { Button, Icon, Loader } from "@stellar/design-system";
 import { useTranslation } from "react-i18next";
 
@@ -28,6 +28,7 @@ export const ChooseAsset = ({
   showHideAssets?: boolean;
 }) => {
   const { t } = useTranslation();
+  const location = useLocation();
   const isSorobanSuported = useSelector(settingsSorobanSupportedSelector);
 
   const ManageAssetRowsWrapperRef = useRef<HTMLDivElement>(null);

--- a/extension/src/popup/components/manageAssets/SearchAsset/hooks/useAssetLookup.ts
+++ b/extension/src/popup/components/manageAssets/SearchAsset/hooks/useAssetLookup.ts
@@ -23,11 +23,6 @@ import {
 } from "popup/ducks/settings";
 import { ManageAssetCurrency } from "popup/components/manageAssets/ManageAssetRows";
 
-interface UseAssetLookupParams {
-  publicKey: string;
-  isAllowListVerificationEnabled: boolean;
-}
-
 interface AssetRecord {
   asset: string;
   domain?: string;
@@ -54,10 +49,7 @@ const DEFAULT_PAYLOAD: AssetLookupDetails = {
   blockaidScanResults: {},
 };
 
-const useAssetLookup = ({
-  publicKey,
-  isAllowListVerificationEnabled,
-}: UseAssetLookupParams) => {
+const useAssetLookup = () => {
   let isVerifiedToken = false;
   let isVerificationInfoShowing = false;
   let verifiedLists = [] as string[];
@@ -140,7 +132,11 @@ const useAssetLookup = ({
    * @param {string} contractId - The contract ID to look up.
    * @returns {Promise<ManageAssetCurrency[]>}
    */
-  const fetchTokenData = async (contractId: string) => {
+  const fetchTokenData = async (
+    publicKey: string,
+    contractId: string,
+    isAllowListVerificationEnabled: boolean,
+  ) => {
     let assetRows = [] as ManageAssetCurrency[];
 
     const nativeContractDetails = getNativeContractDetails(networkDetails);
@@ -275,9 +271,13 @@ const useAssetLookup = ({
   const fetchData = async ({
     asset,
     isBlockaidEnabled,
+    publicKey,
+    isAllowListVerificationEnabled,
   }: {
     asset: string;
     isBlockaidEnabled: boolean;
+    publicKey: string;
+    isAllowListVerificationEnabled: boolean;
   }) => {
     dispatch({ type: "FETCH_DATA_START" });
 
@@ -295,7 +295,11 @@ const useAssetLookup = ({
     if (isContractId(asset)) {
       // for custom tokens, try to go down the the custom token flow
       try {
-        assetRows = await fetchTokenData(asset);
+        assetRows = await fetchTokenData(
+          publicKey,
+          asset,
+          isAllowListVerificationEnabled,
+        );
       } catch (e) {
         captureException(
           `Failed to fetch token details - ${JSON.stringify(e)}`,

--- a/extension/src/popup/components/manageAssets/SearchAsset/hooks/useSearchData.tsx
+++ b/extension/src/popup/components/manageAssets/SearchAsset/hooks/useSearchData.tsx
@@ -2,20 +2,29 @@ import { useReducer } from "react";
 
 import { RequestState } from "../../../../../constants/request";
 import { initialState, isError, reducer } from "../../../../../helpers/request";
-import { useGetAppData } from "../../../../../helpers/hooks/useGetAppData";
+import {
+  AppDataType,
+  NeedsReRoute,
+  useGetAppData,
+} from "../../../../../helpers/hooks/useGetAppData";
 import {
   AccountBalances,
   useGetBalances,
 } from "../../../../../helpers/hooks/useGetBalances";
 import { isMainnet, isTestnet } from "../../../../../helpers/stellar";
 import { NetworkDetails } from "@shared/constants/stellar";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
-export interface SearchData {
+export interface ResolvedSearchData {
+  type: AppDataType.RESOLVED;
   publicKey: string;
   networkDetails: NetworkDetails;
   balances: AccountBalances;
   isAllowListVerificationEnabled: boolean;
+  applicationState: APPLICATION_STATE;
 }
+
+export type SearchData = NeedsReRoute | ResolvedSearchData;
 
 function useGetSearchData(options: {
   showHidden: boolean;
@@ -34,6 +43,11 @@ function useGetSearchData(options: {
       const appData = await fetchAppData();
       if (isError(appData)) {
         throw new Error(appData.message);
+      }
+
+      if (appData.type === AppDataType.REROUTE) {
+        dispatch({ type: "FETCH_DATA_SUCCESS", payload: appData });
+        return appData;
       }
 
       const publicKey = appData.account.publicKey;
@@ -56,6 +70,7 @@ function useGetSearchData(options: {
         publicKey,
         isAllowListVerificationEnabled,
         networkDetails: appData.settings.networkDetails,
+        applicationState: appData.account.applicationState,
       } as SearchData;
       dispatch({ type: "FETCH_DATA_SUCCESS", payload });
       return payload;

--- a/extension/src/popup/components/manageAssets/SearchAsset/hooks/useSearchData.tsx
+++ b/extension/src/popup/components/manageAssets/SearchAsset/hooks/useSearchData.tsx
@@ -1,0 +1,74 @@
+import { useReducer } from "react";
+
+import { RequestState } from "../../../../../constants/request";
+import { initialState, isError, reducer } from "../../../../../helpers/request";
+import { useGetAppData } from "../../../../../helpers/hooks/useGetAppData";
+import {
+  AccountBalances,
+  useGetBalances,
+} from "../../../../../helpers/hooks/useGetBalances";
+import { isMainnet, isTestnet } from "../../../../../helpers/stellar";
+import { NetworkDetails } from "@shared/constants/stellar";
+
+export interface SearchData {
+  publicKey: string;
+  networkDetails: NetworkDetails;
+  balances: AccountBalances;
+  isAllowListVerificationEnabled: boolean;
+}
+
+function useGetSearchData(options: {
+  showHidden: boolean;
+  includeIcons: boolean;
+}) {
+  const [state, dispatch] = useReducer(
+    reducer<SearchData, unknown>,
+    initialState,
+  );
+  const { fetchData: fetchAppData } = useGetAppData();
+  const { fetchData: fetchBalances } = useGetBalances(options);
+
+  const fetchData = async (): Promise<SearchData | Error> => {
+    dispatch({ type: "FETCH_DATA_START" });
+    try {
+      const appData = await fetchAppData();
+      if (isError(appData)) {
+        throw new Error(appData.message);
+      }
+
+      const publicKey = appData.account.publicKey;
+      const networkDetails = appData.settings.networkDetails;
+      const isMainnetNetwork = isMainnet(networkDetails);
+      const isAllowListVerificationEnabled =
+        isMainnet(networkDetails) || isTestnet(networkDetails);
+      const balances = await fetchBalances(
+        publicKey,
+        isMainnetNetwork,
+        networkDetails,
+      );
+
+      if (isError<AccountBalances>(balances)) {
+        throw new Error(balances.message);
+      }
+
+      const payload = {
+        balances,
+        publicKey,
+        isAllowListVerificationEnabled,
+        networkDetails: appData.settings.networkDetails,
+      } as SearchData;
+      dispatch({ type: "FETCH_DATA_SUCCESS", payload });
+      return payload;
+    } catch (error) {
+      dispatch({ type: "FETCH_DATA_ERROR", payload: error });
+      throw new Error("Failed to fetch search data", { cause: error });
+    }
+  };
+
+  return {
+    state,
+    fetchData,
+  };
+}
+
+export { useGetSearchData, RequestState };

--- a/extension/src/popup/components/manageAssets/SearchAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/SearchAsset/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { Formik, Form, Field, FieldProps } from "formik";
 import debounce from "lodash/debounce";
 import { useTranslation } from "react-i18next";
@@ -60,6 +60,7 @@ const ResultsHeader = () => {
 
 export const SearchAsset = () => {
   const { t } = useTranslation();
+  const location = useLocation();
 
   const [hasNoResults, setHasNoResults] = useState(false);
   const ResultsRef = useRef<HTMLDivElement>(null);

--- a/extension/src/popup/components/manageAssets/SearchAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/SearchAsset/index.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { useSelector } from "react-redux";
 import { Navigate } from "react-router-dom";
 import { Formik, Form, Field, FieldProps } from "formik";
 import debounce from "lodash/debounce";
@@ -9,18 +8,18 @@ import { Notification } from "@stellar/design-system";
 
 import { FormRows } from "popup/basics/Forms";
 import { ROUTES } from "popup/constants/routes";
-import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
 import { isMainnet, isTestnet } from "helpers/stellar";
 
 import { SubviewHeader } from "popup/components/SubviewHeader";
 import { View } from "popup/basics/layout/View";
 
-import { useGetBalances } from "helpers/hooks/useGetBalances";
-import { publicKeySelector } from "popup/ducks/accountServices";
-
 import { ManageAssetRows } from "../ManageAssetRows";
 import { SearchInput, SearchCopy, SearchResults } from "../AssetResults";
 import { useAssetLookup } from "./hooks/useAssetLookup";
+import { useGetSearchData } from "./hooks/useSearchData";
+import { NetworkDetails } from "@shared/constants/stellar";
+import { RequestState } from "helpers/hooks/fetchHookInterface";
+import { Loading } from "popup/components/Loading";
 
 import "./styles.scss";
 
@@ -58,32 +57,35 @@ const ResultsHeader = () => {
 
 export const SearchAsset = () => {
   const { t } = useTranslation();
-  const networkDetails = useSelector(settingsNetworkDetailsSelector);
-  const publicKey = useSelector(publicKeySelector);
 
   const [hasNoResults, setHasNoResults] = useState(false);
   const ResultsRef = useRef<HTMLDivElement>(null);
-  // TODO: use this loading state
-  const { state, fetchData } = useGetBalances(publicKey, networkDetails, {
-    isMainnet: isMainnet(networkDetails),
+
+  const { state, fetchData } = useGetSearchData({
     showHidden: true,
     includeIcons: false,
   });
 
-  const { state: tokenState, fetchData: fetchTokenData } = useAssetLookup({
-    publicKey,
-    isAllowListVerificationEnabled:
-      isMainnet(networkDetails) || isTestnet(networkDetails),
-  });
+  const { state: tokenState, fetchData: fetchTokenData } = useAssetLookup();
 
   /* eslint-disable react-hooks/exhaustive-deps */
   const handleSearch = useCallback(
-    debounce(async ({ target: { value: asset } }) => {
-      await fetchTokenData({
-        asset,
-        isBlockaidEnabled: isMainnet(networkDetails),
-      });
-    }, 500),
+    debounce(
+      async (
+        { target: { value: asset } },
+        publicKey: string,
+        isAllowListVerificationEnabled: boolean,
+        networkDetails: NetworkDetails,
+      ) => {
+        await fetchTokenData({
+          publicKey,
+          isAllowListVerificationEnabled,
+          asset,
+          isBlockaidEnabled: isMainnet(networkDetails),
+        });
+      },
+      500,
+    ),
     [],
   );
 
@@ -101,9 +103,32 @@ export const SearchAsset = () => {
     };
 
     getData();
-  }, [networkDetails]);
+  }, []);
 
-  if (!isMainnet(networkDetails) && !isTestnet(networkDetails)) {
+  if (
+    state.state === RequestState.IDLE ||
+    state.state === RequestState.LOADING
+  ) {
+    return <Loading />;
+  }
+
+  if (state.state === RequestState.ERROR) {
+    return (
+      <div className="SearchAsset__fetch-fail">
+        <Notification
+          variant="error"
+          title={t("Failed to fetch your account data.")}
+        >
+          {t("Your account data could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
+
+  if (
+    !isMainnet(state.data.networkDetails) &&
+    !isTestnet(state.data.networkDetails)
+  ) {
     return <Navigate to={ROUTES.addAsset} />;
   }
 
@@ -116,7 +141,12 @@ export const SearchAsset = () => {
           {({ dirty }) => (
             <Form
               onChange={(e) => {
-                handleSearch(e);
+                handleSearch(
+                  e,
+                  state.data.publicKey,
+                  state.data.isAllowListVerificationEnabled,
+                  state.data.networkDetails,
+                );
                 setHasNoResults(false);
               }}
             >
@@ -151,7 +181,7 @@ export const SearchAsset = () => {
                   (tokenState.data.verifiedAssetRows.length ||
                     tokenState.data.unverifiedAssetRows.length) ? (
                     <ManageAssetRows
-                      balances={state.data!}
+                      balances={state.data!.balances}
                       header={
                         tokenState.data.verifiedAssetRows.length > 1 ||
                         tokenState.data.unverifiedAssetRows.length > 1 ? (

--- a/extension/src/popup/components/manageAssets/SearchAsset/styles.scss
+++ b/extension/src/popup/components/manageAssets/SearchAsset/styles.scss
@@ -22,4 +22,8 @@
       text-decoration: underline;
     }
   }
+
+  &__fetch-fail {
+    margin-top: 1.5rem;
+  }
 }

--- a/extension/src/popup/components/manageNetwork/NetworkForm/index.tsx
+++ b/extension/src/popup/components/manageNetwork/NetworkForm/index.tsx
@@ -56,6 +56,7 @@ export const NETWORK_INDEX_SEARCH_PARAM = "networkIndex";
 
 export const NetworkForm = ({ isEditing }: NetworkFormProps) => {
   const { t } = useTranslation();
+  const location = useLocation();
   const dispatch = useDispatch<AppDispatch>();
   const settingsError = useSelector(settingsErrorSelector);
 

--- a/extension/src/popup/components/manageNetwork/NetworkForm/index.tsx
+++ b/extension/src/popup/components/manageNetwork/NetworkForm/index.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Button, Checkbox, Input } from "@stellar/design-system";
+import { Button, Checkbox, Input, Notification } from "@stellar/design-system";
 import { useTranslation } from "react-i18next";
 import { Field, FieldProps, Form, Formik } from "formik";
 import { object as YupObject, string as YupString } from "yup";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useLocation, Navigate } from "react-router-dom";
 
 import { NETWORKS } from "@shared/constants/stellar";
 import { CUSTOM_NETWORK } from "@shared/helpers/stellar";
@@ -14,7 +14,7 @@ import { PillButton } from "popup/basics/buttons/PillButton";
 import { View } from "popup/basics/layout/View";
 import { ROUTES } from "popup/constants/routes";
 
-import { navigateTo } from "popup/helpers/navigate";
+import { navigateTo, openTab } from "popup/helpers/navigate";
 import { isNetworkUrlValid as isNetworkUrlValidHelper } from "popup/helpers/account";
 import { isActiveNetwork } from "helpers/stellar";
 
@@ -25,8 +25,6 @@ import {
   editCustomNetwork,
   removeCustomNetwork,
   settingsErrorSelector,
-  settingsNetworkDetailsSelector,
-  settingsNetworksListSelector,
 } from "popup/ducks/settings";
 
 import { SubviewHeader } from "popup/components/SubviewHeader";
@@ -34,6 +32,11 @@ import { SubviewHeader } from "popup/components/SubviewHeader";
 import { NetworkModal } from "../NetworkModal";
 
 import "./styles.scss";
+import { useGetAppData } from "helpers/hooks/useGetAppData";
+import { RequestState } from "constants/request";
+import { Loading } from "popup/components/Loading";
+import { newTabHref } from "helpers/urls";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
 interface FormValues {
   networkName: string;
@@ -54,8 +57,6 @@ export const NETWORK_INDEX_SEARCH_PARAM = "networkIndex";
 export const NetworkForm = ({ isEditing }: NetworkFormProps) => {
   const { t } = useTranslation();
   const dispatch = useDispatch<AppDispatch>();
-  const networkDetails = useSelector(settingsNetworkDetailsSelector);
-  const networksList = useSelector(settingsNetworksListSelector);
   const settingsError = useSelector(settingsErrorSelector);
 
   const [isNetworkInUse, setIsNetworkInUse] = useState(false);
@@ -64,6 +65,62 @@ export const NetworkForm = ({ isEditing }: NetworkFormProps) => {
   const [invalidUrl, setInvalidUrl] = useState("");
   const navigate = useNavigate();
   const { search } = useLocation();
+  const { state, fetchData } = useGetAppData();
+
+  useEffect(() => {
+    const getData = async () => {
+      await fetchData();
+    };
+    getData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (
+    state.state === RequestState.IDLE ||
+    state.state === RequestState.LOADING
+  ) {
+    return <Loading />;
+  }
+
+  if (state.state === RequestState.ERROR) {
+    return (
+      <div className="AddAsset__fetch-fail">
+        <Notification
+          variant="error"
+          title={t("Failed to fetch your account data.")}
+        >
+          {t("Your account data could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
+
+  if (state.data?.type === "re-route") {
+    if (state.data.shouldOpenTab) {
+      openTab(newTabHref(state.data.routeTarget));
+      window.close();
+    }
+    return (
+      <Navigate
+        to={`${state.data.routeTarget}${location.search}`}
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  if (
+    state.data.type === "resolved" &&
+    (state.data.account.applicationState ===
+      APPLICATION_STATE.PASSWORD_CREATED ||
+      state.data.account.applicationState ===
+        APPLICATION_STATE.MNEMONIC_PHRASE_FAILED)
+  ) {
+    openTab(newTabHref(ROUTES.accountCreator, "isRestartingOnboarding=true"));
+    window.close();
+  }
+
+  const { networksList, networkDetails } = state.data.settings;
 
   const networkIndex = Number(
     new URLSearchParams(search).get(NETWORK_INDEX_SEARCH_PARAM),

--- a/extension/src/popup/components/manageNetwork/NetworkSettings/index.tsx
+++ b/extension/src/popup/components/manageNetwork/NetworkSettings/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { useSelector } from "react-redux";
-import { Navigate, useNavigate } from "react-router-dom";
+import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Button, Notification } from "@stellar/design-system";
 
@@ -27,6 +27,7 @@ import { APPLICATION_STATE } from "@shared/constants/applicationState";
 export const NetworkSettings = () => {
   const activeNetworkDetails = useSelector(settingsNetworkDetailsSelector);
   const { t } = useTranslation();
+  const location = useLocation();
   const navigate = useNavigate();
   const { state, fetchData } = useGetAppData();
 

--- a/extension/src/popup/components/manageNetwork/NetworkSettings/index.tsx
+++ b/extension/src/popup/components/manageNetwork/NetworkSettings/index.tsx
@@ -1,19 +1,16 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { Navigate, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Button } from "@stellar/design-system";
+import { Button, Notification } from "@stellar/design-system";
 
 import { ROUTES } from "popup/constants/routes";
 import { ListNavLink, ListNavLinkWrapper } from "popup/basics/ListNavLink";
 
 import { isActiveNetwork } from "helpers/stellar";
-import { navigateTo } from "popup/helpers/navigate";
+import { navigateTo, openTab } from "popup/helpers/navigate";
 
-import {
-  settingsNetworkDetailsSelector,
-  settingsNetworksListSelector,
-} from "popup/ducks/settings";
+import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
 import { SubviewHeader } from "popup/components/SubviewHeader";
 import { NetworkIcon } from "popup/components/manageNetwork/NetworkIcon";
 import { View } from "popup/basics/layout/View";
@@ -21,12 +18,72 @@ import { View } from "popup/basics/layout/View";
 import { NETWORK_INDEX_SEARCH_PARAM } from "../NetworkForm";
 
 import "./styles.scss";
+import { useGetAppData } from "helpers/hooks/useGetAppData";
+import { RequestState } from "constants/request";
+import { Loading } from "popup/components/Loading";
+import { newTabHref } from "helpers/urls";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
 export const NetworkSettings = () => {
-  const networksList = useSelector(settingsNetworksListSelector);
   const activeNetworkDetails = useSelector(settingsNetworkDetailsSelector);
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { state, fetchData } = useGetAppData();
+
+  useEffect(() => {
+    const getData = async () => {
+      await fetchData();
+    };
+    getData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (
+    state.state === RequestState.IDLE ||
+    state.state === RequestState.LOADING
+  ) {
+    return <Loading />;
+  }
+
+  if (state.state === RequestState.ERROR) {
+    return (
+      <div className="AddAsset__fetch-fail">
+        <Notification
+          variant="error"
+          title={t("Failed to fetch your account data.")}
+        >
+          {t("Your account data could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
+
+  if (state.data?.type === "re-route") {
+    if (state.data.shouldOpenTab) {
+      openTab(newTabHref(state.data.routeTarget));
+      window.close();
+    }
+    return (
+      <Navigate
+        to={`${state.data.routeTarget}${location.search}`}
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  if (
+    state.data.type === "resolved" &&
+    (state.data.account.applicationState ===
+      APPLICATION_STATE.PASSWORD_CREATED ||
+      state.data.account.applicationState ===
+        APPLICATION_STATE.MNEMONIC_PHRASE_FAILED)
+  ) {
+    openTab(newTabHref(ROUTES.accountCreator, "isRestartingOnboarding=true"));
+    window.close();
+  }
+
+  const { networksList } = state.data.settings;
 
   return (
     <React.Fragment>

--- a/extension/src/popup/components/sendPayment/SendAmount/hooks/useSendAmountData.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/hooks/useSendAmountData.tsx
@@ -13,13 +13,19 @@ import {
 } from "helpers/hooks/useGetAssetDomainsWithBalances";
 import { getAccountBalances } from "@shared/api/internal";
 import { getBaseAccount, sortBalances } from "popup/helpers/account";
+import { AppDataType, NeedsReRoute } from "helpers/hooks/useGetAppData";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
-interface SendAmountData {
+interface ResolvedSendAmountData {
+  type: AppDataType.RESOLVED;
   userBalances: AccountBalances;
   destinationBalances: AccountBalances;
   icons: AssetIcons;
   domains: ManageAssetCurrency[];
+  applicationState: APPLICATION_STATE;
 }
+
+type SendAmountData = NeedsReRoute | ResolvedSendAmountData;
 
 function useGetSendAmountData(
   networkDetails: NetworkDetails,
@@ -56,7 +62,14 @@ function useGetSendAmountData(
         throw new Error(userDomains.message);
       }
 
+      if (userDomains.type === AppDataType.REROUTE) {
+        dispatch({ type: "FETCH_DATA_SUCCESS", payload: userDomains });
+        return userDomains;
+      }
+
       const payload = {
+        type: AppDataType.RESOLVED,
+        applicationState: userDomains.applicationState,
         userBalances: userDomains.balances,
         destinationBalances: {
           ...destinationBalances,
@@ -64,7 +77,7 @@ function useGetSendAmountData(
         },
         icons: userDomains.balances.icons || {},
         domains: userDomains.domains,
-      };
+      } as ResolvedSendAmountData;
       dispatch({ type: "FETCH_DATA_SUCCESS", payload });
       return payload;
     } catch (error) {

--- a/extension/src/popup/components/sendPayment/SendAmount/hooks/useSendAmountData.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/hooks/useSendAmountData.tsx
@@ -22,7 +22,6 @@ interface SendAmountData {
 }
 
 function useGetSendAmountData(
-  publicKey: string,
   networkDetails: NetworkDetails,
   options: {
     isMainnet: boolean;
@@ -36,11 +35,8 @@ function useGetSendAmountData(
     initialState,
   );
 
-  const { fetchData: fetchAssetDomains } = useGetAssetDomainsWithBalances(
-    publicKey,
-    networkDetails,
-    options,
-  );
+  const { fetchData: fetchAssetDomains } =
+    useGetAssetDomainsWithBalances(options);
 
   const fetchData = async () => {
     dispatch({ type: "FETCH_DATA_START" });

--- a/extension/src/popup/components/sendPayment/SendAmount/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/index.tsx
@@ -150,7 +150,6 @@ export const SendAmount = ({
     isSoroswap,
   } = transactionData;
   const { state: sendAmountData, fetchData } = useGetSendAmountData(
-    publicKey,
     networkDetails,
     {
       isMainnet: isMainnet(networkDetails),

--- a/extension/src/popup/components/sendPayment/SendAmount/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/index.tsx
@@ -65,7 +65,7 @@ import { useGetSendAmountData } from "./hooks/useSendAmountData";
 import "../styles.scss";
 import { openTab } from "popup/helpers/navigate";
 import { newTabHref } from "helpers/urls";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { ROUTES } from "popup/constants/routes";
 import { APPLICATION_STATE } from "@shared/constants/applicationState";
 import { AppDataType } from "helpers/hooks/useGetAppData";
@@ -131,6 +131,7 @@ export const SendAmount = ({
   goToPaymentType?: () => void;
 }) => {
   const { t } = useTranslation();
+  const location = useLocation();
   const dispatch = useDispatch<AppDispatch>();
   const runAfterUpdate = useRunAfterUpdate();
 

--- a/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useNavigate, Navigate } from "react-router-dom";
+import { useNavigate, Navigate, useLocation } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
 import { createPortal } from "react-dom";
 import get from "lodash/get";
@@ -95,6 +95,7 @@ export const SubmitSuccess = ({ viewDetails }: { viewDetails: () => void }) => {
   } = useSelector(transactionSubmissionSelector);
 
   const { t } = useTranslation();
+  const location = useLocation();
   const isSwap = useIsSwap();
   const dispatch: AppDispatch = useDispatch();
   const navigate = useNavigate();

--- a/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Navigate } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
 import { createPortal } from "react-dom";
 import get from "lodash/get";
@@ -11,16 +11,13 @@ import { AppDispatch } from "popup/App";
 import { AssetIcons, Balance, ErrorMessage } from "@shared/api/types";
 import { stellarSdkServer } from "@shared/api/helpers/stellarSdkServer";
 
-import { getAssetFromCanonical, isMainnet, xlmToStroop } from "helpers/stellar";
+import { getAssetFromCanonical, xlmToStroop } from "helpers/stellar";
 import { navigateTo } from "popup/helpers/navigate";
 import { RESULT_CODES, getResultCodes } from "popup/helpers/parseTransaction";
 import { useIsSwap } from "popup/helpers/useIsSwap";
 import { useNetworkFees } from "popup/helpers/useNetworkFees";
 import { ROUTES } from "popup/constants/routes";
-import {
-  publicKeySelector,
-  hardwareWalletTypeSelector,
-} from "popup/ducks/accountServices";
+import { hardwareWalletTypeSelector } from "popup/ducks/accountServices";
 import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
 import {
   startHwSign,
@@ -105,18 +102,12 @@ export const SubmitSuccess = ({ viewDetails }: { viewDetails: () => void }) => {
     destinationAsset || "native",
   );
   const { recommendedFee } = useNetworkFees();
-  const publicKey = useSelector(publicKeySelector);
   const networkDetails = useSelector(settingsNetworkDetailsSelector);
   const [isTrustlineErrorShowing, setIsTrustlineErrorShowing] = useState(false);
-  const { state: accountData, fetchData } = useGetAccountData(
-    publicKey,
-    networkDetails,
-    {
-      isMainnet: isMainnet(networkDetails),
-      showHidden: false,
-      includeIcons: true,
-    },
-  );
+  const { state: accountData, fetchData } = useGetAccountData({
+    showHidden: false,
+    includeIcons: true,
+  });
   const isLoading =
     accountData.state === RequestState.IDLE ||
     accountData.state === RequestState.LOADING;
@@ -127,7 +118,11 @@ export const SubmitSuccess = ({ viewDetails }: { viewDetails: () => void }) => {
   );
   const isHardwareWallet = !!useSelector(hardwareWalletTypeSelector);
 
-  const removeTrustline = async (assetCode: string, assetIssuer: string) => {
+  const removeTrustline = async (
+    publicKey: string,
+    assetCode: string,
+    assetIssuer: string,
+  ) => {
     const changeParams = { limit: "0" };
     const sourceAccount: Account = await server.loadAccount(publicKey);
 
@@ -156,11 +151,12 @@ export const SubmitSuccess = ({ viewDetails }: { viewDetails: () => void }) => {
       await dispatch(startHwSign({ transactionXDR, shouldSubmit: true }));
       trackRemoveTrustline();
     } else {
-      await signAndSubmit(transactionXDR, trackRemoveTrustline);
+      await signAndSubmit(publicKey, transactionXDR, trackRemoveTrustline);
     }
   };
 
   const signAndSubmit = async (
+    publicKey: string,
     transactionXDR: string,
     trackChangeTrustline: () => void,
   ) => {
@@ -191,13 +187,6 @@ export const SubmitSuccess = ({ viewDetails }: { viewDetails: () => void }) => {
     }
   };
 
-  // TODO: the remove trustline logic here does not work Soroban tokens. We should handle this case
-  const suggestRemoveTrustline = (
-    accountData.data?.balances.balances as Balance[]
-  )
-    ?.find((balance) => balance.contractId === asset)
-    ?.available?.isZero();
-
   useEffect(() => {
     const getData = async () => {
       await fetchData();
@@ -209,6 +198,23 @@ export const SubmitSuccess = ({ viewDetails }: { viewDetails: () => void }) => {
   if (isLoading) {
     return <Loading />;
   }
+
+  if (accountData.data?.type === "needsReRoute") {
+    return (
+      <Navigate
+        to={`${accountData.data.routeTarget}${location.search}`}
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  // TODO: the remove trustline logic here does not work Soroban tokens. We should handle this case
+  const suggestRemoveTrustline = (
+    accountData.data?.balances.balances as Balance[]
+  )
+    ?.find((balance) => balance.contractId === asset)
+    ?.available?.isZero();
 
   const sourceBalance = findAssetBalance(
     accountData.data!.balances.balances,
@@ -227,6 +233,8 @@ export const SubmitSuccess = ({ viewDetails }: { viewDetails: () => void }) => {
     "blockaidData" in destBalance &&
     isAssetSuspicious(destBalance.blockaidData);
 
+  const resolvedData = accountData.data;
+
   return (
     <React.Fragment>
       <View.AppHeader
@@ -244,7 +252,11 @@ export const SubmitSuccess = ({ viewDetails }: { viewDetails: () => void }) => {
                   </p>
                   <button
                     onClick={() =>
-                      removeTrustline(sourceAsset.code, sourceAsset.issuer)
+                      removeTrustline(
+                        resolvedData!.publicKey,
+                        sourceAsset.code,
+                        sourceAsset.issuer,
+                      )
                     }
                   >
                     Remove Trustline

--- a/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/SubmitResult/index.tsx
@@ -12,7 +12,7 @@ import { AssetIcons, Balance, ErrorMessage } from "@shared/api/types";
 import { stellarSdkServer } from "@shared/api/helpers/stellarSdkServer";
 
 import { getAssetFromCanonical, xlmToStroop } from "helpers/stellar";
-import { navigateTo } from "popup/helpers/navigate";
+import { navigateTo, openTab } from "popup/helpers/navigate";
 import { RESULT_CODES, getResultCodes } from "popup/helpers/parseTransaction";
 import { useIsSwap } from "popup/helpers/useIsSwap";
 import { useNetworkFees } from "popup/helpers/useNetworkFees";
@@ -43,6 +43,8 @@ import {
 import { Loading } from "popup/components/Loading";
 
 import "./styles.scss";
+import { newTabHref } from "helpers/urls";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
 const SwapAssetsIcon = ({
   sourceCanon,
@@ -199,7 +201,13 @@ export const SubmitSuccess = ({ viewDetails }: { viewDetails: () => void }) => {
     return <Loading />;
   }
 
-  if (accountData.data?.type === "needsReRoute") {
+  const hasError = accountData.state === RequestState.ERROR;
+
+  if (accountData.data?.type === "re-route") {
+    if (accountData.data.shouldOpenTab) {
+      openTab(newTabHref(accountData.data.routeTarget));
+      window.close();
+    }
     return (
       <Navigate
         to={`${accountData.data.routeTarget}${location.search}`}
@@ -207,6 +215,17 @@ export const SubmitSuccess = ({ viewDetails }: { viewDetails: () => void }) => {
         replace
       />
     );
+  }
+
+  if (
+    !hasError &&
+    accountData.data.type === "resolved" &&
+    (accountData.data.applicationState === APPLICATION_STATE.PASSWORD_CREATED ||
+      accountData.data.applicationState ===
+        APPLICATION_STATE.MNEMONIC_PHRASE_FAILED)
+  ) {
+    openTab(newTabHref(ROUTES.accountCreator, "isRestartingOnboarding=true"));
+    window.close();
   }
 
   // TODO: the remove trustline logic here does not work Soroban tokens. We should handle this case

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/hooks/useGetTxDetailsData.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/hooks/useGetTxDetailsData.tsx
@@ -197,11 +197,7 @@ function useGetTxDetailsData(
     initialState,
   );
 
-  const { fetchData: fetchBalances } = useGetBalances(
-    publicKey,
-    networkDetails,
-    balanceOptions,
-  );
+  const { fetchData: fetchBalances } = useGetBalances(balanceOptions);
   const { assetsLists } = useSelector(settingsSelector);
 
   const { scanTx } = useScanTx();
@@ -209,8 +205,12 @@ function useGetTxDetailsData(
   const fetchData = async () => {
     dispatch({ type: "FETCH_DATA_START" });
     try {
-      const balancesResult = await fetchBalances();
       let destinationAccount = await getBaseAccount(destination);
+      const balancesResult = await fetchBalances(
+        publicKey,
+        balanceOptions.isMainnet,
+        networkDetails,
+      );
       const destBalancesResult =
         destinationAccount && !isContractId(destinationAccount)
           ? await getAccountBalances(

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/hooks/useGetTxDetailsData.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/hooks/useGetTxDetailsData.tsx
@@ -195,7 +195,6 @@ function useGetTxDetailsData(
   },
 ) {
   const hasPrivateKey = useSelector(hasPrivateKeySelector);
-  console.log(hasPrivateKey);
   const [state, dispatch] = useReducer(
     reducer<TxDetailsData, unknown>,
     initialState,
@@ -259,7 +258,7 @@ function useGetTxDetailsData(
       );
 
       const payload = {
-        hasPrivateKey: false,
+        hasPrivateKey,
         balances: balancesResult,
         destinationBalances: {
           ...destBalancesResult,

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/hooks/useGetTxDetailsData.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/hooks/useGetTxDetailsData.tsx
@@ -29,6 +29,7 @@ import { getBaseAccount, sortBalances } from "popup/helpers/account";
 import { isContractId } from "popup/helpers/soroban";
 import { settingsSelector } from "popup/ducks/settings";
 import { getCombinedAssetListData } from "@shared/api/helpers/token-list";
+import { hasPrivateKeySelector } from "popup/ducks/accountServices";
 
 export interface TxDetailsData {
   destAssetIconUrl: string;
@@ -38,6 +39,7 @@ export interface TxDetailsData {
   destinationBalances: AccountBalances;
   scanResult?: BlockAidScanTxResult | null;
   transactionXdr: string;
+  hasPrivateKey: boolean;
 }
 
 interface ScanClassic {
@@ -192,6 +194,8 @@ function useGetTxDetailsData(
     includeIcons: boolean;
   },
 ) {
+  const hasPrivateKey = useSelector(hasPrivateKeySelector);
+  console.log(hasPrivateKey);
   const [state, dispatch] = useReducer(
     reducer<TxDetailsData, unknown>,
     initialState,
@@ -255,6 +259,7 @@ function useGetTxDetailsData(
       );
 
       const payload = {
+        hasPrivateKey: false,
         balances: balancesResult,
         destinationBalances: {
           ...destBalancesResult,

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import BigNumber from "bignumber.js";
@@ -72,6 +72,7 @@ import {
 } from "./hooks/useGetTxDetailsData";
 
 import "./styles.scss";
+import { VerifyAccount } from "popup/components/VerifyAccountDrawer";
 
 const TwoAssetCard = ({
   sourceAssetIcons,
@@ -147,6 +148,8 @@ export const TransactionDetails = ({
 }) => {
   const dispatch: AppDispatch = useDispatch();
   const navigate = useNavigate();
+  const [isVerifyAccountModalOpen, setIsVerifyAccountModalOpen] =
+    useState(false);
   const submission = useSelector(transactionSubmissionSelector);
   const {
     transactionData: {
@@ -408,6 +411,15 @@ export const TransactionDetails = ({
     txDetailsData.state === RequestState.IDLE ||
     txDetailsData.state === RequestState.LOADING;
 
+  useEffect(() => {
+    if (
+      txDetailsData.state === RequestState.SUCCESS &&
+      !txDetailsData.data.hasPrivateKey
+    ) {
+      setIsVerifyAccountModalOpen(true);
+    }
+  }, [txDetailsData]);
+
   return (
     <>
       {hwStatus === ShowOverlayStatus.IN_PROGRESS && hardwareWalletType && (
@@ -618,12 +630,12 @@ export const TransactionDetails = ({
                 />
               )}
             </div>
+            <div className="TransactionDetails__bottom-wrapper__copy">
+              {(isPathPayment || isSwap) &&
+                submission.submitStatus !== ActionStatus.SUCCESS &&
+                t("The final amount is approximate and may change")}
+            </div>
           </View.Content>
-          <div className="TransactionDetails__bottom-wrapper__copy">
-            {(isPathPayment || isSwap) &&
-              submission.submitStatus !== ActionStatus.SUCCESS &&
-              t("The final amount is approximate and may change")}
-          </div>
           <View.Footer isInline>
             {submission.submitStatus === ActionStatus.SUCCESS ? (
               <StellarExpertButton />
@@ -659,6 +671,13 @@ export const TransactionDetails = ({
               </>
             )}
           </View.Footer>
+          <div className="TransactionDetails__modal-wrapper">
+            <VerifyAccount
+              publicKey={publicKey}
+              isModalOpen={isVerifyAccountModalOpen}
+              setIsModalOpen={setIsVerifyAccountModalOpen}
+            />
+          </div>
         </React.Fragment>
       )}
     </>

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/styles.scss
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/styles.scss
@@ -5,6 +5,11 @@
   flex-direction: column;
   text-align: center;
 
+  &__modal-wrapper {
+    display: flex;
+    flex-direction: column;
+  }
+
   &__send-asset {
     align-items: center;
     display: flex;

--- a/extension/src/popup/components/sendPayment/SendSettings/Settings/hooks/useGetSettingsData.tsx
+++ b/extension/src/popup/components/sendPayment/SendSettings/Settings/hooks/useGetSettingsData.tsx
@@ -184,17 +184,17 @@ function useGetSettingsData(
     initialState,
   );
 
-  const { fetchData: fetchBalances } = useGetBalances(
-    publicKey,
-    networkDetails,
-    balanceOptions,
-  );
+  const { fetchData: fetchBalances } = useGetBalances(balanceOptions);
   const reduxDispatch = useDispatch();
 
   const fetchData = async (): Promise<GetSettingsData | Error> => {
     dispatch({ type: "FETCH_DATA_START" });
     try {
-      const balancesResult = await fetchBalances();
+      const balancesResult = await fetchBalances(
+        publicKey,
+        balanceOptions.isMainnet,
+        networkDetails,
+      );
 
       if (isError<AccountBalances>(balancesResult)) {
         throw new Error(balancesResult.message);

--- a/extension/src/popup/components/sendPayment/SendTo/hooks/useSendToData.tsx
+++ b/extension/src/popup/components/sendPayment/SendTo/hooks/useSendToData.tsx
@@ -3,21 +3,32 @@ import { Federation } from "stellar-sdk";
 import { FormikErrors } from "formik";
 import debounce from "lodash/debounce";
 
-import { NetworkDetails } from "@shared/constants/stellar";
-
-import { initialState, reducer } from "helpers/request";
+import { initialState, isError, reducer } from "helpers/request";
 import { AccountBalances } from "helpers/hooks/useGetBalances";
 import { getAccountBalances, loadRecentAddresses } from "@shared/api/internal";
-import { isFederationAddress } from "helpers/stellar";
-import { isContractId } from "popup/helpers/soroban";
 import { getBaseAccount, sortBalances } from "popup/helpers/account";
+import { isFederationAddress, isMainnet } from "helpers/stellar";
+import { isContractId } from "popup/helpers/soroban";
+import {
+  AppDataType,
+  NeedsReRoute,
+  useGetAppData,
+} from "helpers/hooks/useGetAppData";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
+import { NetworkDetails } from "@shared/constants/stellar";
 
-interface SendToData {
+interface ResolvedSendToData {
+  type: AppDataType.RESOLVED;
   recentAddresses: string[];
   destinationBalances?: AccountBalances;
   validatedAddress: string;
   fedAddress: string;
+  applicationState: APPLICATION_STATE;
+  publicKey: string;
+  networkDetails: NetworkDetails;
 }
+
+type SendToData = NeedsReRoute | ResolvedSendToData;
 
 const getAddressFromInput = async (userInput: string) => {
   if (isFederationAddress(userInput)) {
@@ -34,74 +45,103 @@ const getAddressFromInput = async (userInput: string) => {
   };
 };
 
-function useSendToData(
-  publicKey: string,
-  networkDetails: NetworkDetails,
-  balanceOptions: {
-    isMainnet: boolean;
-    showHidden: boolean;
-    includeIcons: boolean;
-  },
-) {
+function useSendToData() {
   const [state, dispatch] = useReducer(
     reducer<SendToData, unknown>,
     initialState,
   );
+  const { fetchData: fetchAppData } = useGetAppData();
 
-  const debouncedFetch = debounce(async (userInput: string) => {
-    try {
-      const { validatedAddress, fedAddress } =
-        await getAddressFromInput(userInput);
-      const { recentAddresses } = await loadRecentAddresses({
-        activePublicKey: publicKey,
-      });
+  const debouncedFetch = debounce(
+    async (
+      userInput: string,
+      publicKey: string,
+      applicationState: APPLICATION_STATE,
+      networkDetails: NetworkDetails,
+      _isMainnet: boolean,
+    ) => {
+      try {
+        const { validatedAddress, fedAddress } =
+          await getAddressFromInput(userInput);
+        const { recentAddresses } = await loadRecentAddresses({
+          activePublicKey: publicKey,
+        });
 
-      let destinationAccount = await getBaseAccount(validatedAddress);
-
-      const payload = {
-        recentAddresses,
-        validatedAddress,
-        fedAddress,
-      } as SendToData;
-
-      if (destinationAccount && !isContractId(destinationAccount)) {
-        const data = await getAccountBalances(
-          destinationAccount,
+        const payload = {
+          type: AppDataType.RESOLVED,
+          recentAddresses,
+          validatedAddress,
+          fedAddress,
+          applicationState,
+          publicKey,
           networkDetails,
-          balanceOptions.isMainnet,
-        );
-        payload.destinationBalances = {
-          ...data,
-          balances: sortBalances(data.balances),
-        };
+        } as ResolvedSendToData;
+
+        let destinationAccount = await getBaseAccount(validatedAddress);
+        if (destinationAccount && !isContractId(destinationAccount)) {
+          const data = await getAccountBalances(
+            destinationAccount,
+            networkDetails,
+            _isMainnet,
+          );
+          payload.destinationBalances = {
+            ...data,
+            balances: sortBalances(data.balances),
+          };
+        }
+
+        dispatch({ type: "FETCH_DATA_SUCCESS", payload });
+        return payload;
+      } catch (error) {
+        dispatch({ type: "FETCH_DATA_ERROR", payload: error });
+        return error;
       }
+    },
+    2000,
+  );
 
-      dispatch({ type: "FETCH_DATA_SUCCESS", payload });
-      return payload;
-    } catch (error) {
-      dispatch({ type: "FETCH_DATA_ERROR", payload: error });
-      return error;
-    }
-  }, 2000);
-
-  const fetchData = (
+  const fetchData = async (
     userInput: string,
     errors: FormikErrors<{
       destination: string;
     }>,
   ) => {
     dispatch({ type: "FETCH_DATA_START" });
+    const appData = await fetchAppData();
+    if (isError(appData)) {
+      throw new Error(appData.message);
+    }
+
+    if (appData.type === AppDataType.REROUTE) {
+      dispatch({ type: "FETCH_DATA_SUCCESS", payload: appData });
+      return appData;
+    }
+
+    const { publicKey, applicationState } = appData.account;
+    const { networkDetails } = appData.settings;
+    const _isMainnet = isMainnet(networkDetails);
+
     if (Object.keys(errors).length !== 0) {
       const payload = {
+        type: AppDataType.RESOLVED,
         recentAddresses: [],
         validatedAddress: "",
         fedAddress: "",
-      };
+        applicationState,
+        publicKey,
+        networkDetails,
+      } as ResolvedSendToData;
       dispatch({ type: "FETCH_DATA_SUCCESS", payload });
       return payload;
     }
 
-    return debouncedFetch(userInput);
+    return debouncedFetch(
+      userInput,
+      publicKey,
+      applicationState,
+      networkDetails,
+      _isMainnet,
+    );
   };
 
   return {

--- a/extension/src/popup/constants/routes.ts
+++ b/extension/src/popup/constants/routes.ts
@@ -1,8 +1,8 @@
 export enum ROUTES {
   debug = "/debug",
   integrationTest = "/integration-test",
-  welcome = "/",
-  account = "/account",
+  welcome = "/welcome",
+  account = "/",
   viewPublicKey = "/account/view-public-key",
   importAccount = "/account/import",
   connectWallet = "/account/connect",

--- a/extension/src/popup/ducks/accountServices.ts
+++ b/extension/src/popup/ducks/accountServices.ts
@@ -599,6 +599,9 @@ const authSlice = createSlice({
         error: message,
       };
     },
+    saveApplicationState(state, action) {
+      state.applicationState = action.payload;
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(createAccount.fulfilled, (state, action) => {
@@ -971,6 +974,7 @@ export const {
   resetAccountStatus,
   saveAccount,
   saveAccountError,
+  saveApplicationState,
 } = authSlice.actions;
 
 export { reducer };

--- a/extension/src/popup/ducks/accountServices.ts
+++ b/extension/src/popup/ducks/accountServices.ts
@@ -597,6 +597,33 @@ const authSlice = createSlice({
     setConnectingWalletType(state, action) {
       state.connectingWalletType = action.payload;
     },
+    saveAccount(state, action) {
+      const {
+        hasPrivateKey,
+        publicKey,
+        applicationState,
+        allAccounts,
+        bipPath,
+        tokenIdList,
+      } = action.payload;
+      state.hasPrivateKey = hasPrivateKey;
+      state.publicKey = publicKey;
+      state.applicationState =
+        applicationState || APPLICATION_STATE.APPLICATION_STARTED;
+      state.allAccounts = allAccounts;
+      state.bipPath = bipPath;
+      state.tokenIdList = tokenIdList;
+    },
+    saveAccountError(state, action) {
+      const {
+        message = "An unknown error occurred when loading your account",
+      } = action.payload;
+      return {
+        ...state,
+        applicationState: APPLICATION_STATE.APPLICATION_ERROR,
+        error: message,
+      };
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(createAccount.fulfilled, (state, action) => {
@@ -1000,7 +1027,12 @@ export const isAccountMismatchSelector = createSelector(
   (auth: InitialState) => auth.isAccountMismatch,
 );
 
-export const { clearApiError, setConnectingWalletType, resetAccountStatus } =
-  authSlice.actions;
+export const {
+  clearApiError,
+  setConnectingWalletType,
+  resetAccountStatus,
+  saveAccount,
+  saveAccountError,
+} = authSlice.actions;
 
 export { reducer };

--- a/extension/src/popup/ducks/accountServices.ts
+++ b/extension/src/popup/ducks/accountServices.ts
@@ -968,6 +968,18 @@ export const isAccountMismatchSelector = createSelector(
   (auth: InitialState) => auth.isAccountMismatch,
 );
 
+export const accountSelector = createSelector(
+  authSelector,
+  (auth: InitialState) => ({
+    hasPrivateKey: auth.hasPrivateKey,
+    publicKey: auth.publicKey,
+    applicationState: auth.applicationState,
+    allAccounts: auth.allAccounts,
+    bipPath: auth.bipPath,
+    tokenIdList: auth.tokenIdList,
+  }),
+);
+
 export const {
   clearApiError,
   setConnectingWalletType,

--- a/extension/src/popup/ducks/settings.ts
+++ b/extension/src/popup/ducks/settings.ts
@@ -9,7 +9,6 @@ import {
   saveAllowList as saveAllowListService,
   saveSettings as saveSettingsService,
   saveExperimentalFeatures as saveExperimentalFeaturesService,
-  loadSettings as loadSettingsService,
   changeNetwork as changeNetworkService,
   addCustomNetwork as addCustomNetworkService,
   removeCustomNetwork as removeCustomNetworkService,
@@ -82,10 +81,6 @@ const initialState = {
   ...experimentalFeaturesInitialState,
   assetsLists: DEFAULT_ASSETS_LISTS,
 };
-
-export const loadSettings = createAsyncThunk("settings/loadSettings", () =>
-  loadSettingsService(),
-);
 
 export const saveAllowList = createAsyncThunk<
   { allowList: AllowList },
@@ -454,62 +449,6 @@ const settingsSlice = createSlice({
         experimentalFeaturesState: SettingsState.SUCCESS,
       };
     });
-    builder.addCase(
-      loadSettings.fulfilled,
-      (
-        state,
-        action: PayloadAction<
-          Settings &
-            IndexerSettings &
-            ExperimentalFeatures & { assetsLists: AssetsLists }
-        >,
-      ) => {
-        const {
-          allowList,
-          isDataSharingAllowed,
-          networkDetails,
-          networksList,
-          isMemoValidationEnabled,
-          isExperimentalModeEnabled,
-          isHashSigningEnabled,
-          isSorobanPublicEnabled,
-          isRpcHealthy,
-          userNotification,
-          assetsLists,
-          isNonSSLEnabled,
-          isHideDustEnabled,
-        } = action?.payload || {
-          ...initialState,
-        };
-
-        return {
-          ...state,
-          allowList,
-          isDataSharingAllowed,
-          networkDetails,
-          networksList,
-          isMemoValidationEnabled,
-          isExperimentalModeEnabled,
-          isHashSigningEnabled,
-          isSorobanPublicEnabled,
-          isRpcHealthy,
-          userNotification,
-          assetsLists,
-          isNonSSLEnabled,
-          isHideDustEnabled,
-          settingsState: SettingsState.SUCCESS,
-        };
-      },
-    );
-    builder.addCase(loadSettings.pending, (state) => ({
-      ...state,
-      indexerState: SettingsState.LOADING,
-    }));
-    builder.addCase(loadSettings.rejected, (state) => ({
-      ...state,
-      indexerState: SettingsState.ERROR,
-      isRpcHealthy: false,
-    }));
     builder.addCase(
       changeNetwork.fulfilled,
       (

--- a/extension/src/popup/ducks/settings.ts
+++ b/extension/src/popup/ducks/settings.ts
@@ -352,6 +352,39 @@ const settingsSlice = createSlice({
     clearSettingsError(state) {
       state.error = "";
     },
+    saveSettings(state, action) {
+      const {
+        allowList,
+        isDataSharingAllowed,
+        networkDetails,
+        networksList,
+        isMemoValidationEnabled,
+        isExperimentalModeEnabled,
+        isHashSigningEnabled,
+        isSorobanPublicEnabled,
+        isRpcHealthy,
+        userNotification,
+        assetsLists,
+        isNonSSLEnabled,
+        isHideDustEnabled,
+      } = action?.payload || {
+        ...initialState,
+      };
+      state.allowList = allowList;
+      state.isDataSharingAllowed = isDataSharingAllowed;
+      state.networkDetails = networkDetails;
+      state.networksList = networksList;
+      state.isMemoValidationEnabled = isMemoValidationEnabled;
+      state.isExperimentalModeEnabled = isExperimentalModeEnabled;
+      state.isHashSigningEnabled = isHashSigningEnabled;
+      state.isSorobanPublicEnabled = isSorobanPublicEnabled;
+      state.isRpcHealthy = isRpcHealthy;
+      state.userNotification = userNotification;
+      state.assetsLists = assetsLists;
+      state.isNonSSLEnabled = isNonSSLEnabled;
+      state.isHideDustEnabled = isHideDustEnabled;
+      state.settingsState = SettingsState.SUCCESS;
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(
@@ -614,6 +647,7 @@ const settingsSlice = createSlice({
 export const { reducer } = settingsSlice;
 
 export const { clearSettingsError } = settingsSlice.actions;
+export const saveSettingsAction = settingsSlice.actions.saveSettings;
 
 export const settingsSelector = (state: {
   settings: Settings &

--- a/extension/src/popup/helpers/blockaid.ts
+++ b/extension/src/popup/helpers/blockaid.ts
@@ -44,10 +44,12 @@ export const useScanSite = () => {
       setData(response.data);
       emitMetric(METRIC_NAMES.blockaidDomainScan, { response: response.data });
       setLoading(false);
+      return response.data;
     } catch (err) {
       setError("Failed to scan site");
       Sentry.captureException(err);
       setLoading(false);
+      return null;
     }
   };
 

--- a/extension/src/popup/helpers/useSetupSigningFlow.ts
+++ b/extension/src/popup/helpers/useSetupSigningFlow.ts
@@ -6,12 +6,10 @@ import { signTransaction, rejectTransaction } from "popup/ducks/access";
 import { Account } from "@shared/api/types";
 
 import {
-  allAccountsSelector,
   confirmPassword,
   hardwareWalletTypeSelector,
   hasPrivateKeySelector,
   makeAccountActive,
-  publicKeySelector,
 } from "popup/ducks/accountServices";
 
 import {
@@ -26,6 +24,8 @@ export function useSetupSigningFlow(
   reject: typeof rejectTransaction,
   signFn: typeof signTransaction,
   transactionXdr: string,
+  publicKey: string,
+  allAccounts: Account[],
   accountToSign?: string,
 ) {
   const [isConfirming, setIsConfirming] = useState(false);
@@ -35,10 +35,8 @@ export function useSetupSigningFlow(
   const [currentAccount, setCurrentAccount] = useState({} as Account);
 
   const dispatch: AppDispatch = useDispatch();
-  const allAccounts = useSelector(allAccountsSelector);
   const hasPrivateKey = useSelector(hasPrivateKeySelector);
   const hardwareWalletType = useSelector(hardwareWalletTypeSelector);
-  const publicKey = useSelector(publicKeySelector);
 
   // the public key the user had selected before starting this flow
   const defaultPublicKey = useRef(publicKey);
@@ -124,6 +122,9 @@ export function useSetupSigningFlow(
     // handle any changes to the current acct - whether by auto select or manual select
     setCurrentAccount(allAccountsMap.current[publicKey] || ({} as Account));
   }, [allAccounts, publicKey]);
+
+  // TODO: setup local state for: accountToSign, allAccounts
+  // setter for that state so we can call hook in other hook bodies
 
   return {
     allAccounts,

--- a/extension/src/popup/helpers/useSetupSigningFlow.ts
+++ b/extension/src/popup/helpers/useSetupSigningFlow.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { AppDispatch } from "popup/App";
 import { signTransaction, rejectTransaction } from "popup/ducks/access";
@@ -33,7 +33,6 @@ export function useSetupSigningFlow(
   const [isPasswordRequired, setIsPasswordRequired] = useState(false);
   const [startedHwSign, setStartedHwSign] = useState(false);
   const [accountNotFound, setAccountNotFound] = useState(false);
-  const [currentAccount, setCurrentAccount] = useState({} as Account);
 
   const dispatch: AppDispatch = useDispatch();
   const hasPrivateKey = useSelector(hasPrivateKeySelector);
@@ -133,15 +132,12 @@ export function useSetupSigningFlow(
     }
   }, [accountToSign, allAccounts, dispatch, publicKey]);
 
-  useEffect(() => {
-    // handle any changes to the current acct - whether by auto select or manual select
-    if (publicKey) {
-      setCurrentAccount(allAccountsMap.current[publicKey] || ({} as Account));
-    }
+  const currentAccount = useMemo(() => {
+    return (
+      allAccounts.find((a) => a.publicKey === publicKey) || ({} as Account)
+    );
   }, [allAccounts, publicKey]);
-
-  // TODO: setup local state for: accountToSign, allAccounts
-  // setter for that state so we can call hook in other hook bodies
+  console.log(currentAccount);
 
   return {
     allAccounts,

--- a/extension/src/popup/views/Account/hooks/useGetAccountData.tsx
+++ b/extension/src/popup/views/Account/hooks/useGetAccountData.tsx
@@ -61,10 +61,10 @@ function useGetAccountData(options: {
   const { fetchData: fetchBalances } = useGetBalances(options);
   const { fetchData: fetchHistory } = useGetHistory();
 
-  const fetchData = async () => {
+  const fetchData = async (useAppDataCache = true) => {
     dispatch({ type: "FETCH_DATA_START" });
     try {
-      const appData = await fetchAppData();
+      const appData = await fetchAppData(useAppDataCache);
       if (isError(appData)) {
         throw new Error(appData.message);
       }

--- a/extension/src/popup/views/Account/index.tsx
+++ b/extension/src/popup/views/Account/index.tsx
@@ -13,11 +13,13 @@ import { useTranslation } from "react-i18next";
 import {
   settingsSorobanSupportedSelector,
   settingsSelector,
+  settingsNetworkDetailsSelector,
 } from "popup/ducks/settings";
 import { View } from "popup/basics/layout/View";
 import {
   accountNameSelector,
   allAccountsSelector,
+  publicKeySelector,
 } from "popup/ducks/accountServices";
 import { ROUTES } from "popup/constants/routes";
 import { navigateTo, openTab } from "popup/helpers/navigate";
@@ -47,7 +49,9 @@ export const Account = () => {
   const isSorobanSuported = useSelector(settingsSorobanSupportedSelector);
   const { userNotification } = useSelector(settingsSelector);
   const currentAccountName = useSelector(accountNameSelector);
+  const storedPublicKey = useSelector(publicKeySelector);
   const allAccounts = useSelector(allAccountsSelector);
+  const networkDetails = useSelector(settingsNetworkDetailsSelector);
   const [selectedAsset, setSelectedAsset] = useState("");
   const isFullscreenModeEnabled = isFullscreenMode();
   const { state: accountData, fetchData } = useGetAccountData({
@@ -61,7 +65,7 @@ export const Account = () => {
     };
     getData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [networkDetails.networkName, storedPublicKey]);
 
   if (
     accountData.state === RequestState.IDLE ||

--- a/extension/src/popup/views/Account/index.tsx
+++ b/extension/src/popup/views/Account/index.tsx
@@ -19,7 +19,6 @@ import { View } from "popup/basics/layout/View";
 import {
   accountNameSelector,
   allAccountsSelector,
-  publicKeySelector,
 } from "popup/ducks/accountServices";
 import { ROUTES } from "popup/constants/routes";
 import { navigateTo, openTab } from "popup/helpers/navigate";
@@ -49,7 +48,6 @@ export const Account = () => {
   const isSorobanSuported = useSelector(settingsSorobanSupportedSelector);
   const { userNotification } = useSelector(settingsSelector);
   const currentAccountName = useSelector(accountNameSelector);
-  const storedPublicKey = useSelector(publicKeySelector);
   const allAccounts = useSelector(allAccountsSelector);
   const networkDetails = useSelector(settingsNetworkDetailsSelector);
   const [selectedAsset, setSelectedAsset] = useState("");
@@ -65,7 +63,7 @@ export const Account = () => {
     };
     getData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [networkDetails.networkName, storedPublicKey]);
+  }, [networkDetails.networkName]);
 
   if (
     accountData.state === RequestState.IDLE ||
@@ -140,6 +138,9 @@ export const Account = () => {
         allAccounts={allAccounts}
         currentAccountName={currentAccountName}
         publicKey={resolvedData?.publicKey || ""}
+        onClickAccount={async () => {
+          await fetchData();
+        }}
       />
       <View.Content hasNoTopPadding>
         <div className="AccountView" data-testid="account-view">
@@ -166,7 +167,7 @@ export const Account = () => {
                 className="AccountView__total-usd-balance"
                 key="total-balance"
               >
-                {isMainnet(resolvedData!.networkDetails) && !hasError
+                {!hasError && isMainnet(resolvedData!.networkDetails)
                   ? `$${formatAmount(
                       roundUsdValue(totalBalanceUsd.toString()),
                     )}`

--- a/extension/src/popup/views/Account/index.tsx
+++ b/extension/src/popup/views/Account/index.tsx
@@ -13,7 +13,6 @@ import { useTranslation } from "react-i18next";
 import {
   settingsSorobanSupportedSelector,
   settingsSelector,
-  settingsNetworkDetailsSelector,
 } from "popup/ducks/settings";
 import { View } from "popup/basics/layout/View";
 import {
@@ -49,7 +48,6 @@ export const Account = () => {
   const { userNotification } = useSelector(settingsSelector);
   const currentAccountName = useSelector(accountNameSelector);
   const allAccounts = useSelector(allAccountsSelector);
-  const networkDetails = useSelector(settingsNetworkDetailsSelector);
   const [selectedAsset, setSelectedAsset] = useState("");
   const isFullscreenModeEnabled = isFullscreenMode();
   const { state: accountData, fetchData } = useGetAccountData({
@@ -63,7 +61,7 @@ export const Account = () => {
     };
     getData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [networkDetails.networkName]);
+  }, []);
 
   if (
     accountData.state === RequestState.IDLE ||
@@ -139,7 +137,7 @@ export const Account = () => {
         currentAccountName={currentAccountName}
         publicKey={resolvedData?.publicKey || ""}
         onClickAccount={async () => {
-          await fetchData();
+          await fetchData(false);
         }}
       />
       <View.Content hasNoTopPadding>

--- a/extension/src/popup/views/AccountCreator/hooks/useGetAccountCreatorData.tsx
+++ b/extension/src/popup/views/AccountCreator/hooks/useGetAccountCreatorData.tsx
@@ -1,0 +1,65 @@
+import { useReducer } from "react";
+
+import { initialState, isError, reducer } from "../../../../helpers/request";
+import {
+  AppDataType,
+  NeedsReRoute,
+  useGetAppData,
+} from "../../../../helpers/hooks/useGetAppData";
+import { NetworkDetails } from "@shared/constants/stellar";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
+
+interface ResolvedAccountData {
+  type: AppDataType.RESOLVED;
+  networkDetails: NetworkDetails;
+  publicKey: string;
+  applicationState: APPLICATION_STATE;
+}
+
+type AccountData = NeedsReRoute | ResolvedAccountData;
+
+function useGetAccountCreatorData() {
+  const [state, dispatch] = useReducer(
+    reducer<AccountData, unknown>,
+    initialState,
+  );
+  const { fetchData: fetchAppData } = useGetAppData();
+
+  const fetchData = async () => {
+    dispatch({ type: "FETCH_DATA_START" });
+    try {
+      const appData = await fetchAppData();
+      if (isError(appData)) {
+        throw new Error(appData.message);
+      }
+
+      if (appData.type === AppDataType.REROUTE) {
+        dispatch({ type: "FETCH_DATA_SUCCESS", payload: appData });
+        return appData;
+      }
+
+      const publicKey = appData.account.publicKey;
+      const networkDetails = appData.settings.networkDetails;
+
+      const payload = {
+        type: AppDataType.RESOLVED,
+        publicKey,
+        applicationState: appData.account.applicationState,
+        networkDetails,
+      } as ResolvedAccountData;
+
+      dispatch({ type: "FETCH_DATA_SUCCESS", payload });
+      return payload;
+    } catch (error) {
+      dispatch({ type: "FETCH_DATA_ERROR", payload: error });
+      return error;
+    }
+  };
+
+  return {
+    state,
+    fetchData,
+  };
+}
+
+export { useGetAccountCreatorData };

--- a/extension/src/popup/views/AccountCreator/hooks/useGetAccountCreatorData.tsx
+++ b/extension/src/popup/views/AccountCreator/hooks/useGetAccountCreatorData.tsx
@@ -11,8 +11,8 @@ import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
 interface ResolvedAccountData {
   type: AppDataType.RESOLVED;
-  networkDetails: NetworkDetails;
-  publicKey: string;
+  networkDetails?: NetworkDetails;
+  publicKey?: string;
   applicationState: APPLICATION_STATE;
 }
 
@@ -33,18 +33,20 @@ function useGetAccountCreatorData() {
         throw new Error(appData.message);
       }
 
-      if (appData.type === AppDataType.REROUTE) {
-        dispatch({ type: "FETCH_DATA_SUCCESS", payload: appData });
-        return appData;
-      }
-
-      const publicKey = appData.account.publicKey;
-      const networkDetails = appData.settings.networkDetails;
+      const publicKey =
+        appData.type === AppDataType.REROUTE ? "" : appData.account.publicKey;
+      const networkDetails =
+        appData.type === AppDataType.REROUTE
+          ? ""
+          : appData.settings.networkDetails;
 
       const payload = {
         type: AppDataType.RESOLVED,
         publicKey,
-        applicationState: appData.account.applicationState,
+        applicationState:
+          appData.type === AppDataType.REROUTE
+            ? APPLICATION_STATE.APPLICATION_STARTED
+            : appData.account.applicationState,
         networkDetails,
       } as ResolvedAccountData;
 

--- a/extension/src/popup/views/AccountCreator/index.tsx
+++ b/extension/src/popup/views/AccountCreator/index.tsx
@@ -37,6 +37,7 @@ export const AccountCreator = () => {
   const params = new URLSearchParams(location.search);
   const isRestartingOnboardingParam = params.get("isRestartingOnboarding");
   const isRestartingOnboarding = isRestartingOnboardingParam === "true";
+  const [mnemonicPhrase, setMnemonicPhrase] = useState("");
 
   const { state: accountData, fetchData } = useGetAccountCreatorData();
 
@@ -81,13 +82,9 @@ export const AccountCreator = () => {
     window.close();
   }
 
-  const publicKey = accountData.data?.publicKey!;
-
   const isShowingOverwriteWarning =
     accountData.data!.applicationState ===
     APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED;
-
-  const [mnemonicPhrase, setMnemonicPhrase] = useState("");
 
   const handleSubmit = async (values: FormValues) => {
     await dispatch(
@@ -111,7 +108,7 @@ export const AccountCreator = () => {
     termsOfUse: termsofUseValidator,
   });
 
-  return mnemonicPhrase && publicKey ? (
+  return mnemonicPhrase ? (
     <MnemonicPhrase mnemonicPhrase={mnemonicPhrase} />
   ) : (
     <React.Fragment>

--- a/extension/src/popup/views/AccountHistory/index.tsx
+++ b/extension/src/popup/views/AccountHistory/index.tsx
@@ -24,7 +24,7 @@ import { RequestState } from "constants/request";
 import { AppDataType } from "helpers/hooks/useGetAppData";
 import { openTab } from "popup/helpers/navigate";
 import { newTabHref } from "helpers/urls";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { APPLICATION_STATE } from "@shared/constants/applicationState";
 import { ROUTES } from "popup/constants/routes";
 import { useGetHistoryData } from "./hooks/useGetHistoryData";
@@ -33,6 +33,7 @@ import "./styles.scss";
 
 export const AccountHistory = () => {
   const { t } = useTranslation();
+  const location = useLocation();
   const networkDetails = useSelector(settingsNetworkDetailsSelector);
   const { isHideDustEnabled } = useSelector(settingsSelector);
   const { state: historyState, fetchData } = useGetHistoryData(

--- a/extension/src/popup/views/AccountHistory/index.tsx
+++ b/extension/src/popup/views/AccountHistory/index.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 
-import { publicKeySelector } from "popup/ducks/accountServices";
 import {
   settingsNetworkDetailsSelector,
   settingsSelector,
@@ -21,7 +20,6 @@ import {
 } from "popup/components/accountHistory/TransactionDetail";
 import { Loading } from "popup/components/Loading";
 import { View } from "popup/basics/layout/View";
-import { isMainnet } from "helpers/stellar";
 import { RequestState } from "constants/request";
 import { useGetHistoryData } from "./hooks/useGetHistoryData";
 
@@ -29,14 +27,10 @@ import "./styles.scss";
 
 export const AccountHistory = () => {
   const { t } = useTranslation();
-  const publicKey = useSelector(publicKeySelector);
   const networkDetails = useSelector(settingsNetworkDetailsSelector);
   const { isHideDustEnabled } = useSelector(settingsSelector);
   const { state: historyState, fetchData } = useGetHistoryData(
-    publicKey,
-    networkDetails,
     {
-      isMainnet: isMainnet(networkDetails),
       showHidden: false,
       includeIcons: true,
     },
@@ -98,7 +92,7 @@ export const AccountHistory = () => {
                       key={operation.id}
                       accountBalances={historyState.data.balances}
                       operation={operation}
-                      publicKey={publicKey}
+                      publicKey={historyState.data.publicKey}
                       networkDetails={networkDetails}
                       setDetailViewProps={setDetailViewProps}
                       setIsDetailViewShowing={setIsDetailViewShowing}

--- a/extension/src/popup/views/AccountMigration/index.tsx
+++ b/extension/src/popup/views/AccountMigration/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Route, Routes } from "react-router-dom";
 
-import { PublicKeyRoute, VerifiedAccountRoute } from "popup/Router";
+import { VerifiedAccountRoute } from "popup/Router";
 import { ROUTES } from "popup/constants/routes";
 import { View } from "popup/basics/layout/View";
 
@@ -40,21 +40,17 @@ export const AccountMigration = () => {
           <Route
             index
             element={
-              <PublicKeyRoute>
-                <div className="AccountMigration">
-                  <MigrationStart />
-                </div>
-              </PublicKeyRoute>
+              <div className="AccountMigration">
+                <MigrationStart />
+              </div>
             }
           ></Route>
           <Route
             path={reviewPath}
             element={
-              <PublicKeyRoute>
-                <div className="AccountMigration">
-                  <ReviewMigration />
-                </div>
-              </PublicKeyRoute>
+              <div className="AccountMigration">
+                <ReviewMigration />
+              </div>
             }
           ></Route>
           <Route
@@ -78,11 +74,9 @@ export const AccountMigration = () => {
           <Route
             path={migrationCompletePath}
             element={
-              <PublicKeyRoute>
-                <div className="AccountMigration">
-                  <MigrationComplete />
-                </div>
-              </PublicKeyRoute>
+              <div className="AccountMigration">
+                <MigrationComplete />
+              </div>
             }
           ></Route>
         </Routes>

--- a/extension/src/popup/views/AddAccount/AddAccount/index.tsx
+++ b/extension/src/popup/views/AddAccount/AddAccount/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from "react";
-import { Navigate, useNavigate } from "react-router-dom";
+import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 
@@ -21,6 +21,7 @@ import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
 export const AddAccount = () => {
   const { t } = useTranslation();
+  const location = useLocation();
   const navigate = useNavigate();
   const dispatch: AppDispatch = useDispatch();
   const { state, fetchData } = useGetAppData();

--- a/extension/src/popup/views/AddAccount/AddAccount/index.tsx
+++ b/extension/src/popup/views/AddAccount/AddAccount/index.tsx
@@ -1,27 +1,29 @@
 import React, { useCallback, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { Navigate, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import { emitMetric } from "helpers/metrics";
 
 import { AppDispatch } from "popup/App";
 import { ROUTES } from "popup/constants/routes";
 import { METRIC_NAMES } from "popup/constants/metricsNames";
-import { navigateTo } from "popup/helpers/navigate";
+import { navigateTo, openTab } from "popup/helpers/navigate";
 import { SubviewHeader } from "popup/components/SubviewHeader";
-import {
-  addAccount,
-  clearApiError,
-  publicKeySelector,
-} from "popup/ducks/accountServices";
+import { addAccount, clearApiError } from "popup/ducks/accountServices";
 import { EnterPassword } from "popup/components/EnterPassword";
+import { useGetAppData } from "helpers/hooks/useGetAppData";
+import { RequestState } from "constants/request";
+import { Loading } from "popup/components/Loading";
+import { Notification } from "@stellar/design-system";
+import { newTabHref } from "helpers/urls";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
 export const AddAccount = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const dispatch: AppDispatch = useDispatch();
-  const publicKey = useSelector(publicKeySelector);
+  const { state, fetchData } = useGetAppData();
 
   const handleAddAccount = useCallback(
     async (password: string = "") => {
@@ -46,13 +48,68 @@ export const AddAccount = () => {
     [dispatch],
   );
 
+  useEffect(() => {
+    const getData = async () => {
+      await fetchData();
+    };
+    getData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (
+    state.state === RequestState.IDLE ||
+    state.state === RequestState.LOADING
+  ) {
+    return <Loading />;
+  }
+
+  if (state.state === RequestState.ERROR) {
+    return (
+      <div className="AddAsset__fetch-fail">
+        <Notification
+          variant="error"
+          title={t("Failed to fetch your account data.")}
+        >
+          {t("Your account data could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
+
+  if (state.data?.type === "re-route") {
+    if (state.data.shouldOpenTab) {
+      openTab(newTabHref(state.data.routeTarget));
+      window.close();
+    }
+    return (
+      <Navigate
+        to={`${state.data.routeTarget}${location.search}`}
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  if (
+    state.data.type === "resolved" &&
+    (state.data.account.applicationState ===
+      APPLICATION_STATE.PASSWORD_CREATED ||
+      state.data.account.applicationState ===
+        APPLICATION_STATE.MNEMONIC_PHRASE_FAILED)
+  ) {
+    openTab(newTabHref(ROUTES.accountCreator, "isRestartingOnboarding=true"));
+    window.close();
+  }
+
+  const data = state.data;
+
   // Ask for user password in case it's not saved in current session store
   return (
     <React.Fragment>
       <SubviewHeader title="" />
 
       <EnterPassword
-        accountAddress={publicKey}
+        accountAddress={data.account.publicKey}
         onConfirm={handleEnterPassword}
         confirmButtonTitle={t("Create New Address")}
       />

--- a/extension/src/popup/views/AddFunds/index.tsx
+++ b/extension/src/popup/views/AddFunds/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Icon, Text } from "@stellar/design-system";
@@ -7,7 +6,6 @@ import { Icon, Text } from "@stellar/design-system";
 import { SubviewHeader } from "popup/components/SubviewHeader";
 import { Loading } from "popup/components/Loading";
 import { View } from "popup/basics/layout/View";
-import { publicKeySelector } from "popup/ducks/accountServices";
 import { ROUTES } from "popup/constants/routes";
 import { navigateTo } from "popup/helpers/navigate";
 import { useGetOnrampToken } from "helpers/hooks/useGetOnrampToken";
@@ -20,7 +18,6 @@ export const AddFunds = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { search } = useLocation();
-  const publicKey = useSelector(publicKeySelector);
 
   const params = new URLSearchParams(search);
   const isAddXlm = params.get("isAddXlm") === "true";
@@ -29,7 +26,7 @@ export const AddFunds = () => {
     isLoading: isTokenRequestLoading,
     fetchData,
     tokenError,
-  } = useGetOnrampToken({ publicKey, ...(isAddXlm ? { asset: "XLM" } : {}) });
+  } = useGetOnrampToken({ ...(isAddXlm ? { asset: "XLM" } : {}) });
 
   const handleOnrampClick = async () => {
     await fetchData();

--- a/extension/src/popup/views/AddToken/index.tsx
+++ b/extension/src/popup/views/AddToken/index.tsx
@@ -4,25 +4,23 @@ import {
   Button,
   Icon,
   Loader,
+  Notification,
   Text,
 } from "@stellar/design-system";
 import BigNumber from "bignumber.js";
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useLocation } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { StellarToml } from "stellar-sdk";
 
 import { BlockAidScanAssetResult } from "@shared/api/types";
 import { getIconUrlFromIssuer } from "@shared/api/helpers/getIconUrlFromIssuer";
 
-import { parsedSearchParam, TokenToAdd } from "helpers/urls";
+import { newTabHref, parsedSearchParam, TokenToAdd } from "helpers/urls";
 
 import { rejectToken, addToken } from "popup/ducks/access";
-import {
-  isNonSSLEnabledSelector,
-  settingsNetworkDetailsSelector,
-} from "popup/ducks/settings";
+import { isNonSSLEnabledSelector } from "popup/ducks/settings";
 import { useSetupAddTokenFlow } from "popup/helpers/useSetupAddTokenFlow";
 import {
   WarningMessageVariant,
@@ -41,6 +39,11 @@ import { isAssetSuspicious, scanAsset } from "popup/helpers/blockaid";
 import { useIsDomainListedAllowed } from "popup/helpers/useIsDomainListedAllowed";
 
 import "./styles.scss";
+import { useGetAppData } from "helpers/hooks/useGetAppData";
+import { RequestState } from "constants/request";
+import { openTab } from "popup/helpers/navigate";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
+import { ROUTES } from "popup/constants/routes";
 
 export const AddToken = () => {
   const location = useLocation();
@@ -55,11 +58,10 @@ export const AddToken = () => {
   const { isDomainListedAllowed } = useIsDomainListedAllowed({
     domain,
   });
+  const { state, fetchData } = useGetAppData();
 
   const { t } = useTranslation();
   const isNonSSLEnabled = useSelector(isNonSSLEnabledSelector);
-  const networkDetails = useSelector(settingsNetworkDetailsSelector);
-  const { networkName, networkPassphrase } = networkDetails;
 
   const [assetRows, setAssetRows] = useState([] as ManageAssetCurrency[]);
   const [assetIcon, setAssetIcon] = useState<string | undefined>(undefined);
@@ -142,9 +144,16 @@ export const AddToken = () => {
   }, [contractId, handleTokenLookup]);
 
   useEffect(() => {
-    if (!assetCode || !assetIssuer || blockaidData) {
+    if (
+      !assetCode ||
+      !assetIssuer ||
+      blockaidData ||
+      state.state !== RequestState.SUCCESS ||
+      state.data.type !== "resolved"
+    ) {
       return;
     }
+    const { networkDetails } = state.data.settings;
 
     const getBlockaidData = async () => {
       const scannedAsset = await scanAsset(
@@ -161,12 +170,20 @@ export const AddToken = () => {
     };
 
     getBlockaidData();
-  }, [assetCode, assetIssuer, blockaidData, networkDetails]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [assetCode, assetIssuer, blockaidData, state.state]);
 
   useEffect(() => {
-    if (!assetCode || !assetIssuer || assetIcon !== undefined) {
+    if (
+      !assetCode ||
+      !assetIssuer ||
+      assetIcon !== undefined ||
+      state.state !== RequestState.SUCCESS ||
+      state.data.type !== "resolved"
+    ) {
       return;
     }
+    const { networkDetails } = state.data.settings;
 
     const getAssetIcon = async () => {
       const iconUrl = await getIconUrlFromIssuer({
@@ -179,7 +196,8 @@ export const AddToken = () => {
     };
 
     getAssetIcon();
-  }, [assetCode, assetIssuer, assetIcon, networkDetails]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [assetCode, assetIssuer, assetIcon, state.state]);
 
   useEffect(() => {
     if (assetCode && assetIssuer && !assetDomain) {
@@ -211,6 +229,68 @@ export const AddToken = () => {
 
     getAssetTomlName();
   }, [assetDomain, assetCode, assetIssuer, assetTomlName]);
+
+  useEffect(() => {
+    const getData = async () => {
+      await fetchData();
+    };
+    getData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (
+    state.state === RequestState.IDLE ||
+    state.state === RequestState.LOADING
+  ) {
+    return (
+      <React.Fragment>
+        <View.Content>
+          <div className="AddToken__loader">
+            <Loader size="5rem" />
+          </div>
+        </View.Content>
+      </React.Fragment>
+    );
+  }
+
+  if (state.state === RequestState.ERROR) {
+    return (
+      <div className="AddAsset__fetch-fail">
+        <Notification
+          variant="error"
+          title={t("Failed to fetch your account data.")}
+        >
+          {t("Your account data could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
+
+  if (state.data?.type === "re-route") {
+    if (state.data.shouldOpenTab) {
+      openTab(newTabHref(state.data.routeTarget));
+      window.close();
+    }
+    return (
+      <Navigate
+        to={`${state.data.routeTarget}${location.search}`}
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  if (
+    state.data.type === "resolved" &&
+    (state.data.account.applicationState ===
+      APPLICATION_STATE.PASSWORD_CREATED ||
+      state.data.account.applicationState ===
+        APPLICATION_STATE.MNEMONIC_PHRASE_FAILED)
+  ) {
+    openTab(newTabHref(ROUTES.accountCreator, "isRestartingOnboarding=true"));
+    window.close();
+  }
+  const { networkPassphrase, networkName } = state.data.settings.networkDetails;
 
   if (entryNetworkPassphrase && entryNetworkPassphrase !== networkPassphrase) {
     return (

--- a/extension/src/popup/views/AdvancedSettings/index.tsx
+++ b/extension/src/popup/views/AdvancedSettings/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
-import { Navigate, useNavigate } from "react-router-dom";
+import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import { Notification, Button, Toggle, Loader } from "@stellar/design-system";
 import { Field, Form, Formik } from "formik";
 
@@ -69,6 +69,7 @@ const AdvancedSettingFeature = ({
 
 export const AdvancedSettings = () => {
   const { t } = useTranslation();
+  const location = useLocation();
   const dispatch = useDispatch<AppDispatch>();
   const navigate = useNavigate();
   const [isUnderstood, setIsUnderstood] = useState(false);

--- a/extension/src/popup/views/AdvancedSettings/index.tsx
+++ b/extension/src/popup/views/AdvancedSettings/index.tsx
@@ -1,14 +1,11 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useSelector, useDispatch } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { Navigate, useNavigate } from "react-router-dom";
 import { Notification, Button, Toggle, Loader } from "@stellar/design-system";
 import { Field, Form, Formik } from "formik";
 
-import {
-  saveExperimentalFeatures,
-  settingsSelector,
-} from "popup/ducks/settings";
+import { saveExperimentalFeatures } from "popup/ducks/settings";
 import { SettingsState } from "@shared/api/types";
 
 import { SubviewHeader } from "popup/components/SubviewHeader";
@@ -18,6 +15,13 @@ import IconExperimental from "popup/assets/icon-settings-experimental.svg";
 
 import "./styles.scss";
 import { AppDispatch } from "popup/App";
+import { useGetAppData } from "helpers/hooks/useGetAppData";
+import { RequestState } from "constants/request";
+import { Loading } from "popup/components/Loading";
+import { openTab } from "popup/helpers/navigate";
+import { newTabHref } from "helpers/urls";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
+import { ROUTES } from "popup/constants/routes";
 
 interface AdvancedSettingFeatureParams {
   title: string;
@@ -68,13 +72,67 @@ export const AdvancedSettings = () => {
   const dispatch = useDispatch<AppDispatch>();
   const navigate = useNavigate();
   const [isUnderstood, setIsUnderstood] = useState(false);
+  const { state, fetchData } = useGetAppData();
+
+  useEffect(() => {
+    const getData = async () => {
+      await fetchData();
+    };
+    getData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (
+    state.state === RequestState.IDLE ||
+    state.state === RequestState.LOADING
+  ) {
+    return <Loading />;
+  }
+
+  if (state.state === RequestState.ERROR) {
+    return (
+      <div className="AddAsset__fetch-fail">
+        <Notification
+          variant="error"
+          title={t("Failed to fetch your account data.")}
+        >
+          {t("Your account data could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
+
+  if (state.data?.type === "re-route") {
+    if (state.data.shouldOpenTab) {
+      openTab(newTabHref(state.data.routeTarget));
+      window.close();
+    }
+    return (
+      <Navigate
+        to={`${state.data.routeTarget}${location.search}`}
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  if (
+    state.data.type === "resolved" &&
+    (state.data.account.applicationState ===
+      APPLICATION_STATE.PASSWORD_CREATED ||
+      state.data.account.applicationState ===
+        APPLICATION_STATE.MNEMONIC_PHRASE_FAILED)
+  ) {
+    openTab(newTabHref(ROUTES.accountCreator, "isRestartingOnboarding=true"));
+    window.close();
+  }
 
   const {
     isExperimentalModeEnabled,
     isHashSigningEnabled,
     experimentalFeaturesState,
     isNonSSLEnabled,
-  } = useSelector(settingsSelector);
+  } = state.data.settings;
 
   interface SettingValues {
     isExperimentalModeEnabledValue: boolean;

--- a/extension/src/popup/views/DisplayBackupPhrase/index.tsx
+++ b/extension/src/popup/views/DisplayBackupPhrase/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Navigate, useNavigate } from "react-router-dom";
+import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import { Button, Input, Notification } from "@stellar/design-system";
 import { useTranslation } from "react-i18next";
 import { Field, Form, Formik } from "formik";
@@ -27,6 +27,7 @@ import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
 export const DisplayBackupPhrase = () => {
   const { t } = useTranslation();
+  const location = useLocation();
   const navigate = useNavigate();
   const [errorMessage, setErrorMessage] = useState("");
   const [isPhraseUnlocked, setIsPhraseUnlocked] = useState(false);

--- a/extension/src/popup/views/DisplayBackupPhrase/index.tsx
+++ b/extension/src/popup/views/DisplayBackupPhrase/index.tsx
@@ -1,15 +1,13 @@
 import React, { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { useSelector } from "react-redux";
-import { Button, Input } from "@stellar/design-system";
+import { Navigate, useNavigate } from "react-router-dom";
+import { Button, Input, Notification } from "@stellar/design-system";
 import { useTranslation } from "react-i18next";
 import { Field, Form, Formik } from "formik";
 
 import { showBackupPhrase } from "@shared/api/internal";
-import { publicKeySelector } from "popup/ducks/accountServices";
 
 import { ROUTES } from "popup/constants/routes";
-import { navigateTo } from "popup/helpers/navigate";
+import { navigateTo, openTab } from "popup/helpers/navigate";
 import { emitMetric } from "helpers/metrics";
 
 import { METRIC_NAMES } from "popup/constants/metricsNames";
@@ -21,14 +19,19 @@ import { View } from "popup/basics/layout/View";
 import { BackupPhraseWarningMessage } from "popup/components/WarningMessages";
 
 import "./styles.scss";
+import { useGetAppData } from "helpers/hooks/useGetAppData";
+import { RequestState } from "constants/request";
+import { Loading } from "popup/components/Loading";
+import { newTabHref } from "helpers/urls";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
 export const DisplayBackupPhrase = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const publicKey = useSelector(publicKeySelector);
   const [errorMessage, setErrorMessage] = useState("");
   const [isPhraseUnlocked, setIsPhraseUnlocked] = useState(false);
   const [mnemonicPhrase, setMnemonicPhrase] = useState("");
+  const { state, fetchData } = useGetAppData();
 
   useEffect(() => {
     emitMetric(
@@ -37,6 +40,61 @@ export const DisplayBackupPhrase = () => {
         : METRIC_NAMES.viewUnlockBackupPhrase,
     );
   }, [isPhraseUnlocked]);
+
+  useEffect(() => {
+    const getData = async () => {
+      await fetchData();
+    };
+    getData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (
+    state.state === RequestState.IDLE ||
+    state.state === RequestState.LOADING
+  ) {
+    return <Loading />;
+  }
+
+  if (state.state === RequestState.ERROR) {
+    return (
+      <div className="AddAsset__fetch-fail">
+        <Notification
+          variant="error"
+          title={t("Failed to fetch your account data.")}
+        >
+          {t("Your account data could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
+
+  if (state.data?.type === "re-route") {
+    if (state.data.shouldOpenTab) {
+      openTab(newTabHref(state.data.routeTarget));
+      window.close();
+    }
+    return (
+      <Navigate
+        to={`${state.data.routeTarget}${location.search}`}
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  if (
+    state.data.type === "resolved" &&
+    (state.data.account.applicationState ===
+      APPLICATION_STATE.PASSWORD_CREATED ||
+      state.data.account.applicationState ===
+        APPLICATION_STATE.MNEMONIC_PHRASE_FAILED)
+  ) {
+    openTab(newTabHref(ROUTES.accountCreator, "isRestartingOnboarding=true"));
+    window.close();
+  }
+
+  const { publicKey } = state.data.account;
 
   interface FormValues {
     password: string;

--- a/extension/src/popup/views/GrantAccess/hooks/useGetGrantAccessData.ts
+++ b/extension/src/popup/views/GrantAccess/hooks/useGetGrantAccessData.ts
@@ -1,0 +1,74 @@
+import { useReducer } from "react";
+
+import { initialState, isError, reducer } from "../../../../helpers/request";
+import {
+  AppDataType,
+  NeedsReRoute,
+  useGetAppData,
+} from "../../../../helpers/hooks/useGetAppData";
+import { useScanSite } from "../../../../popup/helpers/blockaid";
+import { BlockAidScanSiteResult } from "@shared/api/types";
+import { NetworkDetails } from "@shared/constants/stellar";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
+
+type ResolvedGrantAccessData = BlockAidScanSiteResult & {
+  type: AppDataType.RESOLVED;
+  publicKey: string;
+  networkDetails: NetworkDetails;
+  networksList: NetworkDetails[];
+  applicationState: APPLICATION_STATE;
+};
+
+type GrantAccessData = NeedsReRoute | ResolvedGrantAccessData;
+
+function useGetGrantAccessData(url: string) {
+  const [state, dispatch] = useReducer(
+    reducer<GrantAccessData, unknown>,
+    initialState,
+  );
+  const { fetchData: fetchAppData } = useGetAppData();
+  const { scanSite } = useScanSite();
+
+  const fetchData = async () => {
+    dispatch({ type: "FETCH_DATA_START" });
+    try {
+      const appData = await fetchAppData();
+      if (isError(appData)) {
+        throw new Error(appData.message);
+      }
+
+      if (appData.type === AppDataType.REROUTE) {
+        dispatch({ type: "FETCH_DATA_SUCCESS", payload: appData });
+        return appData;
+      }
+
+      const scanData = await scanSite(url, appData.settings.networkDetails);
+
+      if (!scanData) {
+        throw new Error("Unable to scan site");
+      }
+
+      const payload = {
+        type: AppDataType.RESOLVED,
+        publicKey: appData.account.publicKey,
+        networkDetails: appData.settings.networkDetails,
+        applicationState: appData.account.applicationState,
+        networksList: appData.settings.networksList,
+        ...scanData,
+      } as ResolvedGrantAccessData;
+
+      dispatch({ type: "FETCH_DATA_SUCCESS", payload });
+      return payload;
+    } catch (error) {
+      dispatch({ type: "FETCH_DATA_ERROR", payload: error });
+      return error;
+    }
+  };
+
+  return {
+    state,
+    fetchData,
+  };
+}
+
+export { useGetGrantAccessData };

--- a/extension/src/popup/views/GrantAccess/hooks/useGetGrantAccessData.ts
+++ b/extension/src/popup/views/GrantAccess/hooks/useGetGrantAccessData.ts
@@ -60,6 +60,7 @@ function useGetGrantAccessData(url: string) {
       dispatch({ type: "FETCH_DATA_SUCCESS", payload });
       return payload;
     } catch (error) {
+      console.log(error);
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
       return error;
     }

--- a/extension/src/popup/views/ManageAssets/index.tsx
+++ b/extension/src/popup/views/ManageAssets/index.tsx
@@ -5,7 +5,6 @@ import { ChooseAsset } from "popup/components/manageAssets/ChooseAsset";
 import { SearchAsset } from "popup/components/manageAssets/SearchAsset";
 import { AddAsset } from "popup/components/manageAssets/AddAsset";
 import { AssetVisibility } from "popup/components/manageAssets/AssetVisibility";
-import { PrivateKeyRoute } from "popup/Router";
 import { ROUTES } from "popup/constants/routes";
 import { getPathFromRoute } from "popup/helpers/route";
 
@@ -31,36 +30,11 @@ export const ManageAssets = () => {
       <Routes>
         <Route
           index
-          element={
-            <PrivateKeyRoute>
-              <ChooseAsset goBack={() => navigate(-1)} showHideAssets />
-            </PrivateKeyRoute>
-          }
+          element={<ChooseAsset goBack={() => navigate(-1)} showHideAssets />}
         ></Route>
-        <Route
-          path={searchAssetsPath}
-          element={
-            <PrivateKeyRoute>
-              <SearchAsset />
-            </PrivateKeyRoute>
-          }
-        ></Route>
-        <Route
-          path={assetVisibility}
-          element={
-            <PrivateKeyRoute>
-              <AssetVisibility />
-            </PrivateKeyRoute>
-          }
-        ></Route>
-        <Route
-          path={addAssetsPath}
-          element={
-            <PrivateKeyRoute>
-              <AddAsset />
-            </PrivateKeyRoute>
-          }
-        ></Route>
+        <Route path={searchAssetsPath} element={<SearchAsset />}></Route>
+        <Route path={assetVisibility} element={<AssetVisibility />}></Route>
+        <Route path={addAssetsPath} element={<AddAsset />}></Route>
       </Routes>
     </>
   );

--- a/extension/src/popup/views/ManageAssetsLists/index.tsx
+++ b/extension/src/popup/views/ManageAssetsLists/index.tsx
@@ -1,19 +1,24 @@
 import React, { useEffect, useState } from "react";
-import { useSelector } from "react-redux";
-import { Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router-dom";
 import { captureException } from "@sentry/browser";
 import { useTranslation } from "react-i18next";
 
 import { ROUTES } from "popup/constants/routes";
 import { NETWORKS } from "@shared/constants/stellar";
 import { AssetsListKey } from "@shared/constants/soroban/asset-list";
-import { settingsSelector } from "popup/ducks/settings";
 
 import { AssetLists } from "popup/components/manageAssetsLists/AssetLists";
 import { ModifyAssetList } from "popup/components/manageAssetsLists/ModifyAssetList";
 
 import "./styles.scss";
 import { getPathFromRoute } from "popup/helpers/route";
+import { AppDataType, useGetAppData } from "helpers/hooks/useGetAppData";
+import { RequestState } from "constants/request";
+import { Loading } from "popup/components/Loading";
+import { Notification } from "@stellar/design-system";
+import { openTab } from "popup/helpers/navigate";
+import { newTabHref } from "helpers/urls";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
 export interface AssetsListsData {
   url: string;
@@ -38,13 +43,18 @@ export const ManageAssetsLists = () => {
     disabled: [],
   } as SortedAssetsListsData);
   const [isLoading, setIsLoading] = useState(true);
-  const { assetsLists, networkDetails } = useSelector(settingsSelector);
   const { t } = useTranslation();
+  const { state, fetchData } = useGetAppData();
 
   useEffect(() => {
-    if (!selectedNetwork) {
+    if (
+      !selectedNetwork ||
+      state.state !== RequestState.SUCCESS ||
+      state.data.type !== AppDataType.RESOLVED
+    ) {
       return;
     }
+    const { assetsLists } = state.data.settings;
     const networkLists = assetsLists[selectedNetwork] || [];
     const listsArr: AssetsListsData[] = [];
 
@@ -71,7 +81,8 @@ export const ManageAssetsLists = () => {
     };
 
     fetchLists();
-  }, [selectedNetwork, assetsLists]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedNetwork, state.state]);
 
   useEffect(() => {
     if (assetsListsData.length) {
@@ -92,12 +103,74 @@ export const ManageAssetsLists = () => {
   }, [assetsListsData]);
 
   useEffect(() => {
-    setSelectedNetwork(
-      networkDetails.network === NETWORKS.TESTNET
-        ? NETWORKS.TESTNET
-        : NETWORKS.PUBLIC,
+    if (
+      state.state === RequestState.SUCCESS &&
+      state.data.type === AppDataType.RESOLVED
+    ) {
+      const { networkDetails } = state.data.settings;
+      setSelectedNetwork(
+        networkDetails.network === NETWORKS.TESTNET
+          ? NETWORKS.TESTNET
+          : NETWORKS.PUBLIC,
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.state]);
+
+  useEffect(() => {
+    const getData = async () => {
+      await fetchData();
+    };
+    getData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (
+    state.state === RequestState.IDLE ||
+    state.state === RequestState.LOADING
+  ) {
+    return <Loading />;
+  }
+
+  if (state.state === RequestState.ERROR) {
+    return (
+      <div className="AddAsset__fetch-fail">
+        <Notification
+          variant="error"
+          title={t("Failed to fetch your account data.")}
+        >
+          {t("Your account data could not be fetched at this time.")}
+        </Notification>
+      </div>
     );
-  }, [networkDetails]);
+  }
+
+  if (state.data?.type === "re-route") {
+    if (state.data.shouldOpenTab) {
+      openTab(newTabHref(state.data.routeTarget));
+      window.close();
+    }
+    return (
+      <Navigate
+        to={`${state.data.routeTarget}${location.search}`}
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  if (
+    state.data.type === "resolved" &&
+    (state.data.account.applicationState ===
+      APPLICATION_STATE.PASSWORD_CREATED ||
+      state.data.account.applicationState ===
+        APPLICATION_STATE.MNEMONIC_PHRASE_FAILED)
+  ) {
+    openTab(newTabHref(ROUTES.accountCreator, "isRestartingOnboarding=true"));
+    window.close();
+  }
+
+  const { assetsLists } = state.data.settings;
 
   const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setSelectedNetwork(e.target.value as AssetsListKey);

--- a/extension/src/popup/views/ManageAssetsLists/index.tsx
+++ b/extension/src/popup/views/ManageAssetsLists/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Navigate, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { captureException } from "@sentry/browser";
 import { useTranslation } from "react-i18next";
 
@@ -34,6 +34,7 @@ export interface SortedAssetsListsData {
 }
 
 export const ManageAssetsLists = () => {
+  const location = useLocation();
   const [selectedNetwork, setSelectedNetwork] = useState("" as AssetsListKey);
   const [assetsListsData, setAssetsListsData] = useState(
     [] as AssetsListsData[],

--- a/extension/src/popup/views/ManageAssetsLists/index.tsx
+++ b/extension/src/popup/views/ManageAssetsLists/index.tsx
@@ -8,7 +8,6 @@ import { ROUTES } from "popup/constants/routes";
 import { NETWORKS } from "@shared/constants/stellar";
 import { AssetsListKey } from "@shared/constants/soroban/asset-list";
 import { settingsSelector } from "popup/ducks/settings";
-import { PublicKeyRoute } from "popup/Router";
 
 import { AssetLists } from "popup/components/manageAssetsLists/AssetLists";
 import { ModifyAssetList } from "popup/components/manageAssetsLists/ModifyAssetList";
@@ -115,25 +114,21 @@ export const ManageAssetsLists = () => {
         <Route
           index
           element={
-            <PublicKeyRoute>
-              <AssetLists
-                sortedAssetsListsData={sortedAssetsListsData}
-                handleSelectChange={handleSelectChange}
-                selectedNetwork={selectedNetwork}
-                isLoading={isLoading}
-              />
-            </PublicKeyRoute>
+            <AssetLists
+              sortedAssetsListsData={sortedAssetsListsData}
+              handleSelectChange={handleSelectChange}
+              selectedNetwork={selectedNetwork}
+              isLoading={isLoading}
+            />
           }
         ></Route>
         <Route
           path={addNetworkPath}
           element={
-            <PublicKeyRoute>
-              <ModifyAssetList
-                assetsListsData={assetsListsData}
-                selectedNetwork={selectedNetwork}
-              />
-            </PublicKeyRoute>
+            <ModifyAssetList
+              assetsListsData={assetsListsData}
+              selectedNetwork={selectedNetwork}
+            />
           }
         ></Route>
       </Routes>

--- a/extension/src/popup/views/ManageConnectedApps/index.tsx
+++ b/extension/src/popup/views/ManageConnectedApps/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector, useDispatch } from "react-redux";
-import { Button, Select } from "@stellar/design-system";
+import { Button, Notification, Select } from "@stellar/design-system";
 
 import { saveAllowList, settingsSelector } from "popup/ducks/settings";
 import { publicKeySelector } from "popup/ducks/accountServices";
@@ -14,10 +14,19 @@ import { RemoveButton } from "popup/basics/buttons/RemoveButton";
 import { AppDispatch } from "popup/App";
 
 import "./styles.scss";
+import { useGetAppData } from "helpers/hooks/useGetAppData";
+import { RequestState } from "constants/request";
+import { Loading } from "popup/components/Loading";
+import { openTab } from "popup/helpers/navigate";
+import { newTabHref } from "helpers/urls";
+import { Navigate, useLocation } from "react-router-dom";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
+import { ROUTES } from "popup/constants/routes";
 
 export const ManageConnectedApps = () => {
   const dispatch = useDispatch<AppDispatch>();
   const { t } = useTranslation();
+  const location = useLocation();
   const { allowList, networkDetails, networksList } =
     useSelector(settingsSelector);
   const publicKey = useSelector(publicKeySelector);
@@ -27,6 +36,8 @@ export const ManageConnectedApps = () => {
   const [selectedAllowlist, setSelectedAllowlist] = useState(
     allowList?.[networkDetails.networkName]?.[publicKey] || [],
   );
+
+  const { state, fetchData } = useGetAppData();
 
   const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setSelectedNetworkName(e.target.value);
@@ -58,6 +69,59 @@ export const ManageConnectedApps = () => {
     networkDetails,
     networksList,
   ]);
+
+  useEffect(() => {
+    const getData = async () => {
+      await fetchData();
+    };
+    getData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (
+    state.state === RequestState.IDLE ||
+    state.state === RequestState.LOADING
+  ) {
+    return <Loading />;
+  }
+
+  if (state.state === RequestState.ERROR) {
+    return (
+      <div className="AddAsset__fetch-fail">
+        <Notification
+          variant="error"
+          title={t("Failed to fetch your account data.")}
+        >
+          {t("Your account data could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
+
+  if (state.data?.type === "re-route") {
+    if (state.data.shouldOpenTab) {
+      openTab(newTabHref(state.data.routeTarget));
+      window.close();
+    }
+    return (
+      <Navigate
+        to={`${state.data.routeTarget}${location.search}`}
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  if (
+    state.data.type === "resolved" &&
+    (state.data.account.applicationState ===
+      APPLICATION_STATE.PASSWORD_CREATED ||
+      state.data.account.applicationState ===
+        APPLICATION_STATE.MNEMONIC_PHRASE_FAILED)
+  ) {
+    openTab(newTabHref(ROUTES.accountCreator, "isRestartingOnboarding=true"));
+    window.close();
+  }
 
   return (
     <React.Fragment>

--- a/extension/src/popup/views/ManageNetwork/index.tsx
+++ b/extension/src/popup/views/ManageNetwork/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Route, Routes } from "react-router-dom";
 
-import { PublicKeyRoute } from "popup/Router";
 import { ROUTES } from "popup/constants/routes";
 
 import { NetworkForm } from "popup/components/manageNetwork/NetworkForm";
@@ -26,28 +25,10 @@ export const ManageNetwork = () => {
     <Routes>
       <Route
         path={addNetworkPath}
-        element={
-          <PublicKeyRoute>
-            <NetworkForm isEditing={false} />
-          </PublicKeyRoute>
-        }
+        element={<NetworkForm isEditing={false} />}
       ></Route>
-      <Route
-        path={networkSettingsPath}
-        element={
-          <PublicKeyRoute>
-            <NetworkSettings />
-          </PublicKeyRoute>
-        }
-      ></Route>
-      <Route
-        path={editNetworkPath}
-        element={
-          <PublicKeyRoute>
-            <NetworkForm isEditing />
-          </PublicKeyRoute>
-        }
-      ></Route>
+      <Route path={networkSettingsPath} element={<NetworkSettings />}></Route>
+      <Route path={editNetworkPath} element={<NetworkForm isEditing />}></Route>
     </Routes>
   );
 };

--- a/extension/src/popup/views/MnemonicPhrase/index.tsx
+++ b/extension/src/popup/views/MnemonicPhrase/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { Button, Text, Icon, Notification } from "@stellar/design-system";
 
@@ -29,6 +29,7 @@ export const MnemonicPhrase = ({
   mnemonicPhrase = "",
 }: MnemonicPhraseProps) => {
   const { t } = useTranslation();
+  const location = useLocation();
   const [isConfirmed, setIsConfirmed] = useState(false);
   const [isModalShowing, setIsModalShowing] = useState(true);
   const dispatch = useDispatch<AppDispatch>();

--- a/extension/src/popup/views/MnemonicPhrase/index.tsx
+++ b/extension/src/popup/views/MnemonicPhrase/index.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
-import { useSelector, useDispatch } from "react-redux";
+import React, { useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
 import { Navigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { Button, Text, Icon } from "@stellar/design-system";
+import { Button, Text, Icon, Notification } from "@stellar/design-system";
 
 import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
@@ -10,14 +10,16 @@ import { ROUTES } from "popup/constants/routes";
 import { Onboarding, OnboardingModal } from "popup/components/Onboarding";
 import { ConfirmMnemonicPhrase } from "popup/components/mnemonicPhrase/ConfirmMnemonicPhrase";
 import { DisplayMnemonicPhrase } from "popup/components/mnemonicPhrase/DisplayMnemonicPhrase";
-import {
-  applicationStateSelector,
-  confirmMnemonicPhrase,
-} from "popup/ducks/accountServices";
+import { confirmMnemonicPhrase } from "popup/ducks/accountServices";
 import { View } from "popup/basics/layout/View";
 import { AppDispatch } from "popup/App";
 
 import "./styles.scss";
+import { useGetAppData } from "helpers/hooks/useGetAppData";
+import { RequestState } from "constants/request";
+import { Loading } from "popup/components/Loading";
+import { openTab } from "popup/helpers/navigate";
+import { newTabHref } from "helpers/urls";
 
 interface MnemonicPhraseProps {
   mnemonicPhrase: string;
@@ -27,10 +29,64 @@ export const MnemonicPhrase = ({
   mnemonicPhrase = "",
 }: MnemonicPhraseProps) => {
   const { t } = useTranslation();
-  const applicationState = useSelector(applicationStateSelector);
   const [isConfirmed, setIsConfirmed] = useState(false);
   const [isModalShowing, setIsModalShowing] = useState(true);
   const dispatch = useDispatch<AppDispatch>();
+  const { state, fetchData } = useGetAppData();
+
+  useEffect(() => {
+    const getData = async () => {
+      await fetchData();
+    };
+    getData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (
+    state.state === RequestState.IDLE ||
+    state.state === RequestState.LOADING
+  ) {
+    return <Loading />;
+  }
+
+  if (state.state === RequestState.ERROR) {
+    return (
+      <div className="AddAsset__fetch-fail">
+        <Notification
+          variant="error"
+          title={t("Failed to fetch your account data.")}
+        >
+          {t("Your account data could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
+
+  if (state.data?.type === "re-route") {
+    if (state.data.shouldOpenTab) {
+      openTab(newTabHref(state.data.routeTarget));
+      window.close();
+    }
+    return (
+      <Navigate
+        to={`${state.data.routeTarget}${location.search}`}
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  if (
+    state.data.type === "resolved" &&
+    (state.data.account.applicationState ===
+      APPLICATION_STATE.PASSWORD_CREATED ||
+      state.data.account.applicationState ===
+        APPLICATION_STATE.MNEMONIC_PHRASE_FAILED)
+  ) {
+    openTab(newTabHref(ROUTES.accountCreator, "isRestartingOnboarding=true"));
+    window.close();
+  }
+  const { applicationState } = state.data.account;
 
   const handleSkip = () => {
     // confirm the mnemonic phrase for the user

--- a/extension/src/popup/views/Preferences/index.tsx
+++ b/extension/src/popup/views/Preferences/index.tsx
@@ -17,12 +17,13 @@ import { RequestState } from "constants/request";
 import { Loading } from "popup/components/Loading";
 import { openTab } from "popup/helpers/navigate";
 import { newTabHref } from "helpers/urls";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { APPLICATION_STATE } from "@shared/constants/applicationState";
 import { ROUTES } from "popup/constants/routes";
 
 export const Preferences = () => {
   const { t } = useTranslation();
+  const location = useLocation();
   const dispatch = useDispatch<AppDispatch>();
   const { state, fetchData } = useGetAppData();
 

--- a/extension/src/popup/views/Preferences/index.tsx
+++ b/extension/src/popup/views/Preferences/index.tsx
@@ -1,35 +1,36 @@
-import React from "react";
-import { Toggle } from "@stellar/design-system";
+import React, { useEffect } from "react";
+import { Notification, Toggle } from "@stellar/design-system";
 import { Field, Form, Formik } from "formik";
-import { useSelector, useDispatch } from "react-redux";
+import { useDispatch } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { View } from "popup/basics/layout/View";
 import { AppDispatch } from "popup/App";
 
-import { saveSettings, settingsSelector } from "popup/ducks/settings";
+import { saveSettings } from "popup/ducks/settings";
 
 import { SubviewHeader } from "popup/components/SubviewHeader";
 import { AutoSaveFields } from "popup/components/AutoSave";
 
 import "./styles.scss";
+import { useGetAppData } from "helpers/hooks/useGetAppData";
+import { RequestState } from "constants/request";
+import { Loading } from "popup/components/Loading";
+import { openTab } from "popup/helpers/navigate";
+import { newTabHref } from "helpers/urls";
+import { Navigate } from "react-router-dom";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
+import { ROUTES } from "popup/constants/routes";
 
 export const Preferences = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch<AppDispatch>();
-  const { isDataSharingAllowed, isMemoValidationEnabled, isHideDustEnabled } =
-    useSelector(settingsSelector);
+  const { state, fetchData } = useGetAppData();
 
   interface SettingValues {
     isValidatingMemoValue: boolean;
     isDataSharingAllowedValue: boolean;
     isHideDustEnabledValue: boolean;
   }
-
-  const initialValues: SettingValues = {
-    isValidatingMemoValue: isMemoValidationEnabled,
-    isDataSharingAllowedValue: isDataSharingAllowed,
-    isHideDustEnabledValue: isHideDustEnabled,
-  };
 
   const handleSubmit = async (formValue: SettingValues) => {
     const {
@@ -45,6 +46,68 @@ export const Preferences = () => {
         isHideDustEnabled: isHideDustEnabledValue,
       }),
     );
+  };
+
+  useEffect(() => {
+    const getData = async () => {
+      await fetchData();
+    };
+    getData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (
+    state.state === RequestState.IDLE ||
+    state.state === RequestState.LOADING
+  ) {
+    return <Loading />;
+  }
+
+  if (state.state === RequestState.ERROR) {
+    return (
+      <div className="AddAsset__fetch-fail">
+        <Notification
+          variant="error"
+          title={t("Failed to fetch your account data.")}
+        >
+          {t("Your account data could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
+
+  if (state.data?.type === "re-route") {
+    if (state.data.shouldOpenTab) {
+      openTab(newTabHref(state.data.routeTarget));
+      window.close();
+    }
+    return (
+      <Navigate
+        to={`${state.data.routeTarget}${location.search}`}
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  if (
+    state.data.type === "resolved" &&
+    (state.data.account.applicationState ===
+      APPLICATION_STATE.PASSWORD_CREATED ||
+      state.data.account.applicationState ===
+        APPLICATION_STATE.MNEMONIC_PHRASE_FAILED)
+  ) {
+    openTab(newTabHref(ROUTES.accountCreator, "isRestartingOnboarding=true"));
+    window.close();
+  }
+
+  const { isMemoValidationEnabled, isDataSharingAllowed, isHideDustEnabled } =
+    state.data.settings;
+
+  const initialValues: SettingValues = {
+    isValidatingMemoValue: isMemoValidationEnabled,
+    isDataSharingAllowedValue: isDataSharingAllowed,
+    isHideDustEnabledValue: isHideDustEnabled,
   };
 
   return (

--- a/extension/src/popup/views/RecoverAccount/hooks/useGetRecoverAccountData.ts
+++ b/extension/src/popup/views/RecoverAccount/hooks/useGetRecoverAccountData.ts
@@ -1,0 +1,57 @@
+import { useReducer } from "react";
+import { useDispatch } from "react-redux";
+import * as Sentry from "@sentry/browser";
+
+import { initialState, reducer } from "../../../../helpers/request";
+import { storeAccountMetricsData } from "../../../../helpers/metrics";
+import { loadAccount, loadSettings } from "@shared/api/internal";
+import {
+  saveAccount,
+  saveAccountError,
+  saveApplicationState,
+} from "../../../ducks/accountServices";
+import { saveSettingsAction } from "../../../ducks/settings";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
+
+interface AppData {
+  account: Awaited<ReturnType<typeof loadAccount>>;
+  settings: Awaited<ReturnType<typeof loadSettings>>;
+}
+
+function useRecoverAccountData() {
+  const [state, dispatch] = useReducer(reducer<AppData, unknown>, initialState);
+  const reduxDispatch = useDispatch();
+
+  const fetchData = async (): Promise<AppData | Error> => {
+    dispatch({ type: "FETCH_DATA_START" });
+    reduxDispatch(saveApplicationState(APPLICATION_STATE.APPLICATION_LOADING));
+    try {
+      const account = await loadAccount();
+      const settings = await loadSettings();
+
+      storeAccountMetricsData(account.publicKey, account.allAccounts);
+      reduxDispatch(saveAccount(account));
+      reduxDispatch(saveSettingsAction(settings));
+      reduxDispatch(saveApplicationState(account.applicationState));
+
+      const payload = {
+        account,
+        settings,
+      };
+      dispatch({ type: "FETCH_DATA_SUCCESS", payload });
+      return payload;
+    } catch (error) {
+      dispatch({ type: "FETCH_DATA_ERROR", payload: error });
+      reduxDispatch(saveAccountError(error));
+      Sentry.captureException(`Error loading app data: ${error}`);
+      throw new Error("Failed to fetch app data", { cause: error });
+    }
+  };
+
+  return {
+    state,
+    fetchData,
+  };
+}
+
+export { useRecoverAccountData };

--- a/extension/src/popup/views/RecoverAccount/index.tsx
+++ b/extension/src/popup/views/RecoverAccount/index.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   Text,
   Toggle,
+  Notification,
 } from "@stellar/design-system";
 import { useTranslation } from "react-i18next";
 
@@ -34,14 +35,12 @@ import {
   confirmPassword as confirmPasswordValidator,
   termsOfUse as termsofUseValidator,
 } from "popup/helpers/validators";
-import {
-  applicationStateSelector,
-  authErrorSelector,
-  publicKeySelector,
-  recoverAccount,
-} from "popup/ducks/accountServices";
+import { authErrorSelector, recoverAccount } from "popup/ducks/accountServices";
 
 import "./styles.scss";
+import { RequestState } from "constants/request";
+import { Loading } from "popup/components/Loading";
+import { useRecoverAccountData } from "./hooks/useGetRecoverAccountData";
 
 interface PhraseInputProps {
   phraseInput: string;
@@ -102,12 +101,9 @@ const buildMnemonicPhrase = (mnemonicPhraseArr: string[]) =>
 
 export const RecoverAccount = () => {
   const { t } = useTranslation();
-  const publicKey = useSelector(publicKeySelector);
-  const applicationState = useSelector(applicationStateSelector);
 
   const authError = useSelector(authErrorSelector);
   const navigate = useNavigate();
-  const publicKeyRef = useRef(publicKey);
   const RecoverAccountSchema = YupObject().shape({
     password: passwordValidator,
     confirmPassword: confirmPasswordValidator,
@@ -121,29 +117,27 @@ export const RecoverAccount = () => {
   const [mnemonicPhraseArr, setMnemonicPhraseArr] = useState([] as string[]);
   const [password, setPassword] = useState("");
   const [pastedValues, setPastedValues] = useState<string[]>([]);
-
-  const isShowingOverwriteWarning =
-    applicationState === APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED;
+  const { state, fetchData } = useRecoverAccountData();
 
   const handleConfirm = (values: FormValues) => {
     setPassword(values.password);
   };
 
-  const handleSubmit = async () => {
-    await dispatch(
-      recoverAccount({
-        password,
-        mnemonicPhrase: buildMnemonicPhrase(mnemonicPhraseArr),
-        isOverwritingAccount: isShowingOverwriteWarning,
-      }),
-    );
-  };
+  const publicKeyRef = useRef(
+    state.state === RequestState.SUCCESS && state.data.account.publicKey,
+  );
 
   useEffect(() => {
-    if (publicKey && publicKey !== publicKeyRef.current) {
+    console.log(state, publicKeyRef);
+    if (
+      state.state === RequestState.SUCCESS &&
+      state.data.account.publicKey &&
+      state.data.account.publicKey !== publicKeyRef.current
+    ) {
       navigateTo(ROUTES.recoverAccountSuccess, navigate);
     }
-  }, [publicKey, navigate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [navigate, publicKeyRef, state.state]);
 
   useEffect(() => {
     const phraseInputsArr: string[] = [];
@@ -165,11 +159,55 @@ export const RecoverAccount = () => {
     }, 150);
   }, [isLongPhrase]);
 
+  useEffect(() => {
+    const getData = async () => {
+      await fetchData();
+    };
+    getData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (
+    state.state === RequestState.IDLE ||
+    state.state === RequestState.LOADING
+  ) {
+    return <Loading />;
+  }
+
+  if (state.state === RequestState.ERROR) {
+    return (
+      <div className="AddAsset__fetch-fail">
+        <Notification
+          variant="error"
+          title={t("Failed to fetch your account data.")}
+        >
+          {t("Your account data could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
+
+  const { applicationState } = state.data.account;
+
+  const isShowingOverwriteWarning =
+    applicationState === APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED;
+
   const handleMnemonicInputChange = (value: string, i: number) => {
     const arr = [...mnemonicPhraseArr];
     arr[i] = value;
 
     setMnemonicPhraseArr(arr);
+  };
+
+  const handleSubmit = async () => {
+    await dispatch(
+      recoverAccount({
+        password,
+        mnemonicPhrase: buildMnemonicPhrase(mnemonicPhraseArr),
+        isOverwritingAccount: isShowingOverwriteWarning,
+      }),
+    );
+    await fetchData();
   };
 
   const handlePaste = async (e: React.ClipboardEvent<HTMLInputElement>) => {

--- a/extension/src/popup/views/ReviewAuth/hooks/useGetReviewAuthData.tsx
+++ b/extension/src/popup/views/ReviewAuth/hooks/useGetReviewAuthData.tsx
@@ -1,16 +1,25 @@
 import { useReducer } from "react";
 
 import { initialState, isError, reducer } from "helpers/request";
-import { useGetAppData } from "helpers/hooks/useGetAppData";
+import {
+  AppDataType,
+  NeedsReRoute,
+  useGetAppData,
+} from "helpers/hooks/useGetAppData";
 import { useSetupSigningFlow } from "popup/helpers/useSetupSigningFlow";
 import { rejectTransaction, signTransaction } from "popup/ducks/access";
 import { NetworkDetails } from "@shared/constants/stellar";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
-interface ReviewAuthData {
+interface ResolvedData {
+  type: AppDataType.RESOLVED;
   networkDetails: NetworkDetails;
   publicKey: string;
   signFlowState: ReturnType<typeof useSetupSigningFlow>;
+  applicationState: APPLICATION_STATE;
 }
+
+type ReviewAuthData = ResolvedData | NeedsReRoute;
 
 function useGetReviewAuthData(transactionXdr: string, accountToSign?: string) {
   const [state, dispatch] = useReducer(
@@ -42,14 +51,21 @@ function useGetReviewAuthData(transactionXdr: string, accountToSign?: string) {
         throw new Error(appData.message);
       }
 
+      if (appData.type === AppDataType.REROUTE) {
+        dispatch({ type: "FETCH_DATA_SUCCESS", payload: appData });
+        return appData;
+      }
+
       const publicKey = appData.account.publicKey;
       const allAccounts = appData.account.allAccounts;
       const networkDetails = appData.settings.networkDetails;
       setAccountDetails({ publicKey, allAccounts, accountToSign });
 
       const payload = {
+        type: AppDataType.RESOLVED,
         networkDetails,
         publicKey,
+        applicationState: appData.account.applicationState,
         signFlowState: {
           allAccounts,
           accountNotFound,
@@ -65,7 +81,7 @@ function useGetReviewAuthData(transactionXdr: string, accountToSign?: string) {
           hardwareWalletType,
           setAccountDetails,
         },
-      };
+      } as ResolvedData;
       dispatch({ type: "FETCH_DATA_SUCCESS", payload });
       return payload;
     } catch (error) {

--- a/extension/src/popup/views/ReviewAuth/hooks/useGetReviewAuthData.tsx
+++ b/extension/src/popup/views/ReviewAuth/hooks/useGetReviewAuthData.tsx
@@ -8,6 +8,7 @@ import { NetworkDetails } from "@shared/constants/stellar";
 
 interface ReviewAuthData {
   networkDetails: NetworkDetails;
+  publicKey: string;
   signFlowState: ReturnType<typeof useSetupSigningFlow>;
 }
 
@@ -18,6 +19,20 @@ function useGetReviewAuthData(transactionXdr: string, accountToSign?: string) {
   );
 
   const { fetchData: fetchAppData } = useGetAppData();
+  const {
+    accountNotFound,
+    currentAccount,
+    isConfirming,
+    isPasswordRequired,
+    handleApprove,
+    hwStatus,
+    rejectAndClose,
+    isHardwareWallet,
+    setIsPasswordRequired,
+    verifyPasswordThenSign,
+    hardwareWalletType,
+    setAccountDetails,
+  } = useSetupSigningFlow(rejectTransaction, signTransaction, transactionXdr);
 
   const fetchData = async () => {
     dispatch({ type: "FETCH_DATA_START" });
@@ -30,29 +45,11 @@ function useGetReviewAuthData(transactionXdr: string, accountToSign?: string) {
       const publicKey = appData.account.publicKey;
       const allAccounts = appData.account.allAccounts;
       const networkDetails = appData.settings.networkDetails;
-      const {
-        accountNotFound,
-        currentAccount,
-        isConfirming,
-        isPasswordRequired,
-        handleApprove,
-        hwStatus,
-        rejectAndClose,
-        isHardwareWallet,
-        setIsPasswordRequired,
-        verifyPasswordThenSign,
-        hardwareWalletType,
-      } = useSetupSigningFlow(
-        rejectTransaction,
-        signTransaction,
-        transactionXdr,
-        publicKey,
-        allAccounts,
-        accountToSign,
-      );
+      setAccountDetails({ publicKey, allAccounts, accountToSign });
 
       const payload = {
         networkDetails,
+        publicKey,
         signFlowState: {
           allAccounts,
           accountNotFound,
@@ -60,13 +57,13 @@ function useGetReviewAuthData(transactionXdr: string, accountToSign?: string) {
           isConfirming,
           isPasswordRequired,
           isHardwareWallet,
-          publicKey,
           handleApprove,
           hwStatus,
           rejectAndClose,
           setIsPasswordRequired,
           verifyPasswordThenSign,
           hardwareWalletType,
+          setAccountDetails,
         },
       };
       dispatch({ type: "FETCH_DATA_SUCCESS", payload });

--- a/extension/src/popup/views/ReviewAuth/index.tsx
+++ b/extension/src/popup/views/ReviewAuth/index.tsx
@@ -266,7 +266,9 @@ export const ReviewAuth = () => {
             <AccountList
               allAccounts={allAccounts}
               publicKey={publicKey}
-              setIsDropdownOpen={setIsDropdownOpen}
+              onClickAccount={async () => {
+                setIsDropdownOpen(!isDropdownOpen);
+              }}
             />
           </div>
         </SlideupModal>

--- a/extension/src/popup/views/ReviewAuth/index.tsx
+++ b/extension/src/popup/views/ReviewAuth/index.tsx
@@ -114,11 +114,11 @@ export const ReviewAuth = () => {
     return <Loading />;
   }
 
+  const publicKey = reviewAuthState.data?.publicKey!;
   const {
     allAccounts,
     currentAccount,
     isConfirming,
-    publicKey,
     handleApprove,
     hardwareWalletType,
     hwStatus,

--- a/extension/src/popup/views/SendPayment/index.tsx
+++ b/extension/src/popup/views/SendPayment/index.tsx
@@ -5,7 +5,7 @@ import { ROUTES } from "popup/constants/routes";
 import { STEPS } from "popup/constants/send-payment";
 import { emitMetric } from "helpers/metrics";
 import { METRIC_NAMES } from "popup/constants/metricsNames";
-import { PublicKeyRoute, VerifiedAccountRoute } from "popup/Router";
+import { VerifiedAccountRoute } from "popup/Router";
 import { SendTo } from "popup/components/sendPayment/SendTo";
 import { SendAmount } from "popup/components/sendPayment/SendAmount";
 import { SendType } from "popup/components/sendPayment/SendAmount/SendType";
@@ -23,20 +23,14 @@ export const SendPayment = () => {
   const renderStep = (step: STEPS) => {
     switch (step) {
       case STEPS.CHOOSE_ASSET: {
-        return (
-          <PublicKeyRoute>
-            <ChooseAsset goBack={() => setActiveStep(STEPS.AMOUNT)} />
-          </PublicKeyRoute>
-        );
+        return <ChooseAsset goBack={() => setActiveStep(STEPS.AMOUNT)} />;
       }
       case STEPS.SET_PAYMENT_TIMEOUT: {
         emitMetric(METRIC_NAMES.sendPaymentSettingsTimeout);
         return (
-          <PublicKeyRoute>
-            <SendSettingsTxTimeout
-              goBack={() => setActiveStep(STEPS.PAYMENT_SETTINGS)}
-            />
-          </PublicKeyRoute>
+          <SendSettingsTxTimeout
+            goBack={() => setActiveStep(STEPS.PAYMENT_SETTINGS)}
+          />
         );
       }
       case STEPS.PAYMENT_CONFIRM: {
@@ -50,60 +44,46 @@ export const SendPayment = () => {
       case STEPS.SET_PAYMENT_SLIPPAGE: {
         emitMetric(METRIC_NAMES.sendPaymentSettingsSlippage);
         return (
-          <PublicKeyRoute>
-            <SendSettingsSlippage
-              goBack={() => setActiveStep(STEPS.PAYMENT_SETTINGS)}
-            />
-          </PublicKeyRoute>
+          <SendSettingsSlippage
+            goBack={() => setActiveStep(STEPS.PAYMENT_SETTINGS)}
+          />
         );
       }
       case STEPS.SET_PAYMENT_FEE: {
         emitMetric(METRIC_NAMES.sendPaymentSettingsFee);
         return (
-          <PublicKeyRoute>
-            <SendSettingsFee
-              goBack={() => setActiveStep(STEPS.PAYMENT_SETTINGS)}
-            />
-          </PublicKeyRoute>
+          <SendSettingsFee
+            goBack={() => setActiveStep(STEPS.PAYMENT_SETTINGS)}
+          />
         );
       }
       case STEPS.PAYMENT_SETTINGS: {
         emitMetric(METRIC_NAMES.sendPaymentSettings);
         return (
-          <PublicKeyRoute>
-            <SendSettings
-              goBack={() => setActiveStep(STEPS.AMOUNT)}
-              goToNext={() => setActiveStep(STEPS.PAYMENT_CONFIRM)}
-              goToFeeSetting={() => setActiveStep(STEPS.SET_PAYMENT_FEE)}
-              goToSlippageSetting={() =>
-                setActiveStep(STEPS.SET_PAYMENT_SLIPPAGE)
-              }
-              goToTimeoutSetting={() =>
-                setActiveStep(STEPS.SET_PAYMENT_TIMEOUT)
-              }
-            />
-          </PublicKeyRoute>
+          <SendSettings
+            goBack={() => setActiveStep(STEPS.AMOUNT)}
+            goToNext={() => setActiveStep(STEPS.PAYMENT_CONFIRM)}
+            goToFeeSetting={() => setActiveStep(STEPS.SET_PAYMENT_FEE)}
+            goToSlippageSetting={() =>
+              setActiveStep(STEPS.SET_PAYMENT_SLIPPAGE)
+            }
+            goToTimeoutSetting={() => setActiveStep(STEPS.SET_PAYMENT_TIMEOUT)}
+          />
         );
       }
       case STEPS.PAYMENT_TYPE: {
         emitMetric(METRIC_NAMES.sendPaymentType);
-        return (
-          <PublicKeyRoute>
-            <SendType setStep={setActiveStep} />
-          </PublicKeyRoute>
-        );
+        return <SendType setStep={setActiveStep} />;
       }
       case STEPS.AMOUNT: {
         emitMetric(METRIC_NAMES.sendPaymentAmount);
         return (
-          <PublicKeyRoute>
-            <SendAmount
-              goBack={() => setActiveStep(STEPS.DESTINATION)}
-              goToNext={() => setActiveStep(STEPS.PAYMENT_SETTINGS)}
-              goToPaymentType={() => setActiveStep(STEPS.PAYMENT_TYPE)}
-              goToChooseAsset={() => setActiveStep(STEPS.CHOOSE_ASSET)}
-            />
-          </PublicKeyRoute>
+          <SendAmount
+            goBack={() => setActiveStep(STEPS.DESTINATION)}
+            goToNext={() => setActiveStep(STEPS.PAYMENT_SETTINGS)}
+            goToPaymentType={() => setActiveStep(STEPS.PAYMENT_TYPE)}
+            goToChooseAsset={() => setActiveStep(STEPS.CHOOSE_ASSET)}
+          />
         );
       }
       default:

--- a/extension/src/popup/views/SendPayment/index.tsx
+++ b/extension/src/popup/views/SendPayment/index.tsx
@@ -5,7 +5,6 @@ import { ROUTES } from "popup/constants/routes";
 import { STEPS } from "popup/constants/send-payment";
 import { emitMetric } from "helpers/metrics";
 import { METRIC_NAMES } from "popup/constants/metricsNames";
-import { VerifiedAccountRoute } from "popup/Router";
 import { SendTo } from "popup/components/sendPayment/SendTo";
 import { SendAmount } from "popup/components/sendPayment/SendAmount";
 import { SendType } from "popup/components/sendPayment/SendAmount/SendType";
@@ -36,9 +35,7 @@ export const SendPayment = () => {
       case STEPS.PAYMENT_CONFIRM: {
         emitMetric(METRIC_NAMES.sendPaymentConfirm);
         return (
-          <VerifiedAccountRoute>
-            <SendConfirm goBack={() => setActiveStep(STEPS.PAYMENT_SETTINGS)} />
-          </VerifiedAccountRoute>
+          <SendConfirm goBack={() => setActiveStep(STEPS.PAYMENT_SETTINGS)} />
         );
       }
       case STEPS.SET_PAYMENT_SLIPPAGE: {
@@ -90,12 +87,10 @@ export const SendPayment = () => {
       case STEPS.DESTINATION: {
         emitMetric(METRIC_NAMES.sendPaymentRecentAddress);
         return (
-          <VerifiedAccountRoute>
-            <SendTo
-              goBack={() => navigate(ROUTES.account)}
-              goToNext={() => setActiveStep(STEPS.AMOUNT)}
-            />
-          </VerifiedAccountRoute>
+          <SendTo
+            goBack={() => navigate(ROUTES.account)}
+            goToNext={() => setActiveStep(STEPS.AMOUNT)}
+          />
         );
       }
     }

--- a/extension/src/popup/views/SignAuthEntry/index.tsx
+++ b/extension/src/popup/views/SignAuthEntry/index.tsx
@@ -196,7 +196,9 @@ export const SignAuthEntry = () => {
                     accountName={currentAccount.name}
                     active
                     publicKey={currentAccount.publicKey}
-                    setIsDropdownOpen={setIsDropdownOpen}
+                    onClickAccount={async () => {
+                      setIsDropdownOpen(!isDropdownOpen);
+                    }}
                   >
                     <OptionTag
                       hardwareWalletType={currentAccount.hardwareWalletType}
@@ -265,7 +267,9 @@ export const SignAuthEntry = () => {
             <AccountList
               allAccounts={allAccounts}
               publicKey={publicKey}
-              setIsDropdownOpen={setIsDropdownOpen}
+              onClickAccount={async () => {
+                setIsDropdownOpen(!isDropdownOpen);
+              }}
             />
           </div>
         </SlideupModal>

--- a/extension/src/popup/views/SignMessage/hooks/useGetSignMessageData.tsx
+++ b/extension/src/popup/views/SignMessage/hooks/useGetSignMessageData.tsx
@@ -1,39 +1,23 @@
 import { useReducer } from "react";
 
-import { BlockAidScanTxResult } from "@shared/api/types";
 import { initialState, isError, reducer } from "helpers/request";
-import { AccountBalances, useGetBalances } from "helpers/hooks/useGetBalances";
-import { useScanTx } from "popup/helpers/blockaid";
 import { useGetAppData } from "helpers/hooks/useGetAppData";
-import { isMainnet } from "helpers/stellar";
 import { useSetupSigningFlow } from "popup/helpers/useSetupSigningFlow";
 import { rejectTransaction, signTransaction } from "popup/ducks/access";
+import { NetworkDetails } from "@shared/constants/stellar";
 
-interface SignTxData {
-  scanResult: BlockAidScanTxResult | null;
-  balances: AccountBalances;
+interface SignMessageData {
+  networkDetails: NetworkDetails;
   signFlowState: ReturnType<typeof useSetupSigningFlow>;
 }
 
-function useGetSignTxData(
-  scanOptions: {
-    xdr: string;
-    url: string;
-  },
-  balanceOptions: {
-    showHidden: boolean;
-    includeIcons: boolean;
-  },
-  accountToSign?: string,
-) {
+function useGetSignMessageData(transactionXdr: string, accountToSign?: string) {
   const [state, dispatch] = useReducer(
-    reducer<SignTxData, unknown>,
+    reducer<SignMessageData, unknown>,
     initialState,
   );
 
   const { fetchData: fetchAppData } = useGetAppData();
-  const { fetchData: fetchBalances } = useGetBalances(balanceOptions);
-  const { scanTx } = useScanTx();
 
   const fetchData = async () => {
     dispatch({ type: "FETCH_DATA_START" });
@@ -46,17 +30,6 @@ function useGetSignTxData(
       const publicKey = appData.account.publicKey;
       const allAccounts = appData.account.allAccounts;
       const networkDetails = appData.settings.networkDetails;
-      const isMainnetNetwork = isMainnet(networkDetails);
-      const balancesResult = await fetchBalances(
-        publicKey,
-        isMainnetNetwork,
-        networkDetails,
-      );
-      const scanResult = await scanTx(
-        scanOptions.xdr,
-        scanOptions.url,
-        networkDetails,
-      );
       const {
         accountNotFound,
         currentAccount,
@@ -72,18 +45,14 @@ function useGetSignTxData(
       } = useSetupSigningFlow(
         rejectTransaction,
         signTransaction,
-        scanOptions.xdr,
+        transactionXdr,
         publicKey,
         allAccounts,
         accountToSign,
       );
 
-      if (isError<AccountBalances>(balancesResult)) {
-        throw new Error(balancesResult.message);
-      }
       const payload = {
-        balances: balancesResult,
-        scanResult,
+        networkDetails,
         signFlowState: {
           allAccounts,
           accountNotFound,
@@ -114,4 +83,4 @@ function useGetSignTxData(
   };
 }
 
-export { useGetSignTxData };
+export { useGetSignMessageData };

--- a/extension/src/popup/views/SignMessage/index.tsx
+++ b/extension/src/popup/views/SignMessage/index.tsx
@@ -224,7 +224,9 @@ export const SignMessage = () => {
                     accountName={currentAccount.name}
                     active
                     publicKey={currentAccount.publicKey}
-                    setIsDropdownOpen={setIsDropdownOpen}
+                    onClickAccount={async () => {
+                      setIsDropdownOpen(!isDropdownOpen);
+                    }}
                   >
                     <OptionTag
                       hardwareWalletType={currentAccount.hardwareWalletType}
@@ -284,7 +286,9 @@ export const SignMessage = () => {
             <AccountList
               allAccounts={allAccounts}
               publicKey={publicKey}
-              setIsDropdownOpen={setIsDropdownOpen}
+              onClickAccount={async () => {
+                setIsDropdownOpen(!isDropdownOpen);
+              }}
             />
           </div>
         </SlideupModal>

--- a/extension/src/popup/views/SignTransaction/hooks/useGetSignTxData.tsx
+++ b/extension/src/popup/views/SignTransaction/hooks/useGetSignTxData.tsx
@@ -13,6 +13,7 @@ import { isMainnet } from "helpers/stellar";
 import { useSetupSigningFlow } from "popup/helpers/useSetupSigningFlow";
 import { rejectTransaction, signTransaction } from "popup/ducks/access";
 import { APPLICATION_STATE } from "@shared/constants/applicationState";
+import { NetworkDetails } from "@shared/constants/stellar";
 
 interface ResolvedData {
   type: AppDataType.RESOLVED;
@@ -21,6 +22,7 @@ interface ResolvedData {
   publicKey: string;
   signFlowState: ReturnType<typeof useSetupSigningFlow>;
   applicationState: APPLICATION_STATE;
+  networkDetails: NetworkDetails;
 }
 
 type SignTxData = NeedsReRoute | ResolvedData;
@@ -99,6 +101,7 @@ function useGetSignTxData(
         scanResult,
         publicKey,
         applicationState: appData.account.applicationState,
+        networkDetails: appData.settings.networkDetails,
         signFlowState: {
           allAccounts,
           accountNotFound,

--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -13,7 +13,6 @@ import {
   Operation,
 } from "stellar-sdk";
 
-import { signTransaction, rejectTransaction } from "popup/ducks/access";
 import {
   isNonSSLEnabledSelector,
   settingsNetworkDetailsSelector,
@@ -33,7 +32,6 @@ import {
   truncatedPublicKey,
 } from "helpers/stellar";
 import { decodeMemo } from "popup/helpers/parseTransaction";
-import { useSetupSigningFlow } from "popup/helpers/useSetupSigningFlow";
 import { useIsDomainListedAllowed } from "popup/helpers/useIsDomainListedAllowed";
 import { navigateTo } from "popup/helpers/navigate";
 import { ROUTES } from "popup/constants/routes";
@@ -93,26 +91,7 @@ export const SignTransaction = () => {
 
   const { networkName, networkPassphrase } = networkDetails;
   let accountToSign = _accountToSign;
-  // TODO: PUBKEY
-  const {
-    allAccounts,
-    accountNotFound,
-    currentAccount,
-    isConfirming,
-    isPasswordRequired,
-    publicKey,
-    handleApprove,
-    hwStatus,
-    rejectAndClose,
-    setIsPasswordRequired,
-    verifyPasswordThenSign,
-    hardwareWalletType,
-  } = useSetupSigningFlow(
-    rejectTransaction,
-    signTransaction,
-    transactionXdr,
-    accountToSign,
-  );
+
   const { state: scanTxState, fetchData } = useGetSignTxData(
     {
       xdr: transactionXdr,
@@ -122,7 +101,9 @@ export const SignTransaction = () => {
       showHidden: false,
       includeIcons: true,
     },
+    accountToSign,
   );
+
   const scanResult = scanTxState.data?.scanResult;
   const flaggedMalicious =
     scanResult?.validation &&
@@ -226,6 +207,21 @@ export const SignTransaction = () => {
   if (isLoading) {
     return <Loading />;
   }
+
+  const {
+    allAccounts,
+    accountNotFound,
+    currentAccount,
+    isConfirming,
+    isPasswordRequired,
+    publicKey,
+    handleApprove,
+    hwStatus,
+    rejectAndClose,
+    setIsPasswordRequired,
+    verifyPasswordThenSign,
+    hardwareWalletType,
+  } = scanTxState.data?.signFlowState!;
 
   const hasEnoughXlm = scanTxState.data?.balances.balances.some(
     (balance) =>

--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -28,7 +28,6 @@ import { emitMetric } from "helpers/metrics";
 import {
   getTransactionInfo,
   isFederationAddress,
-  isMainnet,
   isMuxedAccount,
   stroopToXlm,
   truncatedPublicKey,
@@ -94,6 +93,7 @@ export const SignTransaction = () => {
 
   const { networkName, networkPassphrase } = networkDetails;
   let accountToSign = _accountToSign;
+  // TODO: PUBKEY
   const {
     allAccounts,
     accountNotFound,
@@ -114,14 +114,11 @@ export const SignTransaction = () => {
     accountToSign,
   );
   const { state: scanTxState, fetchData } = useGetSignTxData(
-    publicKey,
-    networkDetails,
     {
       xdr: transactionXdr,
       url,
     },
     {
-      isMainnet: isMainnet(networkDetails),
       showHidden: false,
       includeIcons: true,
     },

--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -13,10 +13,7 @@ import {
   Operation,
 } from "stellar-sdk";
 
-import {
-  isNonSSLEnabledSelector,
-  settingsNetworkDetailsSelector,
-} from "popup/ducks/settings";
+import { isNonSSLEnabledSelector } from "popup/ducks/settings";
 
 import { ShowOverlayStatus } from "popup/ducks/transactionSubmission";
 
@@ -495,7 +492,9 @@ export const SignTransaction = () => {
             <AccountList
               allAccounts={allAccounts}
               publicKey={publicKey}
-              setIsDropdownOpen={setIsDropdownOpen}
+              onClickAccount={async () => {
+                setIsDropdownOpen(!isDropdownOpen);
+              }}
             />
           </div>
         </SlideupModal>

--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -86,12 +86,10 @@ export const SignTransaction = () => {
   const [hasAcceptedInsufficientFee, setHasAcceptedInsufficientFee] =
     useState(false);
   const isNonSSLEnabled = useSelector(isNonSSLEnabledSelector);
-  const networkDetails = useSelector(settingsNetworkDetailsSelector);
   const { isDomainListedAllowed } = useIsDomainListedAllowed({
     domain,
   });
 
-  const { networkName, networkPassphrase } = networkDetails;
   let accountToSign = _accountToSign;
 
   const { state: scanTxState, fetchData } = useGetSignTxData(
@@ -208,6 +206,8 @@ export const SignTransaction = () => {
     window.close();
   }
 
+  const { networkName, networkPassphrase } = scanTxState.data?.networkDetails!;
+
   const scanResult = scanTxState.data?.scanResult;
   const flaggedMalicious =
     scanResult?.validation &&
@@ -256,6 +256,7 @@ export const SignTransaction = () => {
       balance.token.code === "XLM" &&
       (balance as NativeAsset).available.gt(stroopToXlm(_fee as string)),
   );
+
   if (
     currentAccount.publicKey &&
     !hasEnoughXlm &&

--- a/extension/src/popup/views/Swap/index.tsx
+++ b/extension/src/popup/views/Swap/index.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { STEPS } from "popup/constants/swap";
 import { ROUTES } from "popup/constants/routes";
 import { emitMetric } from "helpers/metrics";
-import { PublicKeyRoute, VerifiedAccountRoute } from "popup/Router";
+import { VerifiedAccountRoute } from "popup/Router";
 import { SendAmount } from "popup/components/sendPayment/SendAmount";
 import { SendSettings } from "popup/components/sendPayment/SendSettings";
 import { SendSettingsFee } from "popup/components/sendPayment/SendSettings/TransactionFee";
@@ -23,11 +23,9 @@ export const Swap = () => {
       case STEPS.SET_SWAP_TIMEOUT: {
         emitMetric(METRIC_NAMES.swapSettingsTimeout);
         return (
-          <PublicKeyRoute>
-            <SendSettingsTxTimeout
-              goBack={() => setActiveStep(STEPS.SWAP_SETTINGS)}
-            />
-          </PublicKeyRoute>
+          <SendSettingsTxTimeout
+            goBack={() => setActiveStep(STEPS.SWAP_SETTINGS)}
+          />
         );
       }
       case STEPS.SWAP_CONFIRM: {
@@ -41,35 +39,27 @@ export const Swap = () => {
       case STEPS.SET_SWAP_SLIPPAGE: {
         emitMetric(METRIC_NAMES.swapSettingsSlippage);
         return (
-          <PublicKeyRoute>
-            <SendSettingsSlippage
-              goBack={() => setActiveStep(STEPS.SWAP_SETTINGS)}
-            />
-          </PublicKeyRoute>
+          <SendSettingsSlippage
+            goBack={() => setActiveStep(STEPS.SWAP_SETTINGS)}
+          />
         );
       }
       case STEPS.SET_SWAP_FEE: {
         emitMetric(METRIC_NAMES.swapSettingsFee);
         return (
-          <PublicKeyRoute>
-            <SendSettingsFee
-              goBack={() => setActiveStep(STEPS.SWAP_SETTINGS)}
-            />
-          </PublicKeyRoute>
+          <SendSettingsFee goBack={() => setActiveStep(STEPS.SWAP_SETTINGS)} />
         );
       }
       case STEPS.SWAP_SETTINGS: {
         emitMetric(METRIC_NAMES.swapSettings);
         return (
-          <PublicKeyRoute>
-            <SendSettings
-              goBack={() => setActiveStep(STEPS.AMOUNT)}
-              goToNext={() => setActiveStep(STEPS.SWAP_CONFIRM)}
-              goToFeeSetting={() => setActiveStep(STEPS.SET_SWAP_FEE)}
-              goToSlippageSetting={() => setActiveStep(STEPS.SET_SWAP_SLIPPAGE)}
-              goToTimeoutSetting={() => setActiveStep(STEPS.SET_SWAP_TIMEOUT)}
-            />
-          </PublicKeyRoute>
+          <SendSettings
+            goBack={() => setActiveStep(STEPS.AMOUNT)}
+            goToNext={() => setActiveStep(STEPS.SWAP_CONFIRM)}
+            goToFeeSetting={() => setActiveStep(STEPS.SET_SWAP_FEE)}
+            goToSlippageSetting={() => setActiveStep(STEPS.SET_SWAP_SLIPPAGE)}
+            goToTimeoutSetting={() => setActiveStep(STEPS.SET_SWAP_TIMEOUT)}
+          />
         );
       }
       default:
@@ -86,11 +76,7 @@ export const Swap = () => {
         );
       }
       case STEPS.CHOOSE_ASSETS: {
-        return (
-          <PublicKeyRoute>
-            <ChooseAsset goBack={() => setActiveStep(STEPS.AMOUNT)} />
-          </PublicKeyRoute>
-        );
+        return <ChooseAsset goBack={() => setActiveStep(STEPS.AMOUNT)} />;
       }
     }
   };

--- a/extension/src/popup/views/Swap/index.tsx
+++ b/extension/src/popup/views/Swap/index.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from "react-router-dom";
 import { STEPS } from "popup/constants/swap";
 import { ROUTES } from "popup/constants/routes";
 import { emitMetric } from "helpers/metrics";
-import { VerifiedAccountRoute } from "popup/Router";
 import { SendAmount } from "popup/components/sendPayment/SendAmount";
 import { SendSettings } from "popup/components/sendPayment/SendSettings";
 import { SendSettingsFee } from "popup/components/sendPayment/SendSettings/TransactionFee";
@@ -31,9 +30,7 @@ export const Swap = () => {
       case STEPS.SWAP_CONFIRM: {
         emitMetric(METRIC_NAMES.swapConfirm);
         return (
-          <VerifiedAccountRoute>
-            <SendConfirm goBack={() => setActiveStep(STEPS.SWAP_SETTINGS)} />
-          </VerifiedAccountRoute>
+          <SendConfirm goBack={() => setActiveStep(STEPS.SWAP_SETTINGS)} />
         );
       }
       case STEPS.SET_SWAP_SLIPPAGE: {
@@ -66,13 +63,11 @@ export const Swap = () => {
       case STEPS.AMOUNT: {
         emitMetric(METRIC_NAMES.swapAmount);
         return (
-          <VerifiedAccountRoute>
-            <SendAmount
-              goBack={() => navigate(ROUTES.account)}
-              goToNext={() => setActiveStep(STEPS.SWAP_SETTINGS)}
-              goToChooseAsset={() => setActiveStep(STEPS.CHOOSE_ASSETS)}
-            />
-          </VerifiedAccountRoute>
+          <SendAmount
+            goBack={() => navigate(ROUTES.account)}
+            goToNext={() => setActiveStep(STEPS.SWAP_SETTINGS)}
+            goToChooseAsset={() => setActiveStep(STEPS.CHOOSE_ASSETS)}
+          />
         );
       }
       case STEPS.CHOOSE_ASSETS: {

--- a/extension/src/popup/views/VerifyAccount/index.tsx
+++ b/extension/src/popup/views/VerifyAccount/index.tsx
@@ -1,19 +1,22 @@
 import get from "lodash/get";
-import React from "react";
+import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch, useSelector } from "react-redux";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { useNavigate, useLocation, Navigate } from "react-router-dom";
 
 import { ROUTES } from "popup/constants/routes";
-import { navigateTo } from "popup/helpers/navigate";
-import {
-  confirmPassword,
-  publicKeySelector,
-} from "popup/ducks/accountServices";
+import { navigateTo, openTab } from "popup/helpers/navigate";
+import { confirmPassword } from "popup/ducks/accountServices";
 import { EnterPassword } from "popup/components/EnterPassword";
 
 import "./styles.scss";
 import { AppDispatch } from "popup/App";
+import { useGetAppData } from "helpers/hooks/useGetAppData";
+import { RequestState } from "constants/request";
+import { Loading } from "popup/components/Loading";
+import { Notification } from "@stellar/design-system";
+import { newTabHref } from "helpers/urls";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
 interface VerifyAccountProps {
   isApproval?: boolean;
@@ -29,8 +32,7 @@ export const VerifyAccount = ({
   const { t } = useTranslation();
   const location = useLocation();
   const dispatch = useDispatch<AppDispatch>();
-
-  const publicKey = useSelector(publicKeySelector);
+  const { state, fetchData } = useGetAppData();
 
   const from = get(location, "state.from.pathname", "") as ROUTES;
 
@@ -53,6 +55,61 @@ export const VerifyAccount = ({
 
     navigate(-1);
   };
+
+  useEffect(() => {
+    const getData = async () => {
+      await fetchData();
+    };
+    getData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (
+    state.state === RequestState.IDLE ||
+    state.state === RequestState.LOADING
+  ) {
+    return <Loading />;
+  }
+
+  if (state.state === RequestState.ERROR) {
+    return (
+      <div className="AddAsset__fetch-fail">
+        <Notification
+          variant="error"
+          title={t("Failed to fetch your account data.")}
+        >
+          {t("Your account data could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
+
+  if (state.data?.type === "re-route") {
+    if (state.data.shouldOpenTab) {
+      openTab(newTabHref(state.data.routeTarget));
+      window.close();
+    }
+    return (
+      <Navigate
+        to={`${state.data.routeTarget}${location.search}`}
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
+
+  if (
+    state.data.type === "resolved" &&
+    (state.data.account.applicationState ===
+      APPLICATION_STATE.PASSWORD_CREATED ||
+      state.data.account.applicationState ===
+        APPLICATION_STATE.MNEMONIC_PHRASE_FAILED)
+  ) {
+    openTab(newTabHref(ROUTES.accountCreator, "isRestartingOnboarding=true"));
+    window.close();
+  }
+
+  const { publicKey } = state.data.account;
 
   return (
     <React.Fragment>

--- a/extension/src/popup/views/ViewPublicKey/index.tsx
+++ b/extension/src/popup/views/ViewPublicKey/index.tsx
@@ -31,12 +31,13 @@ import { useGetAppData } from "helpers/hooks/useGetAppData";
 import { RequestState } from "constants/request";
 import { Loading } from "popup/components/Loading";
 import { newTabHref } from "helpers/urls";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { APPLICATION_STATE } from "@shared/constants/applicationState";
 import { ROUTES } from "popup/constants/routes";
 
 export const ViewPublicKey = () => {
   const { t } = useTranslation();
+  const location = useLocation();
   const [isEditingName, setIsEditingName] = useState(false);
   const accountName = useSelector(accountNameSelector);
   const { state, fetchData } = useGetAppData();

--- a/extension/src/popup/views/__tests__/Account.test.tsx
+++ b/extension/src/popup/views/__tests__/Account.test.tsx
@@ -573,7 +573,30 @@ describe("Account view", () => {
     });
   });
   it("shows prices and deltas", async () => {
-    // TODO: these mocks dont seem to reset, why?
+    jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+      Promise.resolve({
+        networkDetails: MAINNET_NETWORK_DETAILS,
+        networksList: DEFAULT_NETWORKS,
+        hiddenAssets: {},
+        allowList: ApiInternal.DEFAULT_ALLOW_LIST,
+        error: "",
+        isDataSharingAllowed: false,
+        isMemoValidationEnabled: false,
+        isHideDustEnabled: true,
+        settingsState: SettingsState.SUCCESS,
+        isSorobanPublicEnabled: false,
+        isRpcHealthy: true,
+        userNotification: {
+          enabled: false,
+          message: "",
+        },
+        isExperimentalModeEnabled: false,
+        isHashSigningEnabled: false,
+        isNonSSLEnabled: false,
+        experimentalFeaturesState: SettingsState.SUCCESS,
+        assetsLists: DEFAULT_ASSETS_LISTS,
+      }),
+    );
     jest
       .spyOn(ApiInternal, "getAccountBalances")
       .mockImplementation(() => Promise.resolve(mockBalances));

--- a/extension/src/popup/views/__tests__/Account.test.tsx
+++ b/extension/src/popup/views/__tests__/Account.test.tsx
@@ -50,43 +50,52 @@ const mockHistoryOperations = {
   ] as Horizon.ServerApi.PaymentOperationRecord[],
 };
 
-jest.spyOn(global, "fetch").mockImplementation((url: string) => {
-  if (
-    url ===
-    `${INDEXER_URL}/scan-asset-bulk?asset_ids=USDC-GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM`
-  ) {
-    return Promise.resolve({
-      json: async () => {
-        return {
-          data: {
-            results: {
-              "USDC-GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM": {
-                address: "",
-                chain: "stellar",
-                attack_types: {},
-                fees: {},
-                malicious_score: "1.0",
-                metadata: {},
-                financial_stats: {},
-                trading_limits: {},
-                result_type: "Malicious",
-                features: [
-                  { description: "", feature_id: "METADATA", type: "Benign" },
-                ],
+jest
+  .spyOn(global, "fetch")
+  .mockImplementation(
+    (url: string | URL | Request, _init?: RequestInit | undefined) => {
+      if (
+        url ===
+        `${INDEXER_URL}/scan-asset-bulk?asset_ids=USDC-GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM`
+      ) {
+        return Promise.resolve({
+          json: async () => {
+            return {
+              data: {
+                results: {
+                  "USDC-GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM":
+                    {
+                      address: "",
+                      chain: "stellar",
+                      attack_types: {},
+                      fees: {},
+                      malicious_score: "1.0",
+                      metadata: {},
+                      financial_stats: {},
+                      trading_limits: {},
+                      result_type: "Malicious",
+                      features: [
+                        {
+                          description: "",
+                          feature_id: "METADATA",
+                          type: "Benign",
+                        },
+                      ],
+                    },
+                },
               },
-            },
+            };
           },
-        };
-      },
-    } as any);
-  }
+        } as any);
+      }
 
-  return Promise.resolve({
-    json: async () => {
-      return [];
+      return Promise.resolve({
+        json: async () => {
+          return [];
+        },
+      } as any);
     },
-  } as any);
-});
+  );
 
 jest
   .spyOn(ApiInternal, "getHiddenAssets")

--- a/extension/src/popup/views/__tests__/Account.test.tsx
+++ b/extension/src/popup/views/__tests__/Account.test.tsx
@@ -3,7 +3,10 @@ import { render, waitFor, screen, fireEvent } from "@testing-library/react";
 import { Horizon } from "stellar-sdk";
 import BigNumber from "bignumber.js";
 
-import { APPLICATION_STATE as ApplicationState } from "@shared/constants/applicationState";
+import {
+  APPLICATION_STATE,
+  APPLICATION_STATE as ApplicationState,
+} from "@shared/constants/applicationState";
 import {
   TESTNET_NETWORK_DETAILS,
   DEFAULT_NETWORKS,
@@ -16,8 +19,8 @@ import { defaultBlockaidScanAssetResult } from "@shared/helpers/stellar";
 import * as UseAssetDomain from "popup/helpers/useAssetDomain";
 import { INDEXER_URL } from "@shared/constants/mercury";
 import { SERVICE_TYPES } from "@shared/constants/services";
-import { Response } from "@shared/api/types";
 import * as TokenListHelpers from "@shared/api/helpers/token-list";
+import { Response, SettingsState } from "@shared/api/types";
 
 import {
   Wrapper,
@@ -26,9 +29,12 @@ import {
   mockTestnetBalances,
   mockPrices,
   TEST_CANONICAL,
+  TEST_PUBLIC_KEY,
 } from "../../__testHelpers__";
 import { Account } from "../Account";
 import { ROUTES } from "popup/constants/routes";
+import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/asset-list";
+// import * as Metrics from "helpers/metrics";
 
 const mockHistoryOperations = {
   operations: [
@@ -44,7 +50,7 @@ const mockHistoryOperations = {
   ] as Horizon.ServerApi.PaymentOperationRecord[],
 };
 
-jest.spyOn(global, "fetch").mockImplementation((url) => {
+jest.spyOn(global, "fetch").mockImplementation((url: string) => {
   if (
     url ===
     `${INDEXER_URL}/scan-asset-bulk?asset_ids=USDC-GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM`
@@ -147,18 +153,6 @@ jest.mock("stellar-sdk", () => {
     TransactionBuilder: original.TransactionBuilder,
   };
 });
-
-// @ts-ignore
-jest.spyOn(ApiInternal, "loadAccount").mockImplementation(() =>
-  Promise.resolve({
-    publicKey: "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF",
-    tokenIdList: ["C1"],
-    hasPrivateKey: false,
-    applicationState: ApplicationState.MNEMONIC_PHRASE_CONFIRMED,
-    allAccounts: mockAccounts,
-    bipPath: "foo",
-  }),
-);
 
 jest
   .spyOn(ApiInternal, "getTokenIds")
@@ -506,6 +500,42 @@ describe("Account view", () => {
     jest
       .spyOn(ApiInternal, "getAccountBalances")
       .mockImplementation(() => Promise.resolve(mockLpBalance));
+
+    jest.spyOn(ApiInternal, "loadAccount").mockImplementation(() =>
+      Promise.resolve({
+        hasPrivateKey: true,
+        publicKey: TEST_PUBLIC_KEY,
+        applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
+        allAccounts: mockAccounts,
+        bipPath: "bip-path",
+        tokenIdList: [],
+      }),
+    );
+
+    jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+      Promise.resolve({
+        networkDetails: TESTNET_NETWORK_DETAILS,
+        networksList: DEFAULT_NETWORKS,
+        hiddenAssets: {},
+        allowList: ApiInternal.DEFAULT_ALLOW_LIST,
+        error: "",
+        isDataSharingAllowed: false,
+        isMemoValidationEnabled: false,
+        isHideDustEnabled: true,
+        settingsState: SettingsState.SUCCESS,
+        isSorobanPublicEnabled: false,
+        isRpcHealthy: true,
+        userNotification: {
+          enabled: false,
+          message: "",
+        },
+        isExperimentalModeEnabled: false,
+        isHashSigningEnabled: false,
+        isNonSSLEnabled: false,
+        experimentalFeaturesState: SettingsState.SUCCESS,
+        assetsLists: DEFAULT_ASSETS_LISTS,
+      }),
+    );
 
     render(
       <Wrapper

--- a/extension/src/popup/views/__tests__/AccountCreator.test.tsx
+++ b/extension/src/popup/views/__tests__/AccountCreator.test.tsx
@@ -6,11 +6,53 @@ import {
   TESTNET_NETWORK_DETAILS,
   DEFAULT_NETWORKS,
 } from "@shared/constants/stellar";
-import { APPLICATION_STATE as ApplicationState } from "@shared/constants/applicationState";
-import { Wrapper, mockAccounts } from "../../__testHelpers__";
+import {
+  APPLICATION_STATE,
+  APPLICATION_STATE as ApplicationState,
+} from "@shared/constants/applicationState";
+import { TEST_PUBLIC_KEY, Wrapper, mockAccounts } from "../../__testHelpers__";
 import { AccountCreator } from "../AccountCreator";
 import * as internalApi from "@shared/api/internal";
 import { ROUTES } from "popup/constants/routes";
+import * as ApiInternal from "@shared/api/internal";
+import { SettingsState } from "@shared/api/types";
+import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/asset-list";
+
+jest.spyOn(ApiInternal, "loadAccount").mockImplementation(() =>
+  Promise.resolve({
+    hasPrivateKey: true,
+    publicKey: TEST_PUBLIC_KEY,
+    applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
+    allAccounts: mockAccounts,
+    bipPath: "bip-path",
+    tokenIdList: [],
+  }),
+);
+
+jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+  Promise.resolve({
+    networkDetails: TESTNET_NETWORK_DETAILS,
+    networksList: DEFAULT_NETWORKS,
+    hiddenAssets: {},
+    allowList: ApiInternal.DEFAULT_ALLOW_LIST,
+    error: "",
+    isDataSharingAllowed: false,
+    isMemoValidationEnabled: false,
+    isHideDustEnabled: true,
+    settingsState: SettingsState.SUCCESS,
+    isSorobanPublicEnabled: false,
+    isRpcHealthy: true,
+    userNotification: {
+      enabled: false,
+      message: "",
+    },
+    isExperimentalModeEnabled: false,
+    isHashSigningEnabled: false,
+    isNonSSLEnabled: false,
+    experimentalFeaturesState: SettingsState.SUCCESS,
+    assetsLists: DEFAULT_ASSETS_LISTS,
+  }),
+);
 
 describe("Account Creator View", () => {
   afterAll(() => {

--- a/extension/src/popup/views/__tests__/AccountHistory.test.tsx
+++ b/extension/src/popup/views/__tests__/AccountHistory.test.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { render, waitFor, screen } from "@testing-library/react";
-import { APPLICATION_STATE as ApplicationState } from "@shared/constants/applicationState";
+import {
+  APPLICATION_STATE,
+  APPLICATION_STATE as ApplicationState,
+} from "@shared/constants/applicationState";
 import {
   TESTNET_NETWORK_DETAILS,
   DEFAULT_NETWORKS,
@@ -16,6 +19,44 @@ import {
 } from "../../__testHelpers__";
 import { AccountHistory } from "../AccountHistory";
 import { ROUTES } from "popup/constants/routes";
+import { SettingsState } from "@shared/api/types";
+import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/asset-list";
+
+jest.spyOn(ApiInternal, "loadAccount").mockImplementation(() =>
+  Promise.resolve({
+    hasPrivateKey: true,
+    publicKey: "G1",
+    applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
+    allAccounts: mockAccounts,
+    bipPath: "bip-path",
+    tokenIdList: [],
+  }),
+);
+
+jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+  Promise.resolve({
+    networkDetails: TESTNET_NETWORK_DETAILS,
+    networksList: DEFAULT_NETWORKS,
+    hiddenAssets: {},
+    allowList: ApiInternal.DEFAULT_ALLOW_LIST,
+    error: "",
+    isDataSharingAllowed: false,
+    isMemoValidationEnabled: false,
+    isHideDustEnabled: true,
+    settingsState: SettingsState.SUCCESS,
+    isSorobanPublicEnabled: false,
+    isRpcHealthy: true,
+    userNotification: {
+      enabled: false,
+      message: "",
+    },
+    isExperimentalModeEnabled: false,
+    isHashSigningEnabled: false,
+    isNonSSLEnabled: false,
+    experimentalFeaturesState: SettingsState.SUCCESS,
+    assetsLists: DEFAULT_ASSETS_LISTS,
+  }),
+);
 
 jest
   .spyOn(ApiInternal, "getAccountHistory")

--- a/extension/src/popup/views/__tests__/AddFunds.test.tsx
+++ b/extension/src/popup/views/__tests__/AddFunds.test.tsx
@@ -6,11 +6,17 @@ import * as ApiInternal from "@shared/api/internal";
 import {
   DEFAULT_NETWORKS,
   MAINNET_NETWORK_DETAILS,
+  TESTNET_NETWORK_DETAILS,
 } from "@shared/constants/stellar";
-import { APPLICATION_STATE as ApplicationState } from "@shared/constants/applicationState";
+import {
+  APPLICATION_STATE,
+  APPLICATION_STATE as ApplicationState,
+} from "@shared/constants/applicationState";
 import { ROUTES } from "popup/constants/routes";
 import { Wrapper, mockAccounts } from "../../__testHelpers__";
 import { AddFunds } from "../AddFunds";
+import { SettingsState } from "@shared/api/types";
+import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/asset-list";
 
 const token = "foo";
 
@@ -20,15 +26,39 @@ jest.mock("webextension-polyfill", () => ({
   },
 }));
 
-// @ts-ignore
 jest.spyOn(ApiInternal, "loadAccount").mockImplementation(() =>
   Promise.resolve({
-    publicKey: "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF",
-    tokenIdList: ["C1"],
-    hasPrivateKey: false,
-    applicationState: ApplicationState.MNEMONIC_PHRASE_CONFIRMED,
+    hasPrivateKey: true,
+    publicKey: "G1",
+    applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
     allAccounts: mockAccounts,
-    bipPath: "foo",
+    bipPath: "bip-path",
+    tokenIdList: [],
+  }),
+);
+
+jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+  Promise.resolve({
+    networkDetails: TESTNET_NETWORK_DETAILS,
+    networksList: DEFAULT_NETWORKS,
+    hiddenAssets: {},
+    allowList: ApiInternal.DEFAULT_ALLOW_LIST,
+    error: "",
+    isDataSharingAllowed: false,
+    isMemoValidationEnabled: false,
+    isHideDustEnabled: true,
+    settingsState: SettingsState.SUCCESS,
+    isSorobanPublicEnabled: false,
+    isRpcHealthy: true,
+    userNotification: {
+      enabled: false,
+      message: "",
+    },
+    isExperimentalModeEnabled: false,
+    isHashSigningEnabled: false,
+    isNonSSLEnabled: false,
+    experimentalFeaturesState: SettingsState.SUCCESS,
+    assetsLists: DEFAULT_ASSETS_LISTS,
   }),
 );
 

--- a/extension/src/popup/views/__tests__/GrantAccess.test.tsx
+++ b/extension/src/popup/views/__tests__/GrantAccess.test.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { render, waitFor, screen } from "@testing-library/react";
 
-import { APPLICATION_STATE as ApplicationState } from "@shared/constants/applicationState";
+import {
+  APPLICATION_STATE,
+  APPLICATION_STATE as ApplicationState,
+} from "@shared/constants/applicationState";
 import { Wrapper, mockAccounts } from "../../__testHelpers__";
 import {
   TESTNET_NETWORK_DETAILS,
@@ -10,9 +13,11 @@ import {
 } from "@shared/constants/stellar";
 import { GrantAccess } from "../GrantAccess";
 import * as blockAidHelpers from "popup/helpers/blockaid";
-import { BlockAidScanSiteResult } from "@shared/api/types";
+import { BlockAidScanSiteResult, SettingsState } from "@shared/api/types";
 import * as urlHelpers from "../../../helpers/urls";
 import { ROUTES } from "popup/constants/routes";
+import * as ApiInternal from "@shared/api/internal";
+import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/asset-list";
 
 jest.spyOn(urlHelpers, "parsedSearchParam").mockImplementation(() => {
   const original = jest.requireActual("../../../helpers/urls");
@@ -21,6 +26,42 @@ jest.spyOn(urlHelpers, "parsedSearchParam").mockImplementation(() => {
     url: "example.com",
   };
 });
+
+jest.spyOn(ApiInternal, "loadAccount").mockImplementation(() =>
+  Promise.resolve({
+    hasPrivateKey: true,
+    publicKey: "G1",
+    applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
+    allAccounts: mockAccounts,
+    bipPath: "bip-path",
+    tokenIdList: [],
+  }),
+);
+
+jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+  Promise.resolve({
+    networkDetails: TESTNET_NETWORK_DETAILS,
+    networksList: DEFAULT_NETWORKS,
+    hiddenAssets: {},
+    allowList: ApiInternal.DEFAULT_ALLOW_LIST,
+    error: "",
+    isDataSharingAllowed: false,
+    isMemoValidationEnabled: false,
+    isHideDustEnabled: true,
+    settingsState: SettingsState.SUCCESS,
+    isSorobanPublicEnabled: false,
+    isRpcHealthy: true,
+    userNotification: {
+      enabled: false,
+      message: "",
+    },
+    isExperimentalModeEnabled: false,
+    isHashSigningEnabled: false,
+    isNonSSLEnabled: false,
+    experimentalFeaturesState: SettingsState.SUCCESS,
+    assetsLists: DEFAULT_ASSETS_LISTS,
+  }),
+);
 
 describe("Grant Access view", () => {
   afterAll(() => {

--- a/extension/src/popup/views/__tests__/GrantAccess.test.tsx
+++ b/extension/src/popup/views/__tests__/GrantAccess.test.tsx
@@ -77,7 +77,7 @@ describe("Grant Access view", () => {
           is_malicious: false,
         } as BlockAidScanSiteResult,
         scanSite: (_url: string, _networkDetails: NetworkDetails) => {
-          return Promise.resolve();
+          return Promise.resolve(null);
         },
       };
     });
@@ -116,7 +116,7 @@ describe("Grant Access view", () => {
           is_malicious: false,
         } as BlockAidScanSiteResult,
         scanSite: (_url: string, _networkDetails: NetworkDetails) => {
-          return Promise.resolve();
+          return Promise.resolve(null);
         },
       };
     });
@@ -156,7 +156,7 @@ describe("Grant Access view", () => {
           status: "miss",
         } as BlockAidScanSiteResult,
         scanSite: (_url: string, _networkDetails: NetworkDetails) => {
-          return Promise.resolve();
+          return Promise.resolve(null);
         },
       };
     });
@@ -196,7 +196,7 @@ describe("Grant Access view", () => {
           is_malicious: true,
         } as BlockAidScanSiteResult,
         scanSite: (_url: string, _networkDetails: NetworkDetails) => {
-          return Promise.resolve();
+          return Promise.resolve(null);
         },
       };
     });

--- a/extension/src/popup/views/__tests__/GrantAccess.test.tsx
+++ b/extension/src/popup/views/__tests__/GrantAccess.test.tsx
@@ -30,7 +30,7 @@ jest.spyOn(urlHelpers, "parsedSearchParam").mockImplementation(() => {
 jest.spyOn(ApiInternal, "loadAccount").mockImplementation(() =>
   Promise.resolve({
     hasPrivateKey: true,
-    publicKey: "G1",
+    publicKey: "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF",
     applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
     allAccounts: mockAccounts,
     bipPath: "bip-path",
@@ -77,7 +77,9 @@ describe("Grant Access view", () => {
           is_malicious: false,
         } as BlockAidScanSiteResult,
         scanSite: (_url: string, _networkDetails: NetworkDetails) => {
-          return Promise.resolve(null);
+          return Promise.resolve({
+            is_malicious: false,
+          } as BlockAidScanSiteResult);
         },
       };
     });
@@ -116,7 +118,9 @@ describe("Grant Access view", () => {
           is_malicious: false,
         } as BlockAidScanSiteResult,
         scanSite: (_url: string, _networkDetails: NetworkDetails) => {
-          return Promise.resolve(null);
+          return Promise.resolve({
+            is_malicious: false,
+          } as BlockAidScanSiteResult);
         },
       };
     });
@@ -156,7 +160,9 @@ describe("Grant Access view", () => {
           status: "miss",
         } as BlockAidScanSiteResult,
         scanSite: (_url: string, _networkDetails: NetworkDetails) => {
-          return Promise.resolve(null);
+          return Promise.resolve({
+            status: "miss",
+          } as BlockAidScanSiteResult);
         },
       };
     });
@@ -196,7 +202,10 @@ describe("Grant Access view", () => {
           is_malicious: true,
         } as BlockAidScanSiteResult,
         scanSite: (_url: string, _networkDetails: NetworkDetails) => {
-          return Promise.resolve(null);
+          return Promise.resolve({
+            status: "hit",
+            is_malicious: true,
+          } as BlockAidScanSiteResult);
         },
       };
     });
@@ -207,7 +216,7 @@ describe("Grant Access view", () => {
         state={{
           auth: {
             error: null,
-            applicationState: ApplicationState.PASSWORD_CREATED,
+            applicationState: ApplicationState.MNEMONIC_PHRASE_CONFIRMED,
             publicKey:
               "GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF",
             allAccounts: mockAccounts,

--- a/extension/src/popup/views/__tests__/ManageAssets.test.tsx
+++ b/extension/src/popup/views/__tests__/ManageAssets.test.tsx
@@ -19,7 +19,10 @@ import { Balances } from "@shared/api/types/backend-api";
 import * as SorobanHelpers from "@shared/api/helpers/soroban";
 import { defaultBlockaidScanAssetResult } from "@shared/helpers/stellar";
 
-import { APPLICATION_STATE as ApplicationState } from "@shared/constants/applicationState";
+import {
+  APPLICATION_STATE,
+  APPLICATION_STATE as ApplicationState,
+} from "@shared/constants/applicationState";
 import { ROUTES } from "popup/constants/routes";
 import * as AssetDomain from "popup/helpers/getAssetDomain";
 import * as CheckSuspiciousAsset from "popup/helpers/checkForSuspiciousAsset";
@@ -34,6 +37,8 @@ import {
 
 import { Wrapper, mockAccounts } from "../../__testHelpers__";
 import { ManageAssets } from "../ManageAssets";
+import { SettingsState } from "@shared/api/types";
+import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/asset-list";
 
 const mockXDR =
   "AAAAAgAAAADaBSz5rQFDZHNdV8//w/Yiy11vE1ZxGJ8QD8j7HUtNEwAAAGQAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAADaBSz5rQFDZHNdV8//w/Yiy11vE1ZxGJ8QD8j7HUtNEwAAAAAAAAAAAvrwgAAAAAAAAAABHUtNEwAAAEBY/jSiXJNsA2NpiXrOi6Ll6RiIY7v8QZEEZviM8HmmzeI4FBP9wGZm7YMorQue+DK9KI5BEXDt3hi0VOA9gD8A";
@@ -309,6 +314,42 @@ jest.spyOn(BlockaidHelpers, "scanAsset").mockImplementation((address) => {
     ],
   });
 });
+
+jest.spyOn(ApiInternal, "loadAccount").mockImplementation(() =>
+  Promise.resolve({
+    hasPrivateKey: true,
+    publicKey: "G1",
+    applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
+    allAccounts: mockAccounts,
+    bipPath: "bip-path",
+    tokenIdList: [],
+  }),
+);
+
+jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+  Promise.resolve({
+    networkDetails: TESTNET_NETWORK_DETAILS,
+    networksList: DEFAULT_NETWORKS,
+    hiddenAssets: {},
+    allowList: ApiInternal.DEFAULT_ALLOW_LIST,
+    error: "",
+    isDataSharingAllowed: false,
+    isMemoValidationEnabled: false,
+    isHideDustEnabled: true,
+    settingsState: SettingsState.SUCCESS,
+    isSorobanPublicEnabled: false,
+    isRpcHealthy: true,
+    userNotification: {
+      enabled: false,
+      message: "",
+    },
+    isExperimentalModeEnabled: false,
+    isHashSigningEnabled: false,
+    isNonSSLEnabled: false,
+    experimentalFeaturesState: SettingsState.SUCCESS,
+    assetsLists: DEFAULT_ASSETS_LISTS,
+  }),
+);
 
 const mockNavigateTo = jest.fn();
 jest.mock("popup/helpers/navigate", () => {

--- a/extension/src/popup/views/__tests__/MnemonicPhrase.test.tsx
+++ b/extension/src/popup/views/__tests__/MnemonicPhrase.test.tsx
@@ -38,42 +38,6 @@ jest.mock("@shared/api/internal", () => {
   };
 });
 
-jest.spyOn(ApiInternal, "loadAccount").mockImplementation(() =>
-  Promise.resolve({
-    hasPrivateKey: true,
-    publicKey: "G1",
-    applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
-    allAccounts: mockAccounts,
-    bipPath: "bip-path",
-    tokenIdList: [],
-  }),
-);
-
-jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
-  Promise.resolve({
-    networkDetails: TESTNET_NETWORK_DETAILS,
-    networksList: DEFAULT_NETWORKS,
-    hiddenAssets: {},
-    allowList: ApiInternal.DEFAULT_ALLOW_LIST,
-    error: "",
-    isDataSharingAllowed: false,
-    isMemoValidationEnabled: false,
-    isHideDustEnabled: true,
-    settingsState: SettingsState.SUCCESS,
-    isSorobanPublicEnabled: false,
-    isRpcHealthy: true,
-    userNotification: {
-      enabled: false,
-      message: "",
-    },
-    isExperimentalModeEnabled: false,
-    isHashSigningEnabled: false,
-    isNonSSLEnabled: false,
-    experimentalFeaturesState: SettingsState.SUCCESS,
-    assetsLists: DEFAULT_ASSETS_LISTS,
-  }),
-);
-
 describe.skip("MnemonicPhrase", () => {
   afterAll(() => {
     jest.clearAllMocks();

--- a/extension/src/popup/views/__tests__/MnemonicPhrase.test.tsx
+++ b/extension/src/popup/views/__tests__/MnemonicPhrase.test.tsx
@@ -38,6 +38,42 @@ jest.mock("@shared/api/internal", () => {
   };
 });
 
+jest.spyOn(ApiInternal, "loadAccount").mockImplementation(() =>
+  Promise.resolve({
+    hasPrivateKey: true,
+    publicKey: "G1",
+    applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
+    allAccounts: mockAccounts,
+    bipPath: "bip-path",
+    tokenIdList: [],
+  }),
+);
+
+jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+  Promise.resolve({
+    networkDetails: TESTNET_NETWORK_DETAILS,
+    networksList: DEFAULT_NETWORKS,
+    hiddenAssets: {},
+    allowList: ApiInternal.DEFAULT_ALLOW_LIST,
+    error: "",
+    isDataSharingAllowed: false,
+    isMemoValidationEnabled: false,
+    isHideDustEnabled: true,
+    settingsState: SettingsState.SUCCESS,
+    isSorobanPublicEnabled: false,
+    isRpcHealthy: true,
+    userNotification: {
+      enabled: false,
+      message: "",
+    },
+    isExperimentalModeEnabled: false,
+    isHashSigningEnabled: false,
+    isNonSSLEnabled: false,
+    experimentalFeaturesState: SettingsState.SUCCESS,
+    assetsLists: DEFAULT_ASSETS_LISTS,
+  }),
+);
+
 describe.skip("MnemonicPhrase", () => {
   afterAll(() => {
     jest.clearAllMocks();

--- a/extension/src/popup/views/__tests__/ReviewAuth.test.tsx
+++ b/extension/src/popup/views/__tests__/ReviewAuth.test.tsx
@@ -6,6 +6,13 @@ import * as ApiInternal from "@shared/api/internal";
 
 import { Wrapper, mockAccounts } from "../../__testHelpers__";
 import { ROUTES } from "popup/constants/routes";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
+import {
+  DEFAULT_NETWORKS,
+  TESTNET_NETWORK_DETAILS,
+} from "@shared/constants/stellar";
+import { SettingsState } from "@shared/api/types";
+import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/asset-list";
 
 const defaultSettingsState = {
   networkDetails: {
@@ -17,6 +24,42 @@ const defaultSettingsState = {
     networkPassphrase: "foo",
   },
 };
+
+jest.spyOn(ApiInternal, "loadAccount").mockImplementation(() =>
+  Promise.resolve({
+    hasPrivateKey: true,
+    publicKey: "G1",
+    applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
+    allAccounts: mockAccounts,
+    bipPath: "bip-path",
+    tokenIdList: [],
+  }),
+);
+
+jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+  Promise.resolve({
+    networkDetails: TESTNET_NETWORK_DETAILS,
+    networksList: DEFAULT_NETWORKS,
+    hiddenAssets: {},
+    allowList: ApiInternal.DEFAULT_ALLOW_LIST,
+    error: "",
+    isDataSharingAllowed: false,
+    isMemoValidationEnabled: false,
+    isHideDustEnabled: true,
+    settingsState: SettingsState.SUCCESS,
+    isSorobanPublicEnabled: false,
+    isRpcHealthy: true,
+    userNotification: {
+      enabled: false,
+      message: "",
+    },
+    isExperimentalModeEnabled: false,
+    isHashSigningEnabled: false,
+    isNonSSLEnabled: false,
+    experimentalFeaturesState: SettingsState.SUCCESS,
+    assetsLists: DEFAULT_ASSETS_LISTS,
+  }),
+);
 
 it("renders mint token invocation", async () => {
   jest.spyOn(helpersUrls, "decodeString").mockImplementation(() =>

--- a/extension/src/popup/views/__tests__/SignTransaction.test.tsx
+++ b/extension/src/popup/views/__tests__/SignTransaction.test.tsx
@@ -20,6 +20,10 @@ import { SignTransaction } from "../SignTransaction";
 import { Wrapper, mockBalances, mockAccounts } from "../../__testHelpers__";
 import { ROUTES } from "popup/constants/routes";
 import { Balances } from "@shared/api/types/backend-api";
+import { DEFAULT_NETWORKS } from "@shared/constants/stellar";
+import { SettingsState } from "@shared/api/types";
+import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/asset-list";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
 jest.mock("helpers/stellarIdenticon");
 jest.setTimeout(20000);
@@ -171,6 +175,34 @@ describe("SignTransactions", () => {
   });
 
   it("shows non-https domain error on Mainnet", async () => {
+    jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+      Promise.resolve({
+        networkDetails: {
+          ...defaultSettingsState.networkDetails,
+          networkPassphrase: "Public Global Stellar Network ; September 2015",
+        },
+        networksList: DEFAULT_NETWORKS,
+        hiddenAssets: {},
+        allowList: ApiInternal.DEFAULT_ALLOW_LIST,
+        error: "",
+        isDataSharingAllowed: false,
+        isMemoValidationEnabled: false,
+        isHideDustEnabled: true,
+        settingsState: SettingsState.SUCCESS,
+        isSorobanPublicEnabled: false,
+        isRpcHealthy: true,
+        userNotification: {
+          enabled: false,
+          message: "",
+        },
+        isExperimentalModeEnabled: false,
+        isHashSigningEnabled: false,
+        isNonSSLEnabled: false,
+        experimentalFeaturesState: SettingsState.SUCCESS,
+        assetsLists: DEFAULT_ASSETS_LISTS,
+      }),
+    );
+
     const transaction = TransactionBuilder.fromXDR(
       transactions.classic,
       Networks.PUBLIC,
@@ -215,6 +247,38 @@ describe("SignTransactions", () => {
   });
 
   it("does not show non-https domain error on Testnet", async () => {
+    jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+      Promise.resolve({
+        networkDetails: {
+          ...defaultSettingsState.networkDetails,
+          networkPassphrase: "Test SDF Network ; September 2015",
+          networkName: "Test Net",
+        },
+        networksList: DEFAULT_NETWORKS,
+        hiddenAssets: {},
+        allowList: {
+          "Test Net": {
+            [mockAccounts[0].publicKey]: ["laboratory.stellar.org"],
+          },
+        },
+        error: "",
+        isDataSharingAllowed: false,
+        isMemoValidationEnabled: false,
+        isHideDustEnabled: true,
+        settingsState: SettingsState.SUCCESS,
+        isSorobanPublicEnabled: false,
+        isRpcHealthy: true,
+        userNotification: {
+          enabled: false,
+          message: "",
+        },
+        isExperimentalModeEnabled: false,
+        isHashSigningEnabled: false,
+        isNonSSLEnabled: false,
+        experimentalFeaturesState: SettingsState.SUCCESS,
+        assetsLists: DEFAULT_ASSETS_LISTS,
+      }),
+    );
     const transaction = TransactionBuilder.fromXDR(
       transactions.classic,
       Networks.TESTNET,
@@ -262,6 +326,33 @@ describe("SignTransactions", () => {
   });
 
   it("displays token payment parameters for Soroban token payment operations", async () => {
+    jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+      Promise.resolve({
+        networkDetails: {
+          ...defaultSettingsState.networkDetails,
+          networkPassphrase: "Test SDF Future Network ; October 2022",
+        },
+        networksList: DEFAULT_NETWORKS,
+        hiddenAssets: {},
+        allowList: ApiInternal.DEFAULT_ALLOW_LIST,
+        error: "",
+        isDataSharingAllowed: false,
+        isMemoValidationEnabled: false,
+        isHideDustEnabled: true,
+        settingsState: SettingsState.SUCCESS,
+        isSorobanPublicEnabled: false,
+        isRpcHealthy: true,
+        userNotification: {
+          enabled: false,
+          message: "",
+        },
+        isExperimentalModeEnabled: false,
+        isHashSigningEnabled: false,
+        isNonSSLEnabled: false,
+        experimentalFeaturesState: SettingsState.SUCCESS,
+        assetsLists: DEFAULT_ASSETS_LISTS,
+      }),
+    );
     const transaction = TransactionBuilder.fromXDR(
       transactions.sorobanTransfer,
       Networks.FUTURENET,
@@ -561,6 +652,47 @@ describe("SignTransactions", () => {
   });
 
   it("shows unfunded warning when signer has no XLM", async () => {
+    jest.spyOn(ApiInternal, "loadAccount").mockImplementation(() =>
+      Promise.resolve({
+        hasPrivateKey: true,
+        publicKey: mockAccounts[0].publicKey,
+        applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
+        allAccounts: mockAccounts,
+        bipPath: "bip-path",
+        tokenIdList: [],
+      }),
+    );
+    jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+      Promise.resolve({
+        networkDetails: {
+          ...defaultSettingsState.networkDetails,
+          networkPassphrase: "Test SDF Future Network ; October 2022",
+        },
+        networksList: DEFAULT_NETWORKS,
+        hiddenAssets: {},
+        allowList: {
+          "Future Net": {
+            [mockAccounts[0].publicKey]: ["laboratory.stellar.org"],
+          },
+        },
+        error: "",
+        isDataSharingAllowed: false,
+        isMemoValidationEnabled: false,
+        isHideDustEnabled: true,
+        settingsState: SettingsState.SUCCESS,
+        isSorobanPublicEnabled: false,
+        isRpcHealthy: true,
+        userNotification: {
+          enabled: false,
+          message: "",
+        },
+        isExperimentalModeEnabled: true,
+        isHashSigningEnabled: false,
+        isNonSSLEnabled: false,
+        experimentalFeaturesState: SettingsState.SUCCESS,
+        assetsLists: DEFAULT_ASSETS_LISTS,
+      }),
+    );
     const mockBalancesEmpty = {
       ...mockBalances,
       balances: {

--- a/extension/src/popup/views/__tests__/SignTransaction.test.tsx
+++ b/extension/src/popup/views/__tests__/SignTransaction.test.tsx
@@ -20,10 +20,10 @@ import { SignTransaction } from "../SignTransaction";
 import { Wrapper, mockBalances, mockAccounts } from "../../__testHelpers__";
 import { ROUTES } from "popup/constants/routes";
 import { Balances } from "@shared/api/types/backend-api";
+import { APPLICATION_STATE } from "@shared/constants/applicationState";
 import { DEFAULT_NETWORKS } from "@shared/constants/stellar";
 import { SettingsState } from "@shared/api/types";
 import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/asset-list";
-import { APPLICATION_STATE } from "@shared/constants/applicationState";
 
 jest.mock("helpers/stellarIdenticon");
 jest.setTimeout(20000);

--- a/extension/src/popup/views/__tests__/Swap.test.tsx
+++ b/extension/src/popup/views/__tests__/Swap.test.tsx
@@ -17,13 +17,18 @@ import {
 } from "@shared/constants/stellar";
 import BigNumber from "bignumber.js";
 
-import { APPLICATION_STATE as ApplicationState } from "@shared/constants/applicationState";
+import {
+  APPLICATION_STATE,
+  APPLICATION_STATE as ApplicationState,
+} from "@shared/constants/applicationState";
 import { ROUTES } from "popup/constants/routes";
 import { Swap } from "popup/views/Swap";
 
 import { Wrapper, mockAccounts } from "../../__testHelpers__";
 import * as GetAssetDomain from "popup/helpers/getAssetDomain";
 import * as GetIconHelper from "@shared/api/helpers/getIconUrlFromIssuer";
+import { SettingsState } from "@shared/api/types";
+import { DEFAULT_ASSETS_LISTS } from "@shared/constants/soroban/asset-list";
 
 export const swapMockBalances = {
   balances: {
@@ -137,6 +142,42 @@ jest.spyOn(BlockaidHelpers, "useScanTx").mockImplementation(() => {
     error: null,
   };
 });
+
+jest.spyOn(ApiInternal, "loadAccount").mockImplementation(() =>
+  Promise.resolve({
+    hasPrivateKey: true,
+    publicKey: "G1",
+    applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
+    allAccounts: mockAccounts,
+    bipPath: "bip-path",
+    tokenIdList: [],
+  }),
+);
+
+jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+  Promise.resolve({
+    networkDetails: TESTNET_NETWORK_DETAILS,
+    networksList: DEFAULT_NETWORKS,
+    hiddenAssets: {},
+    allowList: ApiInternal.DEFAULT_ALLOW_LIST,
+    error: "",
+    isDataSharingAllowed: false,
+    isMemoValidationEnabled: false,
+    isHideDustEnabled: true,
+    settingsState: SettingsState.SUCCESS,
+    isSorobanPublicEnabled: false,
+    isRpcHealthy: true,
+    userNotification: {
+      enabled: false,
+      message: "",
+    },
+    isExperimentalModeEnabled: false,
+    isHashSigningEnabled: false,
+    isNonSSLEnabled: false,
+    experimentalFeaturesState: SettingsState.SUCCESS,
+    assetsLists: DEFAULT_ASSETS_LISTS,
+  }),
+);
 
 jest.mock("popup/helpers/horizonGetBestPath", () => ({
   get horizonGetBestPath() {


### PR DESCRIPTION
What
Implements verify-account as a drawer

Why
In the send and swap flows, we need a way to verify accounts that is no route based. When a user' session has expired we need to have them enter their password at the confirm step before they can use the key to sign that transaction.




https://github.com/user-attachments/assets/f846a564-e243-4748-8b7c-8bbe7c73d539

