### PR TITLE
Bugfix/sign auth entry return

### DIFF
--- a/@shared/api/external.ts
+++ b/@shared/api/external.ts
@@ -159,6 +159,7 @@ export const submitMessage = async (
 
 export const submitAuthEntry = async (
   entryXdr: string,
+  version: string,
   opts?: {
     address?: string;
     networkPassphrase?: string;
@@ -175,6 +176,7 @@ export const submitAuthEntry = async (
     response = await sendMessageToContentScript({
       entryXdr,
       accountToSign,
+      apiVersion: version,
       networkPassphrase: opts?.networkPassphrase,
       type: EXTERNAL_SERVICE_TYPES.SUBMIT_AUTH_ENTRY,
     });

--- a/@shared/api/types/message-request.ts
+++ b/@shared/api/types/message-request.ts
@@ -33,8 +33,18 @@ export interface EntryToSign {
   networkPassphrase?: string;
 }
 
-export type ResponseQueue = Array<
-  (message?: any, messageAddress?: any) => void
+export type RequestAccessResponse = string;
+export type SignAuthEntryResponse = Buffer | null;
+export type SignTransactionResponse = string;
+export type SignBlobResponse = Buffer | null;
+export type AddTokenResponse = boolean;
+export type SetAllowedStatusResponse = string;
+export type SignedHwPayloadResponse = string | Buffer<ArrayBufferLike>;
+export type RejectAccessResponse = undefined;
+export type RejectTransactionResponse = undefined;
+
+export type ResponseQueue<T> = Array<
+  (message: T, messageAddress?: string) => void
 >;
 
 export type TokenQueue = TokenToAdd[];

--- a/@shared/api/types/types.ts
+++ b/@shared/api/types/types.ts
@@ -147,6 +147,7 @@ export interface ExternalRequestBlob extends ExternalRequestBase {
 }
 
 export interface ExternalRequestAuthEntry extends ExternalRequestBase {
+  apiVersion: string;
   entryXdr: string;
 }
 

--- a/@stellar/freighter-api/package.json
+++ b/@stellar/freighter-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/freighter-api",
-  "version": "4.2.0",
+  "version": "4.1.0",
   "license": "Apache-2.0",
   "author": "Stellar Development Foundation <hello@stellar.org>",
   "description": "Utility functions to interact with Freighter extension",

--- a/@stellar/freighter-api/package.json
+++ b/@stellar/freighter-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/freighter-api",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "license": "Apache-2.0",
   "author": "Stellar Development Foundation <hello@stellar.org>",
   "description": "Utility functions to interact with Freighter extension",

--- a/@stellar/freighter-api/src/signAuthEntry.ts
+++ b/@stellar/freighter-api/src/signAuthEntry.ts
@@ -6,6 +6,7 @@ import {
 import { FreighterApiError } from "@shared/api/types";
 import { FreighterApiNodeError } from "@shared/api/helpers/extensionMessaging";
 import { isBrowser } from ".";
+import packageJson from "../package.json";
 
 export const signAuthEntry = async (
   entryXdr: string,
@@ -28,7 +29,7 @@ export const signAuthEntry = async (
       }
     }
 
-    const req = await submitAuthEntry(entryXdr, opts);
+    const req = await submitAuthEntry(entryXdr, packageJson.version, opts);
 
     if (req.error) {
       return { signedAuthEntry: null, signerAddress: "", error: req.error };

--- a/extension/src/background/messageListener/freighterApiMessageListener.ts
+++ b/extension/src/background/messageListener/freighterApiMessageListener.ts
@@ -431,8 +431,13 @@ export const freighterApiMessageListener = (
 
   const submitAuthEntry = async () => {
     try {
-      const { entryXdr, accountToSign, address, networkPassphrase } =
-        request as ExternalRequestAuthEntry;
+      const {
+        apiVersion,
+        entryXdr,
+        accountToSign,
+        address,
+        networkPassphrase,
+      } = request as ExternalRequestAuthEntry;
 
       const { tab, url: tabUrl = "" } = sender;
       const domain = getUrlHostname(tabUrl);
@@ -474,6 +479,13 @@ export const freighterApiMessageListener = (
         }
         const response = (signedAuthEntry: string) => {
           if (signedAuthEntry) {
+            if (apiVersion && semver.gte(apiVersion, "4.2.0")) {
+              resolve({
+                signedAuthEntry:
+                  Buffer.from(signedAuthEntry).toString("base64"),
+              });
+              return;
+            }
             resolve({ signedAuthEntry });
           }
 

--- a/extension/src/background/messageListener/freighterApiMessageListener.ts
+++ b/extension/src/background/messageListener/freighterApiMessageListener.ts
@@ -10,6 +10,15 @@ import {
   ExternalRequestTx,
   ExternalRequest as Request,
 } from "@shared/api/types";
+import {
+  ResponseQueue,
+  SignTransactionResponse,
+  SignBlobResponse,
+  SignAuthEntryResponse,
+  AddTokenResponse,
+  RequestAccessResponse,
+  SetAllowedStatusResponse,
+} from "@shared/api/types/message-request";
 import { stellarSdkServer } from "@shared/api/helpers/stellarSdkServer";
 import {
   FreighterApiInternalError,
@@ -118,7 +127,7 @@ export const freighterApiMessageListener = (
         });
       };
 
-      responseQueue.push(response);
+      (responseQueue as ResponseQueue<RequestAccessResponse>).push(response);
     });
   };
 
@@ -201,7 +210,7 @@ export const freighterApiMessageListener = (
           });
         };
 
-        responseQueue.push(response);
+        (responseQueue as ResponseQueue<AddTokenResponse>).push(response);
       });
     } catch (e) {
       return {
@@ -334,7 +343,10 @@ export const freighterApiMessageListener = (
             }),
           );
         }
-        const response = (signedTransaction: string, signerAddress: string) => {
+        const response = (
+          signedTransaction: string,
+          signerAddress?: string,
+        ) => {
           if (signedTransaction) {
             resolve({ signedTransaction, signerAddress });
           }
@@ -346,7 +358,9 @@ export const freighterApiMessageListener = (
           });
         };
 
-        responseQueue.push(response);
+        (responseQueue as ResponseQueue<SignTransactionResponse>).push(
+          response,
+        );
       });
     } catch (e) {
       return {
@@ -399,7 +413,10 @@ export const freighterApiMessageListener = (
           );
         }
 
-        const response = (signedBlob: string, signerAddress: string) => {
+        const response = (
+          signedBlob: SignBlobResponse,
+          signerAddress?: string,
+        ) => {
           if (signedBlob) {
             if (apiVersion && semver.gte(apiVersion, "4.0.0")) {
               resolve({
@@ -418,7 +435,7 @@ export const freighterApiMessageListener = (
           });
         };
 
-        responseQueue.push(response);
+        (responseQueue as ResponseQueue<SignBlobResponse>).push(response);
       });
     } catch (e) {
       return {
@@ -477,16 +494,20 @@ export const freighterApiMessageListener = (
             }),
           );
         }
-        const response = (signedAuthEntry: string) => {
+        const response = (
+          signedAuthEntry: SignAuthEntryResponse,
+          signerAddress?: string,
+        ) => {
           if (signedAuthEntry) {
             if (apiVersion && semver.gte(apiVersion, "4.2.0")) {
               resolve({
                 signedAuthEntry:
                   Buffer.from(signedAuthEntry).toString("base64"),
+                signerAddress,
               });
               return;
             }
-            resolve({ signedAuthEntry });
+            resolve({ signedAuthEntry, signerAddress });
           }
 
           resolve({
@@ -495,8 +516,7 @@ export const freighterApiMessageListener = (
             error: FreighterApiDeclinedError.message,
           });
         };
-
-        responseQueue.push(response);
+        (responseQueue as ResponseQueue<SignAuthEntryResponse>).push(response);
       });
     } catch (e) {
       return {
@@ -615,7 +635,7 @@ export const freighterApiMessageListener = (
         });
       };
 
-      responseQueue.push(response);
+      (responseQueue as ResponseQueue<SetAllowedStatusResponse>).push(response);
     });
   };
 

--- a/extension/src/background/messageListener/handlers/addToken.ts
+++ b/extension/src/background/messageListener/handlers/addToken.ts
@@ -1,6 +1,10 @@
 import { Store } from "redux";
 
-import { ResponseQueue, TokenQueue } from "@shared/api/types/message-request";
+import {
+  AddTokenResponse,
+  ResponseQueue,
+  TokenQueue,
+} from "@shared/api/types/message-request";
 import { publicKeySelector } from "background/ducks/session";
 import { getNetworkDetails } from "background/helpers/account";
 import { addTokenWithContractId } from "../helpers/add-token-contract-id";
@@ -15,7 +19,7 @@ export const addToken = async ({
   localStore: DataStorageAccess;
   sessionStore: Store;
   tokenQueue: TokenQueue;
-  responseQueue: ResponseQueue;
+  responseQueue: ResponseQueue<AddTokenResponse>;
 }) => {
   const publicKey = publicKeySelector(sessionStore.getState());
   const networkDetails = await getNetworkDetails({ localStore });

--- a/extension/src/background/messageListener/handlers/grantAccess.ts
+++ b/extension/src/background/messageListener/handlers/grantAccess.ts
@@ -2,6 +2,7 @@ import { Store } from "redux";
 
 import {
   GrantAccessMessage,
+  RequestAccessResponse,
   ResponseQueue,
 } from "@shared/api/types/message-request";
 import { publicKeySelector } from "background/ducks/session";
@@ -20,7 +21,7 @@ export const grantAccess = async ({
 }: {
   request: GrantAccessMessage;
   sessionStore: Store;
-  responseQueue: ResponseQueue;
+  responseQueue: ResponseQueue<RequestAccessResponse>;
   localStore: DataStorageAccess;
 }) => {
   const { url = "" } = request;

--- a/extension/src/background/messageListener/handlers/handleSignedHwPayload.ts
+++ b/extension/src/background/messageListener/handlers/handleSignedHwPayload.ts
@@ -1,6 +1,7 @@
 import {
   HandleSignedHWPayloadMessage,
   ResponseQueue,
+  SignedHwPayloadResponse,
 } from "@shared/api/types/message-request";
 
 export const handleSignedHwPayload = ({
@@ -8,7 +9,7 @@ export const handleSignedHwPayload = ({
   responseQueue,
 }: {
   request: HandleSignedHWPayloadMessage;
-  responseQueue: ResponseQueue;
+  responseQueue: ResponseQueue<SignedHwPayloadResponse>;
 }) => {
   const { signedPayload } = request;
 

--- a/extension/src/background/messageListener/handlers/rejectAccess.ts
+++ b/extension/src/background/messageListener/handlers/rejectAccess.ts
@@ -1,12 +1,15 @@
-import { ResponseQueue } from "@shared/api/types/message-request";
+import {
+  ResponseQueue,
+  RejectAccessResponse,
+} from "@shared/api/types/message-request";
 
 export const rejectAccess = ({
   responseQueue,
 }: {
-  responseQueue: ResponseQueue;
+  responseQueue: ResponseQueue<RejectAccessResponse>;
 }) => {
   const response = responseQueue.pop();
   if (response) {
-    response();
+    response(undefined);
   }
 };

--- a/extension/src/background/messageListener/handlers/rejectTransaction.ts
+++ b/extension/src/background/messageListener/handlers/rejectTransaction.ts
@@ -1,6 +1,7 @@
 import {
   ResponseQueue,
   TransactionQueue,
+  RejectTransactionResponse,
 } from "@shared/api/types/message-request";
 
 export const rejectTransaction = ({
@@ -8,11 +9,11 @@ export const rejectTransaction = ({
   responseQueue,
 }: {
   transactionQueue: TransactionQueue;
-  responseQueue: ResponseQueue;
+  responseQueue: ResponseQueue<RejectTransactionResponse>;
 }) => {
   transactionQueue.pop();
   const response = responseQueue.pop();
   if (response) {
-    response();
+    response(undefined);
   }
 };

--- a/extension/src/background/messageListener/handlers/signAuthEntry.ts
+++ b/extension/src/background/messageListener/handlers/signAuthEntry.ts
@@ -6,7 +6,11 @@ import { getEncryptedTemporaryData } from "background/helpers/session";
 import { KEY_ID } from "constants/localStorageTypes";
 import { getNetworkDetails } from "background/helpers/account";
 import { getSdk } from "@shared/helpers/stellar";
-import { EntryQueue, ResponseQueue } from "@shared/api/types/message-request";
+import {
+  EntryQueue,
+  ResponseQueue,
+  SignAuthEntryResponse,
+} from "@shared/api/types/message-request";
 
 export const signAuthEntry = async ({
   localStore,
@@ -17,7 +21,7 @@ export const signAuthEntry = async ({
   localStore: DataStorageAccess;
   sessionStore: Store;
   authEntryQueue: EntryQueue;
-  responseQueue: ResponseQueue;
+  responseQueue: ResponseQueue<SignAuthEntryResponse>;
 }) => {
   const keyId = (await localStore.getItem(KEY_ID)) || "";
   let privateKey = "";

--- a/extension/src/background/messageListener/handlers/signBlob.ts
+++ b/extension/src/background/messageListener/handlers/signBlob.ts
@@ -6,7 +6,11 @@ import { KEY_ID } from "constants/localStorageTypes";
 import { captureException } from "@sentry/browser";
 import { getNetworkDetails } from "background/helpers/account";
 import { getSdk } from "@shared/helpers/stellar";
-import { BlobQueue, ResponseQueue } from "@shared/api/types/message-request";
+import {
+  BlobQueue,
+  ResponseQueue,
+  SignBlobResponse,
+} from "@shared/api/types/message-request";
 
 export const signBlob = async ({
   localStore,
@@ -17,7 +21,7 @@ export const signBlob = async ({
   localStore: DataStorageAccess;
   sessionStore: Store;
   blobQueue: BlobQueue;
-  responseQueue: ResponseQueue;
+  responseQueue: ResponseQueue<SignBlobResponse>;
 }) => {
   const keyId = (await localStore.getItem(KEY_ID)) || "";
   let privateKey = "";

--- a/extension/src/background/messageListener/handlers/signTransaction.ts
+++ b/extension/src/background/messageListener/handlers/signTransaction.ts
@@ -9,6 +9,7 @@ import { getSdk } from "@shared/helpers/stellar";
 import {
   ResponseQueue,
   TransactionQueue,
+  SignTransactionResponse,
 } from "@shared/api/types/message-request";
 
 export const signTransaction = async ({
@@ -20,7 +21,7 @@ export const signTransaction = async ({
   localStore: DataStorageAccess;
   sessionStore: Store;
   transactionQueue: TransactionQueue;
-  responseQueue: ResponseQueue;
+  responseQueue: ResponseQueue<SignTransactionResponse>;
 }) => {
   const keyId = (await localStore.getItem(KEY_ID)) || "";
   let privateKey = "";
@@ -44,7 +45,7 @@ export const signTransaction = async ({
   if (privateKey.length) {
     const sourceKeys = Sdk.Keypair.fromSecret(privateKey);
 
-    let response;
+    let response = "";
 
     const transactionToSign = transactionQueue.pop();
 

--- a/extension/src/background/messageListener/popupMessageListener.ts
+++ b/extension/src/background/messageListener/popupMessageListener.ts
@@ -3,6 +3,15 @@ import {
   ResponseQueue,
   ServiceMessageRequest,
   TransactionQueue,
+  SignTransactionResponse,
+  SignBlobResponse,
+  SignAuthEntryResponse,
+  AddTokenResponse,
+  RequestAccessResponse,
+  SetAllowedStatusResponse,
+  RejectAccessResponse,
+  RejectTransactionResponse,
+  SignedHwPayloadResponse,
 } from "@shared/api/types/message-request";
 import { SERVICE_TYPES } from "@shared/constants/services";
 import { DataStorageAccess } from "background/helpers/dataStorageAccess";
@@ -66,7 +75,17 @@ import { getHiddenAssets } from "./handlers/getHiddenAssets";
 
 const numOfPublicKeysToCheck = 5;
 
-export const responseQueue: ResponseQueue = [];
+export const responseQueue: ResponseQueue<
+  | RequestAccessResponse
+  | SignTransactionResponse
+  | SignBlobResponse
+  | SignAuthEntryResponse
+  | AddTokenResponse
+  | SetAllowedStatusResponse
+  | RejectAccessResponse
+  | RejectTransactionResponse
+  | SignedHwPayloadResponse
+> = [];
 export const transactionQueue: TransactionQueue = [];
 export const tokenQueue: TokenToAdd[] = [];
 export const blobQueue: MessageToSign[] = [];


### PR DESCRIPTION
Closes #1960 

Similar to our incremental upgrade to signMessage, I'm branching logic based on the API version. This ensures devs using older versions of freighter-api won't have their UX broken by this change.

In addition, I'm adding some better typing for the response queue. It's not the cleanest; I had to do some casting as I ran into some issues because of how different some of the responses are. This is at least a bit more informative than the `any` typing we were using before