### PR TITLE
[BUG] avoids debouncing action when there is no user input

### DIFF
--- a/extension/src/popup/components/sendPayment/SendSettings/Settings/hooks/useGetSettingsData.tsx
+++ b/extension/src/popup/components/sendPayment/SendSettings/Settings/hooks/useGetSettingsData.tsx
@@ -194,6 +194,7 @@ function useGetSettingsData(
         publicKey,
         balanceOptions.isMainnet,
         networkDetails,
+        true,
       );
 
       if (isError<AccountBalances>(balancesResult)) {

--- a/extension/src/popup/components/sendPayment/SendTo/hooks/useSendToData.tsx
+++ b/extension/src/popup/components/sendPayment/SendTo/hooks/useSendToData.tsx
@@ -141,13 +141,30 @@ function useSendToData() {
       return payload;
     }
 
-    return debouncedFetch(
-      userInput,
-      publicKey,
+    if (userInput) {
+      return debouncedFetch(
+        userInput,
+        publicKey,
+        applicationState,
+        networkDetails,
+        _isMainnet,
+      );
+    }
+    const { recentAddresses } = await loadRecentAddresses({
+      activePublicKey: publicKey,
+    });
+
+    const payload = {
+      type: AppDataType.RESOLVED,
+      recentAddresses,
+      validatedAddress: "",
+      fedAddress: "",
       applicationState,
+      publicKey,
       networkDetails,
-      _isMainnet,
-    );
+    } as ResolvedSendToData;
+    dispatch({ type: "FETCH_DATA_SUCCESS", payload });
+    return payload;
   };
 
   return {


### PR DESCRIPTION
What
Avoids debouncing action in our SendTo component when there is no user input.

Why
The action was being debounced in every case, which meant that on load the loading time had to wait for the length of the debounce to load recent addresses, even though there would never be a destination address to use to look up balances.
This makes recent addresses and initial loading time of the SendTo component instant, in the 1-5ms range.


https://github.com/user-attachments/assets/e4f87256-a7e4-4302-9ee2-a12b42b09138

