### PR TITLE
fix issue with sending to a recent federated address

### DIFF
--- a/extension/e2e-tests/sendPayment.test.ts
+++ b/extension/e2e-tests/sendPayment.test.ts
@@ -197,6 +197,71 @@ test("Send doesn't throw error when account is unfunded", async ({
   );
 });
 
+test("Send XLM payments to recent federated addresses", async ({
+  page,
+  extensionId,
+}) => {
+  test.slow();
+  await loginToTestAccount({ page, extensionId });
+  await page.getByTitle("Send Payment").click({ force: true });
+
+  await expect(page.getByText("Send To")).toBeVisible();
+
+  await page.getByTestId("send-to-input").fill("freighter.pb*lobstr.co");
+  await expect(page.getByTestId("send-to-identicon")).toBeVisible();
+  await page.getByText("Continue").click({ force: true });
+
+  await expect(page.getByText("Send XLM")).toBeVisible();
+  await page.getByTestId("send-amount-amount-input").fill("1");
+  await page.getByText("Continue").click({ force: true });
+
+  await expect(page.getByText("Send Settings")).toBeVisible();
+  await expect(page.getByTestId("SendSettingsTransactionFee")).toHaveText(
+    /[0-9]/,
+  );
+  // 100 XLM is the default, so likely a sign the fee was not set properly from Horizon
+  await expect(
+    page.getByTestId("SendSettingsTransactionFee"),
+  ).not.toContainText("100 XLM");
+  await page.getByText("Review Send").click();
+
+  await expect(page.getByText("Confirm Send")).toBeVisible();
+  await expect(page.getByText("XDR")).toBeVisible();
+  await page.getByTestId("transaction-details-btn-send").click();
+
+  await expect(page.getByText("Successfully sent")).toBeVisible({
+    timeout: 60000,
+  });
+
+  await page.getByText("Done").click();
+
+  await page.getByTitle("Send Payment").click();
+
+  await expect(page.getByText("Send To")).toBeVisible();
+  await expect(page.getByText("RECENT")).toBeVisible();
+  await page.getByTestId("recent-address-button").click();
+  await page.getByText("Continue").click({ force: true });
+
+  await expect(page.getByText("Send XLM")).toBeVisible();
+  await page.getByTestId("send-amount-amount-input").fill("1");
+  await page.getByText("Continue").click({ force: true });
+
+  await expect(page.getByText("Send Settings")).toBeVisible();
+  await expect(page.getByTestId("SendSettingsTransactionFee")).toHaveText(
+    /[0-9]/,
+  );
+  // 100 XLM is the default, so likely a sign the fee was not set properly from Horizon
+  await expect(
+    page.getByTestId("SendSettingsTransactionFee"),
+  ).not.toContainText("100 XLM");
+  await page.getByText("Review Send").click();
+  await expect(page.getByText("Confirm Send")).toBeVisible();
+  await page.getByTestId("transaction-details-btn-send").click();
+  await expect(page.getByText("Successfully sent")).toBeVisible({
+    timeout: 60000,
+  });
+});
+
 test("Send XLM payments from multiple accounts to G Address", async ({
   page,
   extensionId,

--- a/extension/src/popup/components/sendPayment/SendTo/hooks/useSendToData.tsx
+++ b/extension/src/popup/components/sendPayment/SendTo/hooks/useSendToData.tsx
@@ -30,7 +30,7 @@ interface ResolvedSendToData {
 
 type SendToData = NeedsReRoute | ResolvedSendToData;
 
-const getAddressFromInput = async (userInput: string) => {
+export const getAddressFromInput = async (userInput: string) => {
   if (isFederationAddress(userInput)) {
     const fedResp = await Federation.Server.resolve(userInput);
     return {

--- a/extension/src/popup/components/sendPayment/SendTo/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendTo/index.tsx
@@ -30,14 +30,15 @@ import {
 } from "popup/ducks/transactionSubmission";
 
 import { RequestState } from "constants/request";
-import { useSendToData } from "./hooks/useSendToData";
+import { useSendToData, getAddressFromInput } from "./hooks/useSendToData";
 
-import "../styles.scss";
 import { openTab } from "popup/helpers/navigate";
 import { newTabHref } from "helpers/urls";
 import { Navigate, useLocation } from "react-router-dom";
 import { AppDataType } from "helpers/hooks/useGetAppData";
 import { reRouteOnboarding } from "popup/helpers/route";
+
+import "../styles.scss";
 
 const baseReserve = new BigNumber(1);
 
@@ -229,10 +230,16 @@ export const SendTo = ({
                       {sendDataState.data!.recentAddresses.map((address) => (
                         <li key={address}>
                           <button
+                            data-testid="recent-address-button"
                             onClick={async () => {
+                              const addressFromInput =
+                                await getAddressFromInput(address);
                               emitMetric(METRIC_NAMES.sendPaymentRecentAddress);
                               await fetchData(address, {});
-                              handleContinue(address);
+                              handleContinue(
+                                addressFromInput.validatedAddress,
+                                addressFromInput.fedAddress,
+                              );
                             }}
                             className="SendTo__subheading-identicon"
                           >
@@ -267,7 +274,10 @@ export const SendTo = ({
                         </>
                       )}
                       <div className="SendTo__subheading">Address</div>
-                      <div className="SendTo__subheading-identicon">
+                      <div
+                        className="SendTo__subheading-identicon"
+                        data-testid="send-to-identicon"
+                      >
                         <IdenticonImg
                           publicKey={sendDataState.data!.validatedAddress}
                         />


### PR DESCRIPTION
Closes #2078 

Fixes an issue with trying to send to a recent federated address and the Transaction Details not properly parsing the base address