### PR TITLE
[BUG] include current version in migration conditional

### DIFF
--- a/extension/src/background/helpers/dataStorage.ts
+++ b/extension/src/background/helpers/dataStorage.ts
@@ -328,7 +328,7 @@ export const migratePubnetRpcUrl = async () => {
   const localStore = dataStorageAccess(browserLocalStorage);
   const storageVersion = (await localStore.getItem(STORAGE_VERSION)) as string;
 
-  if (!storageVersion || semver.lt(storageVersion, "5.33.5")) {
+  if (!storageVersion || semver.lte(storageVersion, "5.33.6")) {
     const networksList: NetworkDetails[] =
       (await localStore.getItem(NETWORKS_LIST_ID)) || DEFAULT_NETWORKS;
 
@@ -353,7 +353,7 @@ export const migratePubnetRpcUrl = async () => {
     }
 
     await localStore.setItem(NETWORKS_LIST_ID, migratedNetworkList);
-    await migrateDataStorageVersion("5.33.5");
+    await migrateDataStorageVersion("5.33.6");
   }
 };
 


### PR DESCRIPTION
The 5.33.5 migration of these values should have included the current version in order to run on first download, this is trying that again with a correct conditional to run.