### PR TITLE
Bugfix/update discord link

### DIFF
--- a/extension/src/popup/views/LeaveFeedback/index.tsx
+++ b/extension/src/popup/views/LeaveFeedback/index.tsx
@@ -18,7 +18,7 @@ export const LeaveFeedback = () => {
         <ListNavLinkWrapper>
           <ListNavLink
             icon={<Icon.Link01 />}
-            href="https://discord.com/channels/897514728459468821/1019346446014759013"
+            href="https://discord.gg/zcdNVJUYqN"
           >
             {t("Join community Discord")}
           </ListNavLink>


### PR DESCRIPTION
Closes #2066 

Fixes an issue on Discord's side where non-members of the Stellar server were being redirected to an unusable page instead of the #wallets channel in Discord