### PR TITLE
[BUG] Only navigate away from password page on succcess

### DIFF
--- a/extension/e2e-tests/login.test.ts
+++ b/extension/e2e-tests/login.test.ts
@@ -1,0 +1,16 @@
+import { loginToTestAccount } from "./helpers/login";
+import { test, expect } from "./test-fixtures";
+
+test("Login shows error state on bad password", async ({
+  page,
+  extensionId,
+}) => {
+  test.slow();
+  await loginToTestAccount({ page, extensionId });
+  await page.getByTestId("BottomNav-link-settings").click();
+  await page.getByText("Log Out").click();
+  await expect(page.getByText("Welcome back!")).toBeVisible();
+  await page.locator("#password-input").fill("wrong");
+  await page.getByText("Login").click();
+  await expect(page.getByText("Incorrect Password")).toBeVisible();
+});

--- a/extension/src/popup/views/UnlockAccount/index.tsx
+++ b/extension/src/popup/views/UnlockAccount/index.tsx
@@ -32,9 +32,11 @@ export const UnlockAccount = () => {
   const dispatch = useDispatch<AppDispatch>();
 
   const handleSubmit = async (password: string) => {
-    await dispatch(confirmPassword(password));
-    // skip this location in history, we won't need to come back here after unlocking account
-    navigate(`${destination}${queryParams}`, { replace: true });
+    const res = await dispatch(confirmPassword(password));
+    if (confirmPassword.fulfilled.match(res) && res.payload.publicKey) {
+      // skip this location in history, we won't need to come back here after unlocking account
+      navigate(`${destination}${queryParams}`, { replace: true });
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
What
Only navigates away from password prompt on success 

Why
Password submission always navigated away causing a refresh on bad password attempts