### PR TITLE
[BUG] wasm upload render

### DIFF
--- a/extension/src/popup/components/signTransaction/Operations/KeyVal/index.tsx
+++ b/extension/src/popup/components/signTransaction/Operations/KeyVal/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import {
   Asset,
   Claimant,
+  hash,
   LiquidityPoolAsset,
   nativeToScVal,
   Operation,
@@ -668,14 +669,17 @@ export const KeyValueInvokeHostFn = ({
       }
 
       case xdr.HostFunctionType.hostFunctionTypeUploadContractWasm(): {
-        const wasm = hostfn.wasm().toString();
+        const wasmHash = hash(hostfn.value() as Buffer);
         return (
           <>
             <KeyValueList
               operationKey={t("Invocation Type")}
               operationValue="Upload Contract Wasm"
             />
-            <KeyValueList operationKey={t("wasm")} operationValue={wasm} />
+            <KeyValueList
+              operationKey={t("Wasm Hash")}
+              operationValue={truncateString(wasmHash.toString("hex"), 8)}
+            />
           </>
         );
       }


### PR DESCRIPTION
Closes #2106 

Uses the wasm's hash as a display value when signing contract upload transactions

<img width="347" height="597" alt="Screenshot 2025-07-16 at 3 08 16 PM" src="https://github.com/user-attachments/assets/976ab7ab-1126-4730-bd3f-bb36d330a947" />
