### PR TITLE
early exit GHA if missing configurations

### DIFF
--- a/.github/workflows/submitBeta.yml
+++ b/.github/workflows/submitBeta.yml
@@ -18,6 +18,16 @@ jobs:
     name: Bump Package Version and Submit Extension
     runs-on: ubuntu-latest
     steps:
+      - if: ${{ env.INDEXER_URL == '' }}
+        run: |
+          echo "Missing INDEXER_URL"
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
+      - if: ${{ env.INDEXER_V2_URL == '' }}
+        run: |
+          echo "Missing INDEXER_V2_URL"
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/submitProduction.yml
+++ b/.github/workflows/submitProduction.yml
@@ -15,6 +15,16 @@ jobs:
     name: Bump Package Version and Submit Extension
     runs-on: ubuntu-latest
     steps:
+      - if: ${{ env.INDEXER_URL == '' }}
+        run: |
+          echo "Missing INDEXER_URL"
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
+      - if: ${{ env.INDEXER_V2_URL == '' }}
+        run: |
+          echo "Missing INDEXER_V2_URL"
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Update package.json version


### PR DESCRIPTION
Related to #2071 

Since ops sets these values for us. we don't have a great way to validate that we have the correct secrets set before the extension is packaged and sent off to the store. We could conceivably get into a situation where the url's are set incorrectly.

This check will at least make sure that the url's are set before building