### PR TITLE
if creating muxed account extract G address before creating operation

### DIFF
--- a/extension/e2e-tests/sendPayment.test.ts
+++ b/extension/e2e-tests/sendPayment.test.ts
@@ -201,7 +201,7 @@ test("Send doesn't throw error when creating muxed account", async ({
   extensionId,
 }) => {
   test.slow();
-  await login({ page, extensionId });
+  await loginAndFund({ page, extensionId });
   await page.getByTitle("Send Payment").click({ force: true });
 
   await expect(page.getByText("Send To")).toBeVisible();
@@ -210,7 +210,7 @@ test("Send doesn't throw error when creating muxed account", async ({
     .fill(
       "MAUPPMNJUS76SG5NA6UXVCSO5HYVAJT422LBISV6LMCX37OIEPDJGAAAAAAAAAAAAF54C",
     );
-  expect(
+  await expect(
     page.getByText("The destination account doesn’t exist."),
   ).toBeVisible();
   await page.getByText("Continue").click();
@@ -219,6 +219,8 @@ test("Send doesn't throw error when creating muxed account", async ({
     "Send XLM",
   );
   await page.getByTestId("send-amount-amount-input").fill("1");
+  await page.getByText("Continue").click({ force: true });
+  await expect(page.getByText("Send Settings")).toBeVisible();
   await page.getByText("Review Send").click();
   await expect(page.getByText("Confirm Send")).toBeVisible({
     timeout: 200000,

--- a/extension/e2e-tests/sendPayment.test.ts
+++ b/extension/e2e-tests/sendPayment.test.ts
@@ -253,6 +253,7 @@ test("Send XLM payments to recent federated addresses", async ({
   await expect(
     page.getByTestId("SendSettingsTransactionFee"),
   ).not.toContainText("100 XLM");
+  await expect(page.getByText("Review Send")).toBeEnabled();
   await page.getByText("Review Send").click();
 
   await expect(page.getByText("Confirm Send")).toBeVisible();

--- a/extension/e2e-tests/sendPayment.test.ts
+++ b/extension/e2e-tests/sendPayment.test.ts
@@ -196,6 +196,34 @@ test("Send doesn't throw error when account is unfunded", async ({
     "Send XLM",
   );
 });
+test("Send doesn't throw error when creating muxed account", async ({
+  page,
+  extensionId,
+}) => {
+  test.slow();
+  await login({ page, extensionId });
+  await page.getByTitle("Send Payment").click({ force: true });
+
+  await expect(page.getByText("Send To")).toBeVisible();
+  await page
+    .getByTestId("send-to-input")
+    .fill(
+      "MAUPPMNJUS76SG5NA6UXVCSO5HYVAJT422LBISV6LMCX37OIEPDJGAAAAAAAAAAAAF54C",
+    );
+  expect(
+    page.getByText("The destination account doesn’t exist."),
+  ).toBeVisible();
+  await page.getByText("Continue").click();
+
+  await expect(page.getByTestId("AppHeaderPageTitle")).toContainText(
+    "Send XLM",
+  );
+  await page.getByTestId("send-amount-amount-input").fill("1");
+  await page.getByText("Review Send").click();
+  await expect(page.getByText("Confirm Send")).toBeVisible({
+    timeout: 200000,
+  });
+});
 
 test("Send XLM payments to recent federated addresses", async ({
   page,

--- a/extension/playwright.config.ts
+++ b/extension/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 4 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
Closes #2092 

We've seen an uptick of `destination is invalid` errors in Sentry. This is a fix for that issue - it makes sure that we extract the base address from the muxed account before we pass it to stellar-sdk's `Operation.createAccount` method as this method only supports G addresses. This is not an issue with `Operation.payment`.

I also confirmed that this is just an issue for muxed account and not for federated addresses