### PR TITLE
[BUG] Fixes empty state for unfunded accounts on custom networks

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -55,7 +55,11 @@ import {
   AssetVisibility,
   ApiTokenPrices,
 } from "./types";
-import { AccountBalancesInterface, Balances } from "./types/backend-api";
+import {
+  AccountBalancesInterface,
+  BalanceMap,
+  Balances,
+} from "./types/backend-api";
 import {
   MAINNET_NETWORK_DETAILS,
   DEFAULT_NETWORKS,
@@ -682,7 +686,7 @@ export const getAccountBalancesStandalone = async ({
 }) => {
   const { network, networkUrl, networkPassphrase } = networkDetails;
 
-  let balances = null;
+  let balances = {} as BalanceMap;
   let isFunded = null;
   let subentryCount = 0;
 

--- a/extension/src/popup/views/GrantAccess/hooks/useGetGrantAccessData.ts
+++ b/extension/src/popup/views/GrantAccess/hooks/useGetGrantAccessData.ts
@@ -10,6 +10,7 @@ import { useScanSite } from "../../../../popup/helpers/blockaid";
 import { BlockAidScanSiteResult } from "@shared/api/types";
 import { NetworkDetails } from "@shared/constants/stellar";
 import { APPLICATION_STATE } from "@shared/constants/applicationState";
+import { isCustomNetwork } from "@shared/helpers/stellar";
 
 type ResolvedGrantAccessData = BlockAidScanSiteResult & {
   type: AppDataType.RESOLVED;
@@ -44,7 +45,7 @@ function useGetGrantAccessData(url: string) {
 
       const scanData = await scanSite(url, appData.settings.networkDetails);
 
-      if (!scanData) {
+      if (!scanData && !isCustomNetwork(appData.settings.networkDetails)) {
         throw new Error("Unable to scan site");
       }
 


### PR DESCRIPTION
What
Fixes the empty state for unfunded accounts on custom networks
Avoids scan site errors in GrantAccess on custom networks

Why
Custom networks did not properly represent the empty state for account balances.
Grant Access throws an error when scan site fails even when on a custom network where scanning is not supported.