### PR TITLE
[FEATURE] Cache slice

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -996,10 +996,12 @@ export const getAssetIcons = async ({
   balances,
   networkDetails,
   assetsListsData,
+  cachedIcons,
 }: {
   balances: Balances;
   networkDetails: NetworkDetails;
   assetsListsData: AssetListResponse[];
+  cachedIcons: Record<string, string>;
 }) => {
   const assetIcons = {} as { [code: string]: string };
 
@@ -1016,6 +1018,12 @@ export const getAssetIcons = async ({
         } = token;
 
         let canonical = getCanonicalFromAsset(code, key);
+        const cachedIcon = cachedIcons[canonical];
+        if (cachedIcon) {
+          assetIcons[canonical] = cachedIcon;
+          continue;
+        }
+
         icon = await getIconUrlFromIssuer({ key, code, networkDetails });
         if (!icon) {
           const tokenListIcon = await getIconFromTokenLists({

--- a/extension/src/helpers/__tests__/useGetAssetDomainsWithBalances.test.tsx
+++ b/extension/src/helpers/__tests__/useGetAssetDomainsWithBalances.test.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { Provider } from "react-redux";
+import { useLocation } from "react-router-dom";
+import { renderHook, act } from "@testing-library/react";
+import { useGetAssetDomainsWithBalances } from "../hooks/useGetAssetDomainsWithBalances";
+import {
+  makeDummyStore,
+  mockBalances,
+  TEST_CANONICAL,
+  TEST_PUBLIC_KEY,
+} from "popup/__testHelpers__";
+import { RequestState } from "constants/request";
+import { TESTNET_NETWORK_DETAILS } from "@shared/constants/stellar";
+import { getAssetDomain } from "popup/helpers/getAssetDomain";
+
+jest.mock("@shared/api/internal", () => ({
+  ...jest.requireActual("@shared/api/internal"),
+  getAccountBalances: jest.fn(),
+  getAssetIcons: jest.fn().mockResolvedValue({}),
+  getHiddenAssets: jest.fn().mockResolvedValue({ hiddenAssets: [] }),
+}));
+jest.mock("@shared/api/helpers/getIconUrlFromIssuer", () => ({
+  ...jest.requireActual("@shared/api/internal"),
+  getIconUrlFromIssuer: jest.fn(),
+}));
+jest.mock("@shared/api/helpers/token-list", () => ({
+  getCombinedAssetListData: jest.fn().mockResolvedValue([]),
+}));
+jest.mock("popup/helpers/account", () => ({
+  ...jest.requireActual("popup/helpers/account"),
+  filterHiddenBalances: (_b: any) => _b,
+}));
+jest.mock("popup/helpers/getAssetDomain", () => ({
+  ...jest.requireActual("popup/helpers/getAssetDomain"),
+  getAssetDomain: jest.fn(),
+}));
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useLocation: jest.fn(),
+}));
+
+describe("useGetAssetDomainsWithBalances (cached path)", () => {
+  (useLocation as jest.Mock).mockReturnValue({
+    pathname: "/test-path",
+    search: "?query=test",
+    state: { from: "test" },
+  });
+
+  const publicKey = TEST_PUBLIC_KEY;
+
+  const cachedBalanceData = {
+    isFunded: true,
+    subentryCount: 3,
+    error: undefined,
+    balances: mockBalances.balances,
+  };
+
+  const tokenListData = [{ id: "example-token-list" }];
+  const canonicalKey = "XLM:GABCDEF";
+  const cachedIcons = {
+    [canonicalKey]: "https://cached/icon/url.png",
+  };
+
+  const testCanonicalIssuer = TEST_CANONICAL.split(":")[1];
+  const preloadedState = {
+    auth: {
+      publicKey: TEST_PUBLIC_KEY,
+    },
+    cache: {
+      balanceData: { [publicKey]: cachedBalanceData },
+      icons: cachedIcons,
+      tokenLists: tokenListData,
+      homeDomains: {
+        [testCanonicalIssuer]: "example.com",
+        GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM: "example.com",
+      },
+    },
+    settings: {
+      assetsLists: [],
+      networkDetails: TESTNET_NETWORK_DETAILS,
+    },
+  };
+
+  const store = makeDummyStore(preloadedState);
+  const Wrapper =
+    (store: ReturnType<typeof makeDummyStore>) =>
+    ({ children }: { children: React.ReactNode }) => (
+      <Provider store={store}>{children}</Provider>
+    );
+
+  it("serves domains from the cache and skips the API call", async () => {
+    const { result } = renderHook(
+      () =>
+        useGetAssetDomainsWithBalances({
+          showHidden: false,
+          includeIcons: false,
+        }),
+      { wrapper: Wrapper(store) },
+    );
+
+    await act(async () => {
+      await result.current.fetchData(true);
+    });
+
+    expect(getAssetDomain).not.toHaveBeenCalled();
+    expect(result.current.state.state).toBe<RequestState>(RequestState.SUCCESS);
+  });
+});

--- a/extension/src/helpers/__tests__/useGetBalances.test.tsx
+++ b/extension/src/helpers/__tests__/useGetBalances.test.tsx
@@ -1,0 +1,139 @@
+import React from "react";
+import { Provider } from "react-redux";
+import { renderHook, act } from "@testing-library/react";
+import { useGetBalances, RequestState } from "../hooks/useGetBalances";
+import { getAccountBalances } from "@shared/api/internal";
+import { makeDummyStore, TEST_PUBLIC_KEY } from "popup/__testHelpers__";
+import { TESTNET_NETWORK_DETAILS } from "@shared/constants/stellar";
+import { getIconUrlFromIssuer } from "@shared/api/helpers/getIconUrlFromIssuer";
+import { getCombinedAssetListData } from "@shared/api/helpers/token-list";
+
+jest.mock("@shared/api/internal", () => ({
+  ...jest.requireActual("@shared/api/internal"),
+  getAccountBalances: jest.fn(),
+  getHiddenAssets: jest.fn().mockResolvedValue({ hiddenAssets: [] }),
+}));
+jest.mock("@shared/api/helpers/getIconUrlFromIssuer", () => ({
+  ...jest.requireActual("@shared/api/internal"),
+  getIconUrlFromIssuer: jest.fn(),
+}));
+jest.mock("@shared/api/helpers/token-list", () => ({
+  getCombinedAssetListData: jest.fn().mockResolvedValue([]),
+}));
+jest.mock("popup/helpers/account", () => ({
+  sortBalances: (b: any) => b,
+  filterHiddenBalances: (_b: any) => _b,
+}));
+
+describe("useGetBalances (cached path)", () => {
+  const publicKey = TEST_PUBLIC_KEY;
+
+  const cachedBalanceData = {
+    isFunded: true,
+    subentryCount: 3,
+    error: undefined,
+    balances: {
+      native: {
+        asset_type: "native",
+        balance: "123.0000000",
+        token: {
+          code: "XLM",
+          issuer: { key: "GABCDEF" },
+        },
+      },
+    },
+  };
+
+  const tokenListData = [{ id: "example-token-list" }];
+  const canonicalKey = "XLM:GABCDEF";
+  const cachedIcons = {
+    [canonicalKey]: "https://cached/icon/url.png",
+  };
+
+  const preloadedState = {
+    cache: {
+      balanceData: { [publicKey]: cachedBalanceData },
+      icons: cachedIcons,
+      tokenLists: tokenListData,
+    },
+    settings: {
+      assetsLists: [],
+    },
+  };
+
+  const store = makeDummyStore(preloadedState);
+  const Wrapper =
+    (store: ReturnType<typeof makeDummyStore>) =>
+    ({ children }: { children: React.ReactNode }) => (
+      <Provider store={store}>{children}</Provider>
+    );
+
+  it("serves balances from the cache and skips the API call", async () => {
+    const { result } = renderHook(
+      () => useGetBalances({ showHidden: false, includeIcons: false }),
+      { wrapper: Wrapper(store) },
+    );
+
+    let payload: any;
+    await act(async () => {
+      payload = await result.current.fetchData(
+        publicKey,
+        true,
+        TESTNET_NETWORK_DETAILS,
+        true,
+      );
+    });
+
+    expect(payload).toMatchObject({
+      balances: cachedBalanceData.balances,
+      isFunded: cachedBalanceData.isFunded,
+      subentryCount: cachedBalanceData.subentryCount,
+    });
+
+    expect(getAccountBalances).not.toHaveBeenCalled();
+    expect(result.current.state.state).toBe<RequestState>(RequestState.SUCCESS);
+  });
+
+  it("serves icons from the cache and skips the API call", async () => {
+    const { result } = renderHook(
+      () => useGetBalances({ showHidden: false, includeIcons: true }),
+      { wrapper: Wrapper(store) },
+    );
+
+    let payload: any;
+    await act(async () => {
+      payload = await result.current.fetchData(
+        publicKey,
+        true,
+        TESTNET_NETWORK_DETAILS,
+        true,
+      );
+    });
+
+    expect(payload.icons[canonicalKey]).toBe(cachedIcons[canonicalKey]);
+
+    expect(getAccountBalances).not.toHaveBeenCalled();
+    expect(getIconUrlFromIssuer).not.toHaveBeenCalled();
+    expect(result.current.state.state).toBe<RequestState>(RequestState.SUCCESS);
+  });
+
+  it("serves token lists from the cache and skips the API calls", async () => {
+    const { result } = renderHook(
+      () => useGetBalances({ showHidden: false, includeIcons: true }),
+      { wrapper: Wrapper(store) },
+    );
+
+    let payload: any;
+    await act(async () => {
+      payload = await result.current.fetchData(
+        publicKey,
+        true,
+        TESTNET_NETWORK_DETAILS,
+        true,
+      );
+    });
+
+    expect(getCombinedAssetListData).not.toHaveBeenCalled();
+    expect(result.current.state.state).toBe<RequestState>(RequestState.SUCCESS);
+  });
+});

--- a/extension/src/helpers/hooks/useGetAssetDomainsWithBalances.ts
+++ b/extension/src/helpers/hooks/useGetAssetDomainsWithBalances.ts
@@ -32,7 +32,7 @@ export interface ResolvedAssetDomains {
 
 export type AssetDomains = NeedsReRoute | ResolvedAssetDomains;
 
-export function useGetAssetDomainsWithBalances(options: {
+export function useGetAssetDomainsWithBalances(getBalancesOptions: {
   showHidden: boolean;
   includeIcons: boolean;
 }) {
@@ -48,12 +48,12 @@ export function useGetAssetDomainsWithBalances(options: {
     initialState,
   );
   const { fetchData: fetchAppData } = useGetAppData();
-  const { fetchData: fetchBalances } = useGetBalances(options);
+  const { fetchData: fetchBalances } = useGetBalances(getBalancesOptions);
 
-  const fetchData = async (): Promise<AssetDomains | Error> => {
+  const fetchData = async (useCache = false): Promise<AssetDomains | Error> => {
     dispatch({ type: "FETCH_DATA_START" });
     try {
-      const appData = await fetchAppData();
+      const appData = await fetchAppData(useCache);
       if (isError(appData)) {
         throw new Error(appData.message);
       }
@@ -70,6 +70,7 @@ export function useGetAssetDomainsWithBalances(options: {
         publicKey,
         isMainnetNetwork,
         networkDetails,
+        useCache,
       );
 
       if (isError<AccountBalances>(balances)) {

--- a/extension/src/helpers/hooks/useGetAssetDomainsWithBalances.ts
+++ b/extension/src/helpers/hooks/useGetAssetDomainsWithBalances.ts
@@ -19,7 +19,7 @@ import { AccountBalances, useGetBalances } from "./useGetBalances";
 import { getNativeContractDetails } from "popup/helpers/searchAsset";
 import { AppDataType, NeedsReRoute, useGetAppData } from "./useGetAppData";
 import { APPLICATION_STATE } from "@shared/constants/applicationState";
-import { homeDomainsSelector, saveDomainForIssuer } from "popup/ducks/balances";
+import { homeDomainsSelector, saveDomainForIssuer } from "popup/ducks/cache";
 import { AppDispatch } from "popup/App";
 
 export interface ResolvedAssetDomains {

--- a/extension/src/helpers/hooks/useGetBalances.tsx
+++ b/extension/src/helpers/hooks/useGetBalances.tsx
@@ -27,7 +27,7 @@ import {
   saveIconsForBalances,
   saveTokenLists,
   tokensListsSelector,
-} from "popup/ducks/balances";
+} from "popup/ducks/cache";
 
 export interface AccountBalances {
   balances: AssetType[];

--- a/extension/src/helpers/hooks/useGetBalances.tsx
+++ b/extension/src/helpers/hooks/useGetBalances.tsx
@@ -25,6 +25,8 @@ import {
   iconsSelector,
   saveBalancesForAccount,
   saveIconsForBalances,
+  saveTokenLists,
+  tokensListsSelector,
 } from "popup/ducks/balances";
 
 export interface AccountBalances {
@@ -47,6 +49,7 @@ function useGetBalances(options: {
   const { assetsLists } = useSelector(settingsSelector);
   const cachedBalances = useSelector(balancesSelector);
   const cachedIcons = useSelector(iconsSelector);
+  const cachedTokenLists = useSelector(tokensListsSelector);
 
   const fetchData = async (
     publicKey: string,
@@ -79,10 +82,12 @@ function useGetBalances(options: {
         }
 
         if (options.includeIcons) {
-          const assetsListsData = await getCombinedAssetListData({
-            networkDetails,
-            assetsLists,
-          });
+          const assetsListsData = cachedTokenLists.length
+            ? cachedTokenLists
+            : await getCombinedAssetListData({
+                networkDetails,
+                assetsLists,
+              });
 
           const icons = await getAssetIcons({
             balances: cachedBalanceData.balances,
@@ -136,6 +141,7 @@ function useGetBalances(options: {
             cachedIcons,
           });
           payload.icons = icons;
+          reduxDispatch(saveTokenLists(assetsListsData));
           reduxDispatch(saveIconsForBalances({ icons }));
         }
 

--- a/extension/src/helpers/hooks/useGetBalances.tsx
+++ b/extension/src/helpers/hooks/useGetBalances.tsx
@@ -24,6 +24,7 @@ import {
   balancesSelector,
   iconsSelector,
   saveBalancesForAccount,
+  saveIconsForBalances,
 } from "popup/ducks/balances";
 
 export interface AccountBalances {
@@ -135,6 +136,7 @@ function useGetBalances(options: {
             cachedIcons,
           });
           payload.icons = icons;
+          reduxDispatch(saveIconsForBalances({ icons }));
         }
 
         reduxDispatch(

--- a/extension/src/popup/App.tsx
+++ b/extension/src/popup/App.tsx
@@ -10,7 +10,7 @@ import { reducer as auth } from "popup/ducks/accountServices";
 import { reducer as settings } from "popup/ducks/settings";
 import { reducer as transactionSubmission } from "popup/ducks/transactionSubmission";
 import { reducer as tokenPaymentSimulation } from "popup/ducks/token-payment";
-import { reducer as balances } from "popup/ducks/balances";
+import { reducer as cache } from "popup/ducks/cache";
 import { ErrorTracking } from "popup/components/ErrorTracking";
 import { AccountMismatch } from "popup/components/AccountMismatch";
 import { ErrorBoundary } from "./components/ErrorBoundary";
@@ -23,7 +23,7 @@ const rootReducer = combineReducers({
   settings,
   transactionSubmission,
   tokenPaymentSimulation,
-  balances,
+  cache,
 });
 export type AppState = ReturnType<typeof rootReducer>;
 export const store = configureStore({

--- a/extension/src/popup/App.tsx
+++ b/extension/src/popup/App.tsx
@@ -10,6 +10,7 @@ import { reducer as auth } from "popup/ducks/accountServices";
 import { reducer as settings } from "popup/ducks/settings";
 import { reducer as transactionSubmission } from "popup/ducks/transactionSubmission";
 import { reducer as tokenPaymentSimulation } from "popup/ducks/token-payment";
+import { reducer as balances } from "popup/ducks/balances";
 import { ErrorTracking } from "popup/components/ErrorTracking";
 import { AccountMismatch } from "popup/components/AccountMismatch";
 import { ErrorBoundary } from "./components/ErrorBoundary";
@@ -22,6 +23,7 @@ const rootReducer = combineReducers({
   settings,
   transactionSubmission,
   tokenPaymentSimulation,
+  balances,
 });
 export type AppState = ReturnType<typeof rootReducer>;
 export const store = configureStore({

--- a/extension/src/popup/__testHelpers__/index.tsx
+++ b/extension/src/popup/__testHelpers__/index.tsx
@@ -8,7 +8,7 @@ import { Balances } from "@shared/api/types/backend-api";
 
 import { reducer as auth } from "popup/ducks/accountServices";
 import { reducer as settings } from "popup/ducks/settings";
-import { reducer as balances } from "popup/ducks/balances";
+import { reducer as cache } from "popup/ducks/cache";
 import { defaultBlockaidScanAssetResult } from "@shared/helpers/stellar";
 import {
   reducer as transactionSubmission,
@@ -29,7 +29,7 @@ const rootReducer = combineReducers({
   settings,
   transactionSubmission,
   tokenPaymentSimulation,
-  balances,
+  cache,
 });
 
 const makeDummyStore = (state: any) =>

--- a/extension/src/popup/__testHelpers__/index.tsx
+++ b/extension/src/popup/__testHelpers__/index.tsx
@@ -8,6 +8,7 @@ import { Balances } from "@shared/api/types/backend-api";
 
 import { reducer as auth } from "popup/ducks/accountServices";
 import { reducer as settings } from "popup/ducks/settings";
+import { reducer as balances } from "popup/ducks/balances";
 import { defaultBlockaidScanAssetResult } from "@shared/helpers/stellar";
 import {
   reducer as transactionSubmission,
@@ -28,6 +29,7 @@ const rootReducer = combineReducers({
   settings,
   transactionSubmission,
   tokenPaymentSimulation,
+  balances,
 });
 
 const makeDummyStore = (state: any) =>

--- a/extension/src/popup/__testHelpers__/index.tsx
+++ b/extension/src/popup/__testHelpers__/index.tsx
@@ -32,7 +32,7 @@ const rootReducer = combineReducers({
   cache,
 });
 
-const makeDummyStore = (state: any) =>
+export const makeDummyStore = (state: any) =>
   configureStore({
     reducer: rootReducer,
     preloadedState: state,

--- a/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
@@ -45,7 +45,7 @@ export const ChooseAsset = ({
 
   useEffect(() => {
     const getData = async () => {
-      await fetchData();
+      await fetchData(true);
     };
     getData();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/extension/src/popup/components/manageAssetsLists/ModifyAssetList/index.tsx
+++ b/extension/src/popup/components/manageAssetsLists/ModifyAssetList/index.tsx
@@ -20,6 +20,7 @@ import { SubviewHeader } from "popup/components/SubviewHeader";
 import { View } from "popup/basics/layout/View";
 import { addAssetsList, modifyAssetsList } from "popup/ducks/settings";
 import { navigateTo } from "popup/helpers/navigate";
+import { saveTokenLists } from "popup/ducks/cache";
 import { DeleteModal } from "../DeleteModal";
 
 import "./styles.scss";
@@ -233,6 +234,7 @@ export const ModifyAssetList = ({
     }
 
     if (modifyAssetsList.fulfilled.match(modifyAssetsListResp)) {
+      dispatch(saveTokenLists([]));
       navigateTo(ROUTES.manageAssetsLists, navigate);
     }
   };

--- a/extension/src/popup/components/sendPayment/SendAmount/hooks/useSendAmountData.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/hooks/useSendAmountData.tsx
@@ -48,7 +48,7 @@ function useGetSendAmountData(
   const fetchData = async () => {
     dispatch({ type: "FETCH_DATA_START" });
     try {
-      const userDomains = await fetchAssetDomains();
+      const userDomains = await fetchAssetDomains(true);
       let destinationAccount = await getBaseAccount(destinationAddress);
 
       if (isError<AssetDomains>(userDomains)) {

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/hooks/useGetTxDetailsData.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/hooks/useGetTxDetailsData.tsx
@@ -30,6 +30,7 @@ import { isContractId } from "popup/helpers/soroban";
 import { settingsSelector } from "popup/ducks/settings";
 import { getCombinedAssetListData } from "@shared/api/helpers/token-list";
 import { hasPrivateKeySelector } from "popup/ducks/accountServices";
+import { iconsSelector } from "popup/ducks/balances";
 
 export interface TxDetailsData {
   destAssetIconUrl: string;
@@ -202,6 +203,7 @@ function useGetTxDetailsData(
 
   const { fetchData: fetchBalances } = useGetBalances(balanceOptions);
   const { assetsLists } = useSelector(settingsSelector);
+  const cachedIcons = useSelector(iconsSelector);
 
   const { scanTx } = useScanTx();
 
@@ -234,6 +236,7 @@ function useGetTxDetailsData(
               balances: destBalancesResult.balances,
               networkDetails,
               assetsListsData,
+              cachedIcons,
             })
           : {};
 

--- a/extension/src/popup/ducks/balances.ts
+++ b/extension/src/popup/ducks/balances.ts
@@ -1,9 +1,13 @@
 import { createSelector, createSlice } from "@reduxjs/toolkit";
 import { AccountBalancesInterface } from "@shared/api/types/backend-api";
 
-interface SetBalancesPayload {
+interface SaveBalancesPayload {
   publicKey: string;
   balances: AccountBalancesInterface;
+}
+
+interface SaveIconsPayload {
+  icons: Record<string, string>;
 }
 
 interface InitialState {
@@ -24,16 +28,16 @@ const balancesSlice = createSlice({
       state.balanceData = {};
       state.icons = {};
     },
-    saveBalancesForAccount(state, action: { payload: SetBalancesPayload }) {
+    saveBalancesForAccount(state, action: { payload: SaveBalancesPayload }) {
       state.balanceData = {
         ...state.balanceData,
         [action.payload.publicKey]: action.payload.balances,
       };
     },
-    saveIconsForBalances(state, action: { payload: SetBalancesPayload }) {
-      state.balanceData = {
-        ...state.balanceData,
-        [action.payload.publicKey]: action.payload.balances,
+    saveIconsForBalances(state, action: { payload: SaveIconsPayload }) {
+      state.icons = {
+        ...state.icons,
+        ...action.payload.icons,
       };
     },
   },
@@ -47,4 +51,5 @@ export const selectBalancesByPublicKey = (publicKey: string) =>
   createSelector(balancesSelector, (balances) => balances[publicKey]);
 
 export const { reducer } = balancesSlice;
-export const { clearAll, saveBalancesForAccount } = balancesSlice.actions;
+export const { clearAll, saveBalancesForAccount, saveIconsForBalances } =
+  balancesSlice.actions;

--- a/extension/src/popup/ducks/balances.ts
+++ b/extension/src/popup/ducks/balances.ts
@@ -1,0 +1,50 @@
+import { createSelector, createSlice } from "@reduxjs/toolkit";
+import { AccountBalancesInterface } from "@shared/api/types/backend-api";
+
+interface SetBalancesPayload {
+  publicKey: string;
+  balances: AccountBalancesInterface;
+}
+
+interface InitialState {
+  balanceData: Record<string, AccountBalancesInterface>;
+  icons: Record<string, string>;
+}
+
+const initialState: InitialState = {
+  balanceData: {},
+  icons: {},
+};
+
+const balancesSlice = createSlice({
+  name: "balances",
+  initialState,
+  reducers: {
+    clearAll(state) {
+      state.balanceData = {};
+      state.icons = {};
+    },
+    saveBalancesForAccount(state, action: { payload: SetBalancesPayload }) {
+      state.balanceData = {
+        ...state.balanceData,
+        [action.payload.publicKey]: action.payload.balances,
+      };
+    },
+    saveIconsForBalances(state, action: { payload: SetBalancesPayload }) {
+      state.balanceData = {
+        ...state.balanceData,
+        [action.payload.publicKey]: action.payload.balances,
+      };
+    },
+  },
+});
+
+export const balancesSelector = (state: { balances: InitialState }) =>
+  state.balances.balanceData;
+export const iconsSelector = (state: { balances: InitialState }) =>
+  state.balances.icons;
+export const selectBalancesByPublicKey = (publicKey: string) =>
+  createSelector(balancesSelector, (balances) => balances[publicKey]);
+
+export const { reducer } = balancesSlice;
+export const { clearAll, saveBalancesForAccount } = balancesSlice.actions;

--- a/extension/src/popup/ducks/balances.ts
+++ b/extension/src/popup/ducks/balances.ts
@@ -1,23 +1,32 @@
 import { createSelector, createSlice } from "@reduxjs/toolkit";
 import { AccountBalancesInterface } from "@shared/api/types/backend-api";
 
+type AssetCode = string;
+type PublicKey = string;
+type IconUrl = string;
+type HomeDomain = string;
+
 interface SaveBalancesPayload {
-  publicKey: string;
+  publicKey: PublicKey;
   balances: AccountBalancesInterface;
 }
 
 interface SaveIconsPayload {
-  icons: Record<string, string>;
+  icons: Record<AssetCode, IconUrl>;
 }
 
+type SaveDomainPayload = Record<PublicKey, HomeDomain>;
+
 interface InitialState {
-  balanceData: Record<string, AccountBalancesInterface>;
-  icons: Record<string, string>;
+  balanceData: Record<PublicKey, AccountBalancesInterface>;
+  icons: Record<AssetCode, IconUrl>;
+  homeDomains: Record<PublicKey, HomeDomain>;
 }
 
 const initialState: InitialState = {
   balanceData: {},
   icons: {},
+  homeDomains: {},
 };
 
 const balancesSlice = createSlice({
@@ -27,6 +36,7 @@ const balancesSlice = createSlice({
     clearAll(state) {
       state.balanceData = {};
       state.icons = {};
+      state.homeDomains = {};
     },
     saveBalancesForAccount(state, action: { payload: SaveBalancesPayload }) {
       state.balanceData = {
@@ -40,6 +50,12 @@ const balancesSlice = createSlice({
         ...action.payload.icons,
       };
     },
+    saveDomainForIssuer(state, action: { payload: SaveDomainPayload }) {
+      state.homeDomains = {
+        ...state.homeDomains,
+        ...action.payload,
+      };
+    },
   },
 });
 
@@ -47,9 +63,15 @@ export const balancesSelector = (state: { balances: InitialState }) =>
   state.balances.balanceData;
 export const iconsSelector = (state: { balances: InitialState }) =>
   state.balances.icons;
+export const homeDomainsSelector = (state: { balances: InitialState }) =>
+  state.balances.homeDomains;
 export const selectBalancesByPublicKey = (publicKey: string) =>
   createSelector(balancesSelector, (balances) => balances[publicKey]);
 
 export const { reducer } = balancesSlice;
-export const { clearAll, saveBalancesForAccount, saveIconsForBalances } =
-  balancesSlice.actions;
+export const {
+  clearAll,
+  saveBalancesForAccount,
+  saveIconsForBalances,
+  saveDomainForIssuer,
+} = balancesSlice.actions;

--- a/extension/src/popup/ducks/balances.ts
+++ b/extension/src/popup/ducks/balances.ts
@@ -1,5 +1,6 @@
 import { createSelector, createSlice } from "@reduxjs/toolkit";
 import { AccountBalancesInterface } from "@shared/api/types/backend-api";
+import { AssetListResponse } from "@shared/constants/soroban/asset-list";
 
 type AssetCode = string;
 type PublicKey = string;
@@ -17,16 +18,20 @@ interface SaveIconsPayload {
 
 type SaveDomainPayload = Record<PublicKey, HomeDomain>;
 
+type SaveTokenLists = AssetListResponse[];
+
 interface InitialState {
   balanceData: Record<PublicKey, AccountBalancesInterface>;
   icons: Record<AssetCode, IconUrl>;
   homeDomains: Record<PublicKey, HomeDomain>;
+  tokenLists: AssetListResponse[];
 }
 
 const initialState: InitialState = {
   balanceData: {},
   icons: {},
   homeDomains: {},
+  tokenLists: [],
 };
 
 const balancesSlice = createSlice({
@@ -37,6 +42,7 @@ const balancesSlice = createSlice({
       state.balanceData = {};
       state.icons = {};
       state.homeDomains = {};
+      state.tokenLists = [];
     },
     saveBalancesForAccount(state, action: { payload: SaveBalancesPayload }) {
       state.balanceData = {
@@ -56,6 +62,9 @@ const balancesSlice = createSlice({
         ...action.payload,
       };
     },
+    saveTokenLists(state, action: { payload: SaveTokenLists }) {
+      state.tokenLists = action.payload;
+    },
   },
 });
 
@@ -65,6 +74,8 @@ export const iconsSelector = (state: { balances: InitialState }) =>
   state.balances.icons;
 export const homeDomainsSelector = (state: { balances: InitialState }) =>
   state.balances.homeDomains;
+export const tokensListsSelector = (state: { balances: InitialState }) =>
+  state.balances.tokenLists;
 export const selectBalancesByPublicKey = (publicKey: string) =>
   createSelector(balancesSelector, (balances) => balances[publicKey]);
 
@@ -74,4 +85,5 @@ export const {
   saveBalancesForAccount,
   saveIconsForBalances,
   saveDomainForIssuer,
+  saveTokenLists,
 } = balancesSlice.actions;

--- a/extension/src/popup/ducks/cache.ts
+++ b/extension/src/popup/ducks/cache.ts
@@ -34,7 +34,7 @@ const initialState: InitialState = {
   tokenLists: [],
 };
 
-const balancesSlice = createSlice({
+const cacheSlice = createSlice({
   name: "balances",
   initialState,
   reducers: {
@@ -68,22 +68,22 @@ const balancesSlice = createSlice({
   },
 });
 
-export const balancesSelector = (state: { balances: InitialState }) =>
-  state.balances.balanceData;
-export const iconsSelector = (state: { balances: InitialState }) =>
-  state.balances.icons;
-export const homeDomainsSelector = (state: { balances: InitialState }) =>
-  state.balances.homeDomains;
-export const tokensListsSelector = (state: { balances: InitialState }) =>
-  state.balances.tokenLists;
+export const balancesSelector = (state: { cache: InitialState }) =>
+  state.cache.balanceData;
+export const iconsSelector = (state: { cache: InitialState }) =>
+  state.cache.icons;
+export const homeDomainsSelector = (state: { cache: InitialState }) =>
+  state.cache.homeDomains;
+export const tokensListsSelector = (state: { cache: InitialState }) =>
+  state.cache.tokenLists;
 export const selectBalancesByPublicKey = (publicKey: string) =>
   createSelector(balancesSelector, (balances) => balances[publicKey]);
 
-export const { reducer } = balancesSlice;
+export const { reducer } = cacheSlice;
 export const {
   clearAll,
   saveBalancesForAccount,
   saveIconsForBalances,
   saveDomainForIssuer,
   saveTokenLists,
-} = balancesSlice.actions;
+} = cacheSlice.actions;

--- a/extension/src/popup/views/IntegrationTest.tsx
+++ b/extension/src/popup/views/IntegrationTest.tsx
@@ -251,6 +251,7 @@ export const IntegrationTest = () => {
         balances: testBalances,
         networkDetails: TESTNET_NETWORK_DETAILS,
         assetsListsData: [] as AssetListResponse[],
+        cachedIcons: {},
       });
       runAsserts("getAssetIcons", () => {
         assertEq(Object.keys(res as object).length > 0, true);


### PR DESCRIPTION
Closes #2029 

**What**
Adds a new store slice - cache slice

**Why**
The cache slice is used to cache data that hooks can optionally take advantage of when it makes sense to rely on a cached value, like in later stages of the send/swap flows.

The key difference between this slice and our previous use of keys like `balances` in the transactionSubmission store is that we only cache data in this slice and not state related to the data fetching lifecycle. This allows views to be completely unaware of a cache hit or miss due to the cache lookup happening in the data hooks. Data hooks can be implemented to either take cache params or always try to use a cache key in order improve the time it takes to resolve their data. Wether we have a cache hit or miss, views still go through the same data fetching lifecycles(`IDLE -> LOADING -> SUCCESS|ERROR`).

**Current Cache Keys**

`balanceData` - This is a map of public key to `AccountBalancesInterface`. We can now use this for user balances or when fetching destination balances in flows like send/swap.
`icons` - A map of asset code to icon url. These are expensive to fetch in flows where we need an icon for every asset that a user has at once, like when you are selecting an asset in the send/swap flows.
`homeDomains` - A map of issuers to home domains. These are expensive to fetch in similar situations as the asset icons, we previously had to do a `server.loadAccount` for every issuer in order to resolve their home domains and this happened for every asset in flows like send/swap when a user is selecting an asset.
`tokenLists` - A list of token list responses. We fetch these in several steps of our key flows and some lists resolve faster than others, with some taking several seconds to resolve.

**When to use this cache**
I currently took advantage of this cache in the flows that were most affected by redundant data fetching, which are the send and swap flows.
I did not use the cache on views where a user is more likely to be negatively impacted by stale data like in the main account view.

**TODO**
Some cache keys could be good candidates for persisting longer than 1 session, like the token lists( and maybe home domains?). The cache slice can be updated to use internal APIs to persist data that we decide to cache longer in local storage.