### PR TITLE
don't show info for non-XLM assets

### DIFF
--- a/extension/src/popup/components/sendPayment/SendAmount/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/index.tsx
@@ -583,16 +583,18 @@ export const SendAmount = ({
             </span>
           }
           subtitle={
-            <div className="SendAmount__subtitle">
-              <InfoTooltip
-                infoText={t(
-                  "The amount of XLM not reserved or needed for fees. This number may be lower than your total balance.",
-                )}
-                placement="bottom-end"
-              >
-                {`${formatAmount(availBalance)} ${parsedSourceAsset.code} ${t("available")}`}
-              </InfoTooltip>
-            </div>
+            asset === "native" ? (
+              <div className="SendAmount__subtitle">
+                <InfoTooltip
+                  infoText={t(
+                    "The amount of XLM not reserved or needed for fees. This number may be lower than your total balance.",
+                  )}
+                  placement="bottom-end"
+                >
+                  {`${formatAmount(availBalance)} ${parsedSourceAsset.code} ${t("available")}`}
+                </InfoTooltip>
+              </div>
+            ) : null
           }
           hasBackButton={!isSwap}
           customBackAction={() => {


### PR DESCRIPTION
Don't show info tooltip for non-xlm assets

<img width="358" alt="Screenshot 2025-05-27 at 12 36 27 PM" src="https://github.com/user-attachments/assets/20bed4f1-fbec-4d00-9169-09052aece159" />
<img width="361" alt="Screenshot 2025-05-27 at 12 36 36 PM" src="https://github.com/user-attachments/assets/4aeba20a-94c9-403c-89e5-4f6a1b38daae" />
