### PR TITLE
use the appropriate signing method when signing a message

### DIFF
--- a/extension/e2e-tests/freighterApiIntegration.test.ts
+++ b/extension/e2e-tests/freighterApiIntegration.test.ts
@@ -192,7 +192,7 @@ test("should not sign auth entry when not allowed", async ({
   });
 });
 
-test.skip("should sign message when allowed", async ({ page, extensionId }) => {
+test("should sign message when allowed", async ({ page, extensionId }) => {
   await loginToTestAccount({ page, extensionId });
   await allowDapp({ page });
 

--- a/extension/src/popup/views/SignMessage/index.tsx
+++ b/extension/src/popup/views/SignMessage/index.tsx
@@ -37,7 +37,7 @@ import { Loading } from "popup/components/Loading";
 import { AppDataType } from "helpers/hooks/useGetAppData";
 import { openTab } from "popup/helpers/navigate";
 import { useSetupSigningFlow } from "popup/helpers/useSetupSigningFlow";
-import { rejectTransaction, signTransaction } from "popup/ducks/access";
+import { rejectTransaction, signBlob } from "popup/ducks/access";
 import { reRouteOnboarding } from "popup/helpers/route";
 
 export const SignMessage = () => {
@@ -77,7 +77,7 @@ export const SignMessage = () => {
     setIsPasswordRequired,
     verifyPasswordThenSign,
     hardwareWalletType,
-  } = useSetupSigningFlow(rejectTransaction, signTransaction, message.message);
+  } = useSetupSigningFlow(rejectTransaction, signBlob, message.message);
 
   useEffect(() => {
     const getData = async () => {


### PR DESCRIPTION
Closes https://github.com/Creit-Tech/Stellar-Wallets-Kit/issues/67

Fixes an issue with the signMessage API method not properly signing and returning a message. The UI was just calling the wrong signing method here