### PR TITLE
[BUG] Handle errors to resolve account ID from fed address

### DIFF
--- a/extension/src/helpers/stellar.ts
+++ b/extension/src/helpers/stellar.ts
@@ -102,6 +102,21 @@ export const isMuxedAccount = (publicKey: string) => publicKey.startsWith("M");
 
 export const isFederationAddress = (address: string) => address.includes("*");
 
+export const isValidDomain = (input: string) => {
+  // eslint-disable-next-line no-useless-escape
+  const domainRegex = /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}$/i;
+  if (domainRegex.test(input)) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
+export const isValidFederatedDomain = (input: string) => {
+  const [_, domain] = input.split("*");
+  return isFederationAddress(input) && isValidDomain(domain);
+};
+
 export const isMainnet = (networkDetails: NetworkDetails) => {
   const { networkPassphrase } = networkDetails;
 

--- a/extension/src/popup/components/sendPayment/SendTo/hooks/useSendToData.tsx
+++ b/extension/src/popup/components/sendPayment/SendTo/hooks/useSendToData.tsx
@@ -33,11 +33,16 @@ type SendToData = NeedsReRoute | ResolvedSendToData;
 
 export const getAddressFromInput = async (userInput: string) => {
   if (isFederationAddress(userInput)) {
-    const fedResp = await Federation.Server.resolve(userInput);
-    return {
-      validatedAddress: fedResp.account_id,
-      fedAddress: userInput,
-    };
+    try {
+      const fedResp = await Federation.Server.resolve(userInput);
+      return {
+        validatedAddress: fedResp.account_id,
+        fedAddress: userInput,
+      };
+    } catch (error) {
+      Sentry.captureException(`Failed to fetch toml for ${userInput}`);
+      throw new Error("Failed to resolve federated address.");
+    }
   }
 
   return {

--- a/extension/src/popup/components/sendPayment/SendTo/hooks/useSendToData.tsx
+++ b/extension/src/popup/components/sendPayment/SendTo/hooks/useSendToData.tsx
@@ -119,47 +119,41 @@ function useSendToData() {
     }>,
   ) => {
     dispatch({ type: "FETCH_DATA_START" });
-    try {
-      const appData = await fetchAppData(true);
-      if (isError(appData)) {
-        throw new Error(appData.message);
-      }
-
-      if (appData.type === AppDataType.REROUTE) {
-        dispatch({ type: "FETCH_DATA_SUCCESS", payload: appData });
-        return appData;
-      }
-
-      const { publicKey, applicationState } = appData.account;
-      const { networkDetails } = appData.settings;
-      const _isMainnet = isMainnet(networkDetails);
-
-      if (Object.keys(errors).length !== 0 && userInput) {
-        const payload = {
-          type: AppDataType.RESOLVED,
-          recentAddresses: [],
-          validatedAddress: "",
-          fedAddress: "",
-          applicationState,
-          publicKey,
-          networkDetails,
-        } as ResolvedSendToData;
-        dispatch({ type: "FETCH_DATA_SUCCESS", payload });
-        return payload;
-      }
-
-      return debouncedFetch(
-        userInput,
-        publicKey,
-        applicationState,
-        networkDetails,
-        _isMainnet,
-      );
-    } catch (error) {
-      dispatch({ type: "FETCH_DATA_ERROR", payload: error });
-      Sentry.captureException(`Error send-to data: ${error}`);
-      return error;
+    const appData = await fetchAppData(true);
+    if (isError(appData)) {
+      throw new Error(appData.message);
     }
+
+    if (appData.type === AppDataType.REROUTE) {
+      dispatch({ type: "FETCH_DATA_SUCCESS", payload: appData });
+      return appData;
+    }
+
+    const { publicKey, applicationState } = appData.account;
+    const { networkDetails } = appData.settings;
+    const _isMainnet = isMainnet(networkDetails);
+
+    if (Object.keys(errors).length !== 0 && userInput) {
+      const payload = {
+        type: AppDataType.RESOLVED,
+        recentAddresses: [],
+        validatedAddress: "",
+        fedAddress: "",
+        applicationState,
+        publicKey,
+        networkDetails,
+      } as ResolvedSendToData;
+      dispatch({ type: "FETCH_DATA_SUCCESS", payload });
+      return payload;
+    }
+
+    return debouncedFetch(
+      userInput,
+      publicKey,
+      applicationState,
+      networkDetails,
+      _isMainnet,
+    );
   };
 
   return {

--- a/extension/src/popup/components/sendPayment/SendTo/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendTo/index.tsx
@@ -13,7 +13,11 @@ import {
 } from "@stellar/design-system";
 import { useTranslation } from "react-i18next";
 
-import { isFederationAddress, truncatedPublicKey } from "helpers/stellar";
+import {
+  isFederationAddress,
+  isValidFederatedDomain,
+  truncatedPublicKey,
+} from "helpers/stellar";
 
 import { AppDispatch } from "popup/App";
 import { SubviewHeader } from "popup/components/SubviewHeader";
@@ -143,7 +147,7 @@ export const SendTo = ({
     if (StrKey.isValidMed25519PublicKey(publicKey)) {
       return true;
     }
-    if (isFederationAddress(publicKey)) {
+    if (isValidFederatedDomain(publicKey)) {
       return true;
     }
     if (StrKey.isValidEd25519PublicKey(publicKey)) {

--- a/extension/src/popup/components/sendPayment/SendTo/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendTo/index.tsx
@@ -122,8 +122,8 @@ export const SendTo = ({
         sendDataState.data.type == AppDataType.RESOLVED
       ) {
         handleContinue(
-          sendDataState.data!.validatedAddress,
-          sendDataState.data!.fedAddress,
+          sendDataState.data.validatedAddress,
+          sendDataState.data.fedAddress,
         );
       }
     },
@@ -209,7 +209,8 @@ export const SendTo = ({
             <div className="SendTo__loader">
               <Loader />
             </div>
-          ) : sendDataState.error ? (
+          ) : sendDataState.error ||
+            sendDataState.state === RequestState.ERROR ? (
             <Notification
               variant="error"
               title={
@@ -222,12 +223,12 @@ export const SendTo = ({
             <div>
               {formik.values.destination === "" ? (
                 <>
-                  {sendDataState.data!.recentAddresses.length > 0 && (
+                  {sendDataState.data.recentAddresses.length > 0 && (
                     <div className="SendTo__subheading">{t("RECENT")}</div>
                   )}
                   <div className="SendTo__simplebar">
                     <ul className="SendTo__recent-accts-ul">
-                      {sendDataState.data!.recentAddresses.map((address) => (
+                      {sendDataState.data.recentAddresses.map((address) => (
                         <li key={address}>
                           <button
                             data-testid="recent-address-button"
@@ -259,8 +260,8 @@ export const SendTo = ({
                 <div>
                   {formik.isValid ? (
                     <>
-                      {sendDataState.data!.destinationBalances &&
-                        !sendDataState.data!.destinationBalances.isFunded && (
+                      {sendDataState.data.destinationBalances &&
+                        !sendDataState.data.destinationBalances.isFunded && (
                           <AccountDoesntExistWarning />
                         )}
                       {isFederationAddress(formik.values.destination) && (
@@ -279,11 +280,11 @@ export const SendTo = ({
                         data-testid="send-to-identicon"
                       >
                         <IdenticonImg
-                          publicKey={sendDataState.data!.validatedAddress}
+                          publicKey={sendDataState.data.validatedAddress}
                         />
                         <span>
                           {truncatedPublicKey(
-                            sendDataState.data!.validatedAddress,
+                            sendDataState.data.validatedAddress,
                           )}
                         </span>
                       </div>


### PR DESCRIPTION
What
Handles errors to resolve the account ID from a federated address in the data hook for send-to view component.
Improves error messaging in cases where the toml is malformed
Explicitly checks for request state errors in send-to view

Why
In some cases the toml from federated addresses is malformed and not properly handled by our addresses resolver in `useSendToData`. 