### PR TITLE
return the public key from popupMessageListener in all cases

### DIFF
--- a/extension/e2e-tests/freighterApiIntegration.test.ts
+++ b/extension/e2e-tests/freighterApiIntegration.test.ts
@@ -321,3 +321,30 @@ test("should not add token when not allowed", async ({ page, extensionId }) => {
     screenshot: "domain-not-allowed-add-token.png",
   });
 });
+test("should get public key when logged out", async ({ page, extensionId }) => {
+  await loginToTestAccount({ page, extensionId });
+  await page.getByTestId("BottomNav-link-settings").click();
+  await page.getByText("Log Out").click();
+  await expect(page.getByText("Welcome back!")).toBeVisible();
+
+  // open a second tab and go to docs playground
+  const pageTwo = await page.context().newPage();
+  await pageTwo.waitForLoadState();
+
+  const popupPromise = page.context().waitForEvent("page");
+  await pageTwo.goto(
+    "https://docs.freighter.app/docs/playground/requestAccess",
+  );
+  await pageTwo.getByText("Request Access").click();
+
+  const popup = await popupPromise;
+  await expect(popup.getByText("Welcome back!")).toBeVisible();
+  await popup.locator("#password-input").fill("My-password123");
+  await popup.getByText("Login").click();
+  await expect(popup.getByText("Connection Request")).toBeVisible();
+  await popup.getByTestId("grant-access-connect-button").click();
+
+  await expect(pageTwo.getByRole("textbox").first()).toHaveValue(
+    "GDF32CQINROD3E2LMCGZUDVMWTXCJFR5SBYVRJ7WAAIAS3P7DCVWZEFY",
+  );
+});

--- a/extension/src/background/messageListener/freighterApiMessageListener.ts
+++ b/extension/src/background/messageListener/freighterApiMessageListener.ts
@@ -104,11 +104,11 @@ export const freighterApiMessageListener = (
     });
 
     return new Promise((resolve) => {
-      const response = (url?: string) => {
+      const response = (url?: string, publicKey?: string) => {
         // queue it up, we'll let user confirm the url looks okay and then we'll send publicKey
         // if we're good, of course
         if (url === tabUrl) {
-          resolve({ publicKey: publicKeySelector(sessionStore.getState()) });
+          resolve({ publicKey });
         }
 
         resolve({

--- a/extension/src/background/messageListener/handlers/grantAccess.ts
+++ b/extension/src/background/messageListener/handlers/grantAccess.ts
@@ -41,7 +41,7 @@ export const grantAccess = async ({
   });
 
   if (typeof response === "function") {
-    return response(url);
+    return response(url, publicKey);
   }
 
   return { error: "Access was denied" };


### PR DESCRIPTION
Closes #1843 

Fixes issue where if a user is logged out when freighter-api requests access, logging in and granting access doesn't return the public key. The fix here follows the model we use in our other "sign" methods where we pass the address from popupMessageListener to freighterApiMessageListener using the responseQueue 