### PR TITLE
Feature/discover fe

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -604,6 +604,39 @@ export const getTokenPrices = async (tokens: string[]) => {
   return parsedResponse.data;
 };
 
+export const getDiscoverData = async () => {
+  const url = new URL(`${INDEXER_URL}/discover`);
+  const response = await fetch(url.href);
+  const parsedResponse = (await response.json()) as {
+    data: {
+      protocols: {
+        description: string;
+        icon_url: string;
+        name: string;
+        website_url: string;
+        tags: string[];
+        is_blacklisted: boolean;
+      }[];
+    };
+  };
+  if (!response.ok || !parsedResponse.data.protocols) {
+    const _err = JSON.stringify(parsedResponse);
+    captureException(
+      `Failed to fetch discover entries - ${response.status}: ${response.statusText}`,
+    );
+    throw new Error(_err);
+  }
+
+  return parsedResponse.data.protocols.map((entry) => ({
+    description: entry.description,
+    iconUrl: entry.icon_url,
+    name: entry.name,
+    websiteUrl: entry.website_url,
+    tags: entry.tags,
+    isBlacklisted: entry.is_blacklisted,
+  }));
+};
+
 export const getSorobanTokenBalance = async (
   server: SorobanRpc.Server,
   contractId: string,
@@ -1881,7 +1914,8 @@ export const simulateTransaction = async (args: {
     body: JSON.stringify({
       xdr,
 
-      network_url: networkDetails.sorobanRpcUrl,
+      network_url:
+        "https://rough-fragrant-bird.stellar-mainnet.quiknode.pro/980bd2f552c04a7a30ad4503caae3c354213623e",
 
       network_passphrase: networkDetails.networkPassphrase,
     }),

--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -1914,8 +1914,7 @@ export const simulateTransaction = async (args: {
     body: JSON.stringify({
       xdr,
 
-      network_url:
-        "https://rough-fragrant-bird.stellar-mainnet.quiknode.pro/980bd2f552c04a7a30ad4503caae3c354213623e",
+      network_url: networkDetails.sorobanRpcUrl,
 
       network_passphrase: networkDetails.networkPassphrase,
     }),

--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -605,7 +605,7 @@ export const getTokenPrices = async (tokens: string[]) => {
 };
 
 export const getDiscoverData = async () => {
-  const url = new URL(`${INDEXER_URL}/discover`);
+  const url = new URL(`${INDEXER_URL}/protocols`);
   const response = await fetch(url.href);
   const parsedResponse = (await response.json()) as {
     data: {

--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -609,17 +609,15 @@ export const getDiscoverData = async () => {
   const response = await fetch(url.href);
   const parsedResponse = (await response.json()) as {
     data: {
-      protocols: {
-        description: string;
-        icon_url: string;
-        name: string;
-        website_url: string;
-        tags: string[];
-        is_blacklisted: boolean;
-      }[];
-    };
+      description: string;
+      icon_url: string;
+      name: string;
+      website_url: string;
+      tags: string[];
+      is_blacklisted: boolean;
+    }[];
   };
-  if (!response.ok || !parsedResponse.data.protocols) {
+  if (!response.ok || !parsedResponse.data) {
     const _err = JSON.stringify(parsedResponse);
     captureException(
       `Failed to fetch discover entries - ${response.status}: ${response.statusText}`,
@@ -627,7 +625,7 @@ export const getDiscoverData = async () => {
     throw new Error(_err);
   }
 
-  return parsedResponse.data.protocols.map((entry) => ({
+  return parsedResponse.data.map((entry) => ({
     description: entry.description,
     iconUrl: entry.icon_url,
     name: entry.name,

--- a/@shared/api/types/types.ts
+++ b/@shared/api/types/types.ts
@@ -351,3 +351,12 @@ export interface ApiTokenPrices {
     percentagePriceChange24h?: string;
   } | null;
 }
+
+export type DiscoverData = {
+  description: string;
+  iconUrl: string;
+  name: string;
+  websiteUrl: string;
+  tags: string[];
+  isBlacklisted: boolean;
+}[];

--- a/extension/src/popup/Router.tsx
+++ b/extension/src/popup/Router.tsx
@@ -58,6 +58,7 @@ import { ManageNetwork } from "popup/views/ManageNetwork";
 import { LeaveFeedback } from "popup/views/LeaveFeedback";
 import { AccountMigration } from "popup/views/AccountMigration";
 import { AddFunds } from "popup/views/AddFunds";
+import { Discover } from "popup/views/Discover";
 
 import "popup/metrics/views";
 import { DEV_SERVER } from "@shared/constants/services";
@@ -276,6 +277,7 @@ export const Router = () => (
           element={<AdvancedSettings />}
         ></Route>
         <Route path={ROUTES.addFunds} element={<AddFunds />} />
+        <Route path={ROUTES.discover} element={<Discover />} />
 
         {DEV_SERVER && (
           <>

--- a/extension/src/popup/components/account/AccountHeader/index.tsx
+++ b/extension/src/popup/components/account/AccountHeader/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 import { Account } from "@shared/api/types";
 import { Icon } from "@stellar/design-system";
@@ -10,6 +10,7 @@ import { ROUTES } from "popup/constants/routes";
 import { LoadingBackground } from "popup/basics/LoadingBackground";
 import { View } from "popup/basics/layout/View";
 import { isActiveNetwork } from "helpers/stellar";
+import { navigateTo } from "popup/helpers/navigate";
 import { AccountListIdenticon } from "popup/components/identicons/AccountListIdenticon";
 import {
   settingsNetworkDetailsSelector,
@@ -43,6 +44,7 @@ export const AccountHeader = ({
   const networksList = useSelector(settingsNetworksListSelector);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isNetworkSelectorOpen, setIsNetworkSelectorOpen] = useState(false);
+  const navigate = useNavigate();
 
   const networksModalHeight = useRef(0);
   const activeNetworkIndex = useRef<number | null>(null);
@@ -76,14 +78,19 @@ export const AccountHeader = ({
         </div>
       }
       rightContent={
-        <div
-          className="AccountHeader__network-wrapper"
-          data-testid="network-selector-open"
-          onClick={() => setIsNetworkSelectorOpen(!isNetworkSelectorOpen)}
-        >
-          <NetworkIcon index={activeNetworkIndex.current} />
-          <div className="AccountHeader__network-copy">
-            {networkDetails.networkName}
+        <div className="AccountHeader__right-content">
+          <div
+            className="AccountHeader__right-button"
+            onClick={() => navigateTo(ROUTES.discover, navigate)}
+          >
+            <Icon.Compass03 />
+          </div>
+          <div
+            className="AccountHeader__right-button"
+            data-testid="network-selector-open"
+            onClick={() => setIsNetworkSelectorOpen(!isNetworkSelectorOpen)}
+          >
+            <Icon.Globe02 />
           </div>
         </div>
       }

--- a/extension/src/popup/components/account/AccountHeader/index.tsx
+++ b/extension/src/popup/components/account/AccountHeader/index.tsx
@@ -80,10 +80,10 @@ export const AccountHeader = ({
       rightContent={
         <div className="AccountHeader__right-content">
           <div
-            className="AccountHeader__right-button"
+            className="AccountHeader__right-button AccountHeader__right-button--with-label"
             onClick={() => navigateTo(ROUTES.discover, navigate)}
           >
-            <Icon.Compass03 />
+            <Icon.Compass03 /> {t("Discover")}
           </div>
           <div
             className="AccountHeader__right-button"

--- a/extension/src/popup/components/account/AccountHeader/styles.scss
+++ b/extension/src/popup/components/account/AccountHeader/styles.scss
@@ -17,15 +17,28 @@
     flex-direction: column;
   }
 
-  &__network-wrapper {
+  &__right-content {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-end;
+    gap: pxToRem(12);
+  }
+
+  &__right-button {
     cursor: pointer;
     display: flex;
     flex-flow: row nowrap;
     align-items: center;
-    justify-content: right;
+    height: pxToRem(32px);
+    justify-content: center;
     border: 1px solid var(--sds-clr-gray-06);
-    padding: pxToRem(2px) pxToRem(6px);
-    border-radius: pxToRem(6px);
+    border-radius: pxToRem(100px);
+    width: pxToRem(32px);
+
+    svg {
+      color: var(--sds-clr-gray-09);
+    }
   }
 
   &__network-copy {

--- a/extension/src/popup/components/account/AccountHeader/styles.scss
+++ b/extension/src/popup/components/account/AccountHeader/styles.scss
@@ -30,11 +30,21 @@
     display: flex;
     flex-flow: row nowrap;
     align-items: center;
-    height: pxToRem(32px);
     justify-content: center;
     border: 1px solid var(--sds-clr-gray-06);
     border-radius: pxToRem(100px);
-    width: pxToRem(32px);
+    height: pxToRem(32);
+    width: pxToRem(32);
+
+    &--with-label {
+      padding: pxToRem(6) pxToRem(10);
+      height: auto;
+      width: auto;
+      display: flex;
+      gap: pxToRem(4);
+      font-size: pxToRem(14);
+      font-weight: var(--sds-fw-semi-bold);
+    }
 
     svg {
       color: var(--sds-clr-gray-09);

--- a/extension/src/popup/constants/metricsNames.ts
+++ b/extension/src/popup/constants/metricsNames.ts
@@ -83,6 +83,7 @@ export const METRIC_NAMES = {
   viewEditNetwork: "loaded screen: edit network",
   viewNetworkSettings: "loaded screen: network settings",
   viewAddFunds: "loaded screen: add fund",
+  discover: "loaded screen: discover",
 
   manageAssetAddAsset: "manage asset: add asset",
   manageAssetAddToken: "manage asset: add token",

--- a/extension/src/popup/constants/routes.ts
+++ b/extension/src/popup/constants/routes.ts
@@ -51,4 +51,6 @@ export enum ROUTES {
   accountMigrationMnemonicPhrase = "/account-migration/mnemonic-phrase",
   accountMigrationConfirmMigration = "/account-migration/confirm-migration",
   accountMigrationMigrationComplete = "/account-migration/migration-complete",
+
+  discover = "/discover",
 }

--- a/extension/src/popup/locales/en/translation.json
+++ b/extension/src/popup/locales/en/translation.json
@@ -142,6 +142,7 @@
   "digits after the decimal allowed": "digits after the decimal allowed",
   "Disabled": "Disabled",
   "Disconnect all": "Disconnect all",
+  "Discover": "Discover",
   "Do this later": "Do this later",
   "Done": "Done",
   "Double check the domain name": {
@@ -342,6 +343,7 @@
   },
   "One or more operations in this transaction failed": "One or more operations in this transaction failed.",
   "Only accounts ready for migration will be migrated": "Only accounts ready for migration will be migrated.",
+  "Open": "Open",
   "Operation": "Operation",
   "Operations": "Operations",
   "Optional": "Optional",
@@ -357,6 +359,7 @@
   "Please note the following message": "Please note the following message",
   "Please select a different network before removing it": "Please select a different network before removing it.",
   "Please select each word in the same order you have them noted to confirm you got them right": "Please select each word in the same order you have them noted to confirm you got them right.",
+  "Popular Sites": "Popular Sites",
   "powered by": "powered by",
   "Powered by ": "Powered by ",
   "Pre Auth Transaction": "Pre Auth Transaction",
@@ -464,6 +467,7 @@
       " You may enable connection to domains that do not use an SSL certificate in Settings &gt; Security &gt; Advanced Settings": "The website <1>{url}</1> does not use an SSL certificate. For additional safety Freighter only works with websites that provide an SSL certificate by default. You may enable connection to domains that do not use an SSL certificate in Settings &gt; Security &gt; Advanced Settings."
     }
   },
+  "There are no sites to display at this moment": "There are no sites to display at this moment.",
   "These assets are not on any of your lists": {
     " Proceed with caution before adding": "These assets are not on any of your lists. Proceed with caution before adding."
   },

--- a/extension/src/popup/locales/en/translation.json
+++ b/extension/src/popup/locales/en/translation.json
@@ -91,6 +91,7 @@
   "Buy XLM with Coinbase": "Buy XLM with Coinbase",
   "Buying": "Buying",
   "by": "by",
+  "By using these services, you act at your own risk, and Freighter or Stellar Development Foundation (SDF) bears no liability for any resulting losses or damages": "By using these services, you act at your own risk, and Freighter or Stellar Development Foundation (SDF) bears no liability for any resulting losses or damages.",
   "Cancel": "Cancel",
   "Check the destination account memo requirements and include it in the transaction": "Check the destination account memo requirements and include it in the transaction.",
   "Choose Asset": "Choose Asset",
@@ -126,6 +127,7 @@
   "Create New Address": "Create New Address",
   "Create new wallet": "Create new wallet",
   "Custom": "Custom",
+  "Dapps": "Dapps",
   "data entries": "data entries",
   "Date": "Date",
   "Delete": "Delete",
@@ -198,6 +200,9 @@
     " It’s a safer alternative to copying and pasting private keys for use with web apps": "Freighter is a non-custodial wallet extension that enables you to sign Stellar transactions via your browser. It’s a safer alternative to copying and pasting private keys for use with web apps."
   },
   "Freighter is set to": "Freighter is set to",
+  "Freighter provides access to third-party dApps, protocols, and tokens for informational purposes only": {
+    " Freighter does not endorse any listed items": "Freighter provides access to third-party dApps, protocols, and tokens for informational purposes only. Freighter does not endorse any listed items."
+  },
   "Freighter uses asset lists to check assets you interact with": {
     " You can define your own assets lists in Settings": "Freighter uses asset lists to check assets you interact with. You can define your own assets lists in Settings."
   },
@@ -359,7 +364,6 @@
   "Please note the following message": "Please note the following message",
   "Please select a different network before removing it": "Please select a different network before removing it.",
   "Please select each word in the same order you have them noted to confirm you got them right": "Please select each word in the same order you have them noted to confirm you got them right.",
-  "Popular Sites": "Popular Sites",
   "powered by": "powered by",
   "Powered by ": "Powered by ",
   "Pre Auth Transaction": "Pre Auth Transaction",

--- a/extension/src/popup/locales/pt/translation.json
+++ b/extension/src/popup/locales/pt/translation.json
@@ -142,6 +142,7 @@
   "digits after the decimal allowed": "digits after the decimal allowed",
   "Disabled": "Disabled",
   "Disconnect all": "Disconnect all",
+  "Discover": "Discover",
   "Do this later": "Do this later",
   "Done": "Done",
   "Double check the domain name": {
@@ -342,6 +343,7 @@
   },
   "One or more operations in this transaction failed": "One or more operations in this transaction failed.",
   "Only accounts ready for migration will be migrated": "Only accounts ready for migration will be migrated.",
+  "Open": "Open",
   "Operation": "Operation",
   "Operations": "Operations",
   "Optional": "Optional",
@@ -357,6 +359,7 @@
   "Please note the following message": "Please note the following message",
   "Please select a different network before removing it": "Please select a different network before removing it.",
   "Please select each word in the same order you have them noted to confirm you got them right": "Please select each word in the same order you have them noted to confirm you got them right.",
+  "Popular Sites": "Popular Sites",
   "powered by": "powered by",
   "Powered by ": "Powered by ",
   "Pre Auth Transaction": "Pre Auth Transaction",
@@ -464,6 +467,7 @@
       " You may enable connection to domains that do not use an SSL certificate in Settings &gt; Security &gt; Advanced Settings": "The website <1>{url}</1> does not use an SSL certificate. For additional safety Freighter only works with websites that provide an SSL certificate by default. You may enable connection to domains that do not use an SSL certificate in Settings &gt; Security &gt; Advanced Settings."
     }
   },
+  "There are no sites to display at this moment": "There are no sites to display at this moment.",
   "These assets are not on any of your lists": {
     " Proceed with caution before adding": "These assets are not on any of your lists. Proceed with caution before adding."
   },

--- a/extension/src/popup/locales/pt/translation.json
+++ b/extension/src/popup/locales/pt/translation.json
@@ -91,6 +91,7 @@
   "Buy XLM with Coinbase": "Buy XLM with Coinbase",
   "Buying": "Buying",
   "by": "by",
+  "By using these services, you act at your own risk, and Freighter or Stellar Development Foundation (SDF) bears no liability for any resulting losses or damages": "By using these services, you act at your own risk, and Freighter or Stellar Development Foundation (SDF) bears no liability for any resulting losses or damages.",
   "Cancel": "Cancel",
   "Check the destination account memo requirements and include it in the transaction": "Check the destination account memo requirements and include it in the transaction.",
   "Choose Asset": "Choose Asset",
@@ -126,6 +127,7 @@
   "Create New Address": "Create New Address",
   "Create new wallet": "Create new wallet",
   "Custom": "Custom",
+  "Dapps": "Dapps",
   "data entries": "data entries",
   "Date": "Date",
   "Delete": "Delete",
@@ -198,6 +200,9 @@
     " It’s a safer alternative to copying and pasting private keys for use with web apps": "Freighter is a non-custodial wallet extension that enables you to sign Stellar transactions via your browser. It’s a safer alternative to copying and pasting private keys for use with web apps."
   },
   "Freighter is set to": "Freighter is set to",
+  "Freighter provides access to third-party dApps, protocols, and tokens for informational purposes only": {
+    " Freighter does not endorse any listed items": "Freighter provides access to third-party dApps, protocols, and tokens for informational purposes only. Freighter does not endorse any listed items."
+  },
   "Freighter uses asset lists to check assets you interact with": {
     " You can define your own assets lists in Settings": "Freighter uses asset lists to check assets you interact with. You can define your own assets lists in Settings."
   },
@@ -359,7 +364,6 @@
   "Please note the following message": "Please note the following message",
   "Please select a different network before removing it": "Please select a different network before removing it.",
   "Please select each word in the same order you have them noted to confirm you got them right": "Please select each word in the same order you have them noted to confirm you got them right.",
-  "Popular Sites": "Popular Sites",
   "powered by": "powered by",
   "Powered by ": "Powered by ",
   "Pre Auth Transaction": "Pre Auth Transaction",

--- a/extension/src/popup/metrics/views.ts
+++ b/extension/src/popup/metrics/views.ts
@@ -65,6 +65,7 @@ const routeToEventName = {
     METRIC_NAMES.viewAccountMigrationMigrationComplete,
   [ROUTES.advancedSettings]: METRIC_NAMES.viewAdvancedSettings,
   [ROUTES.addFunds]: METRIC_NAMES.viewAddFunds,
+  [ROUTES.discover]: METRIC_NAMES.discover,
 };
 
 registerHandler<AppState>(navigate, (_, a) => {

--- a/extension/src/popup/views/Discover/hooks/useGetDiscoverData.ts
+++ b/extension/src/popup/views/Discover/hooks/useGetDiscoverData.ts
@@ -1,4 +1,5 @@
 import { useReducer } from "react";
+import { captureException } from "@sentry/browser";
 
 import { RequestState } from "constants/request";
 import { initialState, reducer } from "helpers/request";
@@ -27,6 +28,7 @@ const useGetDiscoverData = () => {
       return payload;
     } catch (error) {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
+      captureException(`Error loading discover protocols - ${error}`);
       return error;
     }
   };

--- a/extension/src/popup/views/Discover/hooks/useGetDiscoverData.ts
+++ b/extension/src/popup/views/Discover/hooks/useGetDiscoverData.ts
@@ -1,0 +1,40 @@
+import { useReducer } from "react";
+
+import { RequestState } from "constants/request";
+import { initialState, reducer } from "helpers/request";
+import { getDiscoverData } from "@shared/api/internal";
+import { DiscoverData } from "@shared/api/types";
+
+interface DiscoverDataPayload {
+  discoverData: DiscoverData;
+}
+
+const useGetDiscoverData = () => {
+  const [state, dispatch] = useReducer(
+    reducer<DiscoverDataPayload, unknown>,
+    initialState,
+  );
+
+  const fetchData = async () => {
+    dispatch({ type: "FETCH_DATA_START" });
+    try {
+      const discoverData = await getDiscoverData();
+
+      const payload = {
+        discoverData,
+      };
+      dispatch({ type: "FETCH_DATA_SUCCESS", payload });
+      return payload;
+    } catch (error) {
+      dispatch({ type: "FETCH_DATA_ERROR", payload: error });
+      return error;
+    }
+  };
+
+  return {
+    state,
+    fetchData,
+  };
+};
+
+export { useGetDiscoverData, RequestState };

--- a/extension/src/popup/views/Discover/index.tsx
+++ b/extension/src/popup/views/Discover/index.tsx
@@ -42,10 +42,14 @@ export const Discover = () => {
             {t("Popular Sites")}
           </Text>
         </div>
-        <div className="Discover__content">
+        <div className="Discover__content" data-testid="discover-content">
           {allowedDiscoverRows.length ? (
             allowedDiscoverRows.map((row) => (
-              <div className="Discover__row" key={row.name}>
+              <div
+                className="Discover__row"
+                key={row.name}
+                data-testid="discover-row"
+              >
                 <img
                   src={row.iconUrl}
                   alt={row.name}
@@ -66,6 +70,7 @@ export const Discover = () => {
                   target="_blank"
                   rel="noopener noreferrer"
                   className="Discover__row__button"
+                  data-testid="discover-row-button"
                 >
                   <Text as="div" size="sm" weight="semi-bold">
                     {t("Open")}

--- a/extension/src/popup/views/Discover/index.tsx
+++ b/extension/src/popup/views/Discover/index.tsx
@@ -5,6 +5,7 @@ import { Icon, Text } from "@stellar/design-system";
 import { View } from "popup/basics/layout/View";
 import { SubviewHeader } from "popup/components/SubviewHeader";
 import { Loading } from "popup/components/Loading";
+import { DiscoverData } from "@shared/api/types";
 
 import { RequestState, useGetDiscoverData } from "./hooks/useGetDiscoverData";
 import "./styles.scss";
@@ -23,13 +24,14 @@ export const Discover = () => {
   const { state, data } = discoverData;
   const isLoading =
     state === RequestState.IDLE || state === RequestState.LOADING;
-  const discoverRowsData = data?.discoverData || [];
-  const allowedDiscoverRows = discoverRowsData.filter(
-    (row) => !row.isBlacklisted,
-  );
+  let allowedDiscoverRows = [] as DiscoverData;
 
   if (isLoading) {
     return <Loading />;
+  }
+
+  if (state !== RequestState.ERROR) {
+    allowedDiscoverRows = data.discoverData.filter((row) => !row.isBlacklisted);
   }
 
   return (

--- a/extension/src/popup/views/Discover/index.tsx
+++ b/extension/src/popup/views/Discover/index.tsx
@@ -41,7 +41,7 @@ export const Discover = () => {
         <div className="Discover__eyebrow">
           <Icon.Stars03 />
           <Text as="div" size="sm" weight="medium">
-            {t("Popular Sites")}
+            {t("Dapps")}
           </Text>
         </div>
         <div className="Discover__content" data-testid="discover-content">
@@ -90,6 +90,20 @@ export const Discover = () => {
               </Text>
             </div>
           )}
+          {allowedDiscoverRows.length ? (
+            <div className="Discover__footer">
+              <div className="Discover__footer__copy">
+                {t(
+                  "Freighter provides access to third-party dApps, protocols, and tokens for informational purposes only. Freighter does not endorse any listed items.",
+                )}
+              </div>
+              <div className="Discover__footer__copy">
+                {t(
+                  "By using these services, you act at your own risk, and Freighter or Stellar Development Foundation (SDF) bears no liability for any resulting losses or damages.",
+                )}
+              </div>
+            </div>
+          ) : null}
         </div>
       </View.Content>
     </>

--- a/extension/src/popup/views/Discover/index.tsx
+++ b/extension/src/popup/views/Discover/index.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { Icon, Text } from "@stellar/design-system";
+
+import { View } from "popup/basics/layout/View";
+import { SubviewHeader } from "popup/components/SubviewHeader";
+import { Loading } from "popup/components/Loading";
+
+import { RequestState, useGetDiscoverData } from "./hooks/useGetDiscoverData";
+import "./styles.scss";
+
+export const Discover = () => {
+  const { t } = useTranslation();
+  const { state: discoverData, fetchData } = useGetDiscoverData();
+
+  useEffect(() => {
+    const getData = async () => {
+      await fetchData();
+    };
+    getData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  const { state, data } = discoverData;
+  const isLoading =
+    state === RequestState.IDLE || state === RequestState.LOADING;
+  const discoverRowsData = data?.discoverData || [];
+  const allowedDiscoverRows = discoverRowsData.filter(
+    (row) => !row.isBlacklisted,
+  );
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  return (
+    <>
+      <SubviewHeader title={t("Discover")} />
+      <View.Content hasNoTopPadding>
+        <div className="Discover__eyebrow">
+          <Icon.Stars03 />
+          <Text as="div" size="sm" weight="medium">
+            {t("Popular Sites")}
+          </Text>
+        </div>
+        <div className="Discover__content">
+          {allowedDiscoverRows.length ? (
+            allowedDiscoverRows.map((row) => (
+              <div className="Discover__row" key={row.name}>
+                <img
+                  src={row.iconUrl}
+                  alt={row.name}
+                  className="Discover__row__icon"
+                />
+                <div className="Discover__row__label">
+                  <Text as="div" size="sm" weight="medium">
+                    {row.name}
+                  </Text>
+                  <div className="Discover__row__label__subtitle">
+                    <Text as="div" size="xs" weight="medium">
+                      {row.tags.join(", ")}
+                    </Text>
+                  </div>
+                </div>
+                <a
+                  href={row.websiteUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="Discover__row__button"
+                >
+                  <Text as="div" size="sm" weight="semi-bold">
+                    {t("Open")}
+                  </Text>
+                  <div className="Discover__row__button__icon">
+                    <Icon.LinkExternal01 />
+                  </div>
+                </a>
+              </div>
+            ))
+          ) : (
+            <div className="Discover__row" key="no-data">
+              <Text as="div" size="sm" weight="medium">
+                {t("There are no sites to display at this moment.")}
+              </Text>
+            </div>
+          )}
+        </div>
+      </View.Content>
+    </>
+  );
+};

--- a/extension/src/popup/views/Discover/styles.scss
+++ b/extension/src/popup/views/Discover/styles.scss
@@ -1,0 +1,55 @@
+@use "../../styles/utils.scss" as *;
+
+.Discover {
+  &__eyebrow {
+    align-items: center;
+    color: var(--sds-clr-gray-11);
+    display: flex;
+    gap: pxToRem(8);
+    margin-bottom: pxToRem(16);
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: pxToRem(24);
+  }
+
+  &__row {
+    display: flex;
+    gap: pxToRem(12);
+    align-items: center;
+
+    &__icon {
+      height: pxToRem(32);
+      width: pxToRem(32);
+    }
+
+    &__label {
+      display: flex;
+      flex-direction: column;
+      flex: 1 0 0;
+
+      &__subtitle {
+        color: var(--sds-clr-gray-11);
+      }
+    }
+
+    &__button {
+      border-radius: 100px;
+      border: 1px solid var(--sds-clr-gray-11);
+      color: var(--sds-clr-gray-12);
+      display: flex;
+      gap: pxToRem(4);
+      padding: pxToRem(6) pxToRem(10);
+      justify-content: center;
+      align-items: center;
+
+      &__icon {
+        height: pxToRem(14);
+        width: pxToRem(14);
+        color: var(--sds-clr-gray-11);
+      }
+    }
+  }
+}

--- a/extension/src/popup/views/Discover/styles.scss
+++ b/extension/src/popup/views/Discover/styles.scss
@@ -52,4 +52,19 @@
       }
     }
   }
+
+  &__footer {
+    display: flex;
+    flex-direction: column;
+    gap: pxToRem(8);
+    border-radius: pxToRem(16);
+    background-color: var(--sds-clr-gray-02);
+    padding: pxToRem(16);
+
+    &__copy {
+      color: var(--sds-clr-gray-11);
+      font-size: pxToRem(10);
+      line-height: pxToRem(14);
+    }
+  }
 }

--- a/extension/src/popup/views/__tests__/Discover.test.tsx
+++ b/extension/src/popup/views/__tests__/Discover.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { render, waitFor, screen } from "@testing-library/react";
+import {
+  DEFAULT_NETWORKS,
+  MAINNET_NETWORK_DETAILS,
+} from "@shared/constants/stellar";
+import { APPLICATION_STATE as ApplicationState } from "@shared/constants/applicationState";
+import { ROUTES } from "popup/constants/routes";
+import * as ApiInternal from "@shared/api/internal";
+import { Wrapper, mockAccounts } from "../../__testHelpers__";
+import { Discover } from "../Discover";
+
+describe("Discover view", () => {
+  it("displays Discover protocols with links that are not blacklisted", async () => {
+    jest.spyOn(ApiInternal, "getDiscoverData").mockImplementation(() =>
+      Promise.resolve([
+        {
+          description: "description text",
+          name: "Foo",
+          iconUrl: "https://example.com/icon.png",
+          websiteUrl: "https://foo.com",
+          tags: ["tag1", "tag2"],
+          isBlacklisted: false,
+        },
+        {
+          description: "description text",
+          name: "Baz",
+          iconUrl: "https://example.com/icon.png",
+          websiteUrl: "https://baz.com",
+          tags: ["tag1", "tag2"],
+          isBlacklisted: true,
+        },
+      ]),
+    );
+    render(
+      <Wrapper
+        routes={[ROUTES.discover]}
+        state={{
+          auth: {
+            error: null,
+            applicationState: ApplicationState.PASSWORD_CREATED,
+            publicKey: "G1",
+            allAccounts: mockAccounts,
+          },
+          settings: {
+            networkDetails: MAINNET_NETWORK_DETAILS,
+            networksList: DEFAULT_NETWORKS,
+          },
+        }}
+      >
+        <Discover />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("AppHeaderPageTitle")).toHaveTextContent(
+        "Discover",
+      );
+    });
+    const protocolLinks = screen.queryAllByTestId("discover-row");
+
+    expect(protocolLinks).toHaveLength(1);
+    expect(protocolLinks[0]).toHaveTextContent("Foo");
+    expect(screen.getByTestId("discover-row-button")).toHaveAttribute(
+      "href",
+      "https://foo.com",
+    );
+  });
+});

--- a/extension/src/popup/views/__tests__/ManageAssets.test.tsx
+++ b/extension/src/popup/views/__tests__/ManageAssets.test.tsx
@@ -431,7 +431,7 @@ describe.skip("Manage assets", () => {
     );
   });
 
-  it.only("renders manage assets view initial state", async () => {
+  it("renders manage assets view initial state", async () => {
     await initView();
 
     await waitFor(() => {


### PR DESCRIPTION
Closes #1946 

NOTE: This demo video shows test data; we are waiting on the final protocols/tags from Product. Also, the `/discover` endpoint is not live in prod yet (as the final list is pending), so if you pull this branch, you'll need to connect to the dev BE env: https://freighter-backend-v2-dev.kube001-dev.services.stellar-ops.com/api/v1/protocols 

This PR adds a UI for the Discover tab. You'll notice that there is a small redesign on Account that adds a link to this Discover tab next to a button that opens the Network settings drawer. This was designed for Freighter v3, which we have not yet implemented yet. I worked with Charles and we settled on just adding these 2 buttons from Freighter v3 for now. We'll be redesigning the rest of the Account view in a later ticket


https://github.com/user-attachments/assets/0bf9c2a1-0c7e-424c-ad81-60a621d204eb

