### PR TITLE
add indexer v2 url to beta pipeline

### DIFF
--- a/.github/workflows/submitBeta.yml
+++ b/.github/workflows/submitBeta.yml
@@ -1,6 +1,7 @@
 name: Beta Deployment
 env:
   INDEXER_URL: ${{ secrets.INDEXER_URL }}
+  INDEXER_V2_URL: ${{ secrets.INDEXER_BETA_URL }}
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Adding INDEXER_V2_URL on master directly because GitHub actions won't pick up the pipeline from the release branch. We'll need to add this to master in order to deploy the release branch to beta
