### PR TITLE
make sure to close request access window when chaining api methods

### DIFF
--- a/@stellar/freighter-api/package.json
+++ b/@stellar/freighter-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/freighter-api",
-  "version": "4.2.0",
+  "version": "4.1.0",
   "license": "Apache-2.0",
   "author": "Stellar Development Foundation <hello@stellar.org>",
   "description": "Utility functions to interact with Freighter extension",

--- a/@stellar/freighter-api/package.json
+++ b/@stellar/freighter-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/freighter-api",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "license": "Apache-2.0",
   "author": "Stellar Development Foundation <hello@stellar.org>",
   "description": "Utility functions to interact with Freighter extension",


### PR DESCRIPTION
A small bug I noticed while testing #1843 and #1960

In this next version of freighter-api (unreleased), to aid users who are trying to sign a tx, but haven't added the dapp to "connected apps", we will first display the `Grant Access` modal. If the user says yes, we will then show the Sign modal they were intending to sign.

I noticed a bug where there was sometimes a race condition where opting in to Grant Access (and subsequently dismissing that modal) would inadvertently trigger this logic in the following Sign modal before the user could sign the tx: https://github.com/stellar/freighter/blob/master/extension/src/background/messageListener/freighterApiMessageListener.ts#L329

This bugfix makes sure the Grant Access has properly closed before moving onto the show the Sign modal