### PR TITLE
[FEATURE] Adds Contract Addresses to Recent Addresses

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -1324,14 +1324,14 @@ export const submitFreighterSorobanTransaction = async ({
 
 export const addRecentAddress = async ({
   activePublicKey,
-  publicKey,
+  address,
 }: {
   activePublicKey: string;
-  publicKey: string;
+  address: string;
 }): Promise<{ recentAddresses: Array<string> }> => {
   return await sendMessageToBackground({
     activePublicKey,
-    publicKey,
+    address,
     type: SERVICE_TYPES.ADD_RECENT_ADDRESS,
   });
 };

--- a/@shared/api/types/message-request.ts
+++ b/@shared/api/types/message-request.ts
@@ -208,7 +208,7 @@ export interface SignFreighterSorobanTransactionMessage extends BaseMessage {
 
 export interface AddRecentAddressMessage extends BaseMessage {
   type: SERVICE_TYPES.ADD_RECENT_ADDRESS;
-  publicKey: string;
+  address: string;
 }
 
 export interface LoadRecentAddressesMessage extends BaseMessage {

--- a/extension/src/background/messageListener/handlers/addRecentAddress.ts
+++ b/extension/src/background/messageListener/handlers/addRecentAddress.ts
@@ -9,11 +9,11 @@ export const addRecentAddress = async ({
   request: AddRecentAddressMessage;
   localStore: DataStorageAccess;
 }) => {
-  const { publicKey } = request;
+  const { address } = request;
   const storedData = (await localStore.getItem(RECENT_ADDRESSES)) || [];
   const recentAddresses = storedData;
-  if (recentAddresses.indexOf(publicKey) === -1) {
-    recentAddresses.push(publicKey);
+  if (recentAddresses.indexOf(address) === -1) {
+    recentAddresses.push(address);
   }
   await localStore.setItem(RECENT_ADDRESSES, recentAddresses);
 

--- a/extension/src/popup/components/hardwareConnect/HardwareSign/index.tsx
+++ b/extension/src/popup/components/hardwareConnect/HardwareSign/index.tsx
@@ -104,7 +104,7 @@ export const HardwareSign = ({
             submitFreighterTransaction.fulfilled.match(submitResp) &&
             !isSwap
           ) {
-            dispatch(addRecentAddress({ publicKey: destination }));
+            dispatch(addRecentAddress({ address: destination }));
           }
         } else {
           // right now there are only two cases after signing,

--- a/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendConfirm/TransactionDetails/index.tsx
@@ -266,9 +266,10 @@ export const TransactionDetails = ({
         );
 
         if (submitFreighterSorobanTransaction.fulfilled.match(submitResp)) {
-          emitMetric(METRIC_NAMES.sendPaymentSuccess, {
-            sourceAsset: sourceAsset.code,
-          });
+          addRecentAddress({ address: destination }),
+            emitMetric(METRIC_NAMES.sendPaymentSuccess, {
+              sourceAsset: sourceAsset.code,
+            });
 
           if (isSoroswap && destAsset.issuer) {
             await dispatch(
@@ -319,7 +320,7 @@ export const TransactionDetails = ({
         if (submitFreighterTransaction.fulfilled.match(submitResp)) {
           if (!isSwap) {
             await dispatch(
-              addRecentAddress({ publicKey: federationAddress || destination }),
+              addRecentAddress({ address: federationAddress || destination }),
             );
           }
           if (isPathPayment) {

--- a/extension/src/popup/components/sendPayment/SendTo/hooks/useSendToData.tsx
+++ b/extension/src/popup/components/sendPayment/SendTo/hooks/useSendToData.tsx
@@ -127,7 +127,7 @@ function useSendToData() {
     const { networkDetails } = appData.settings;
     const _isMainnet = isMainnet(networkDetails);
 
-    if (Object.keys(errors).length !== 0) {
+    if (Object.keys(errors).length !== 0 && userInput) {
       const payload = {
         type: AppDataType.RESOLVED,
         recentAddresses: [],

--- a/extension/src/popup/ducks/transactionSubmission.ts
+++ b/extension/src/popup/ducks/transactionSubmission.ts
@@ -282,13 +282,13 @@ export const signWithHardwareWallet = createAsyncThunk<
 
 export const addRecentAddress = createAsyncThunk<
   { recentAddresses: string[] },
-  { publicKey: string },
+  { address: string },
   { rejectValue: ErrorMessage; state: AppState }
->("addRecentAddress", async ({ publicKey }, { getState, rejectWithValue }) => {
+>("addRecentAddress", async ({ address }, { getState, rejectWithValue }) => {
   const activePublicKey = publicKeySelector(getState());
 
   try {
-    return await internalAddRecentAddress({ activePublicKey, publicKey });
+    return await internalAddRecentAddress({ activePublicKey, address });
   } catch (e) {
     const message = e instanceof Error ? e.message : JSON.stringify(e);
     return rejectWithValue({ errorMessage: message });

--- a/extension/src/popup/views/IntegrationTest.tsx
+++ b/extension/src/popup/views/IntegrationTest.tsx
@@ -303,7 +303,7 @@ export const IntegrationTest = () => {
 
       res = await addRecentAddress({
         activePublicKey: "G123",
-        publicKey: testPublicKey,
+        address: testPublicKey,
       });
       runAsserts("addRecentAddress", () => {
         assertArray(res.recentAddresses);


### PR DESCRIPTION
Closes #1774 

What
Adds contract addresses to recent addresses when they are part of a successfull send as the destination.
Fixes initial lookup for recent addresses on load of the Send To component.

Why
They are currently missing from recent addresses