### PR TITLE
use prod BE for all routes except Discover endpoint

### DIFF
--- a/.github/workflows/runSnapshots.yml
+++ b/.github/workflows/runSnapshots.yml
@@ -1,6 +1,7 @@
 name: Run Snapshots
 env:
   INDEXER_URL: ${{ secrets.INDEXER_URL }}
+  INDEXER_V2_URL: ${{ secrets.INDEXER_BETA_URL }}
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -1,6 +1,7 @@
 name: Run Tests
 env:
   INDEXER_URL: ${{ secrets.INDEXER_URL }}
+  INDEXER_V2_URL: ${{ secrets.INDEXER_BETA_URL }}
 on: [pull_request]
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/submitBeta.yml
+++ b/.github/workflows/submitBeta.yml
@@ -1,6 +1,7 @@
 name: Beta Deployment
 env:
   INDEXER_URL: ${{ secrets.INDEXER_URL }}
+  INDEXER_V2_URL: ${{ secrets.INDEXER_BETA_URL }}
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/submitBeta.yml
+++ b/.github/workflows/submitBeta.yml
@@ -1,6 +1,6 @@
 name: Beta Deployment
 env:
-  INDEXER_URL: ${{ secrets.INDEXER_BETA_URL }}
+  INDEXER_URL: ${{ secrets.INDEXER_URL }}
 on:
   workflow_dispatch:
     inputs:

--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -605,18 +605,23 @@ export const getTokenPrices = async (tokens: string[]) => {
 };
 
 export const getDiscoverData = async () => {
-  const url = new URL(`${INDEXER_URL}/protocols`);
+  const url = new URL(
+    "https://freighter-backend-v2-stg.stellar.org/api/v1/protocols",
+  );
   const response = await fetch(url.href);
   const parsedResponse = (await response.json()) as {
     data: {
-      description: string;
-      icon_url: string;
-      name: string;
-      website_url: string;
-      tags: string[];
-      is_blacklisted: boolean;
-    }[];
+      protocols: {
+        description: string;
+        icon_url: string;
+        name: string;
+        website_url: string;
+        tags: string[];
+        is_blacklisted: boolean;
+      }[];
+    };
   };
+
   if (!response.ok || !parsedResponse.data) {
     const _err = JSON.stringify(parsedResponse);
     captureException(
@@ -625,7 +630,7 @@ export const getDiscoverData = async () => {
     throw new Error(_err);
   }
 
-  return parsedResponse.data.map((entry) => ({
+  return parsedResponse.data.protocols.map((entry) => ({
     description: entry.description,
     iconUrl: entry.icon_url,
     name: entry.name,

--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -11,7 +11,7 @@ import {
   XdrLargeInt,
 } from "stellar-sdk";
 import BigNumber from "bignumber.js";
-import { INDEXER_URL } from "@shared/constants/mercury";
+import { INDEXER_URL, INDEXER_V2_URL } from "@shared/constants/mercury";
 import {
   AssetListResponse,
   AssetsListItem,
@@ -605,9 +605,7 @@ export const getTokenPrices = async (tokens: string[]) => {
 };
 
 export const getDiscoverData = async () => {
-  const url = new URL(
-    "https://freighter-backend-v2-stg.stellar.org/api/v1/protocols",
-  );
+  const url = new URL(`${INDEXER_V2_URL}/protocols`);
   const response = await fetch(url.href);
   const parsedResponse = (await response.json()) as {
     data: {

--- a/@shared/constants/mercury.ts
+++ b/@shared/constants/mercury.ts
@@ -1,1 +1,2 @@
 export const INDEXER_URL = process.env.INDEXER_URL;
+export const INDEXER_V2_URL = process.env.INDEXER_V2_URL;

--- a/extension/e2e-tests/helpers/sendPayment.ts
+++ b/extension/e2e-tests/helpers/sendPayment.ts
@@ -40,7 +40,7 @@ export const sendXlmPayment = async ({ page }) => {
       mask: [page.locator("[data-testid='SendSettingsTransactionFee']")],
     },
   );
-  await page.getByText("Review Send").click({ force: true });
+  await page.getByText("Review Send").click();
 
   await expect(page.getByText("Confirm Send")).toBeVisible();
   await expect(page.getByText("XDR")).toBeVisible();
@@ -48,7 +48,7 @@ export const sendXlmPayment = async ({ page }) => {
     page,
     screenshot: "send-payment-confirm.png",
   });
-  await page.getByTestId("transaction-details-btn-send").click({ force: true });
+  await page.getByTestId("transaction-details-btn-send").click();
 
   await expect(page.getByText("Successfully sent")).toBeVisible({
     timeout: 60000,

--- a/extension/e2e-tests/sendPayment.test.ts
+++ b/extension/e2e-tests/sendPayment.test.ts
@@ -467,10 +467,10 @@ test("Send token payment to C address", async ({ page, extensionId }) => {
 
   await expect(page.getByText("Send Settings")).toBeVisible();
   await expect(page.getByText("Review Send")).toBeEnabled();
-  await page.getByText("Review Send").click({ force: true });
+  await page.getByText("Review Send").click();
 
   await expect(page.getByText("Confirm Send")).toBeVisible();
-  await page.getByTestId("transaction-details-btn-send").click({ force: true });
+  await page.getByTestId("transaction-details-btn-send").click();
 
   await expect(page.getByText("Successfully sent")).toBeVisible({
     timeout: 600000,


### PR DESCRIPTION
Because the v2 BE only has the Discover endpoint, we need to rely on the v1 BE for all the endpoint except for Discover. Here we're injecting a second env var for the v2 URL