### PR TITLE
[BUG] Handle unexpected errors in all sequential migrations

### DIFF
--- a/extension/src/background/helpers/dataStorage.ts
+++ b/extension/src/background/helpers/dataStorage.ts
@@ -107,16 +107,9 @@ export const migrateTokenIdList = async () => {
   const storageVersion = (await localStore.getItem(STORAGE_VERSION)) as string;
 
   if (shouldRunMigration({ storageVersion, migrationVersion: "1.0.0" })) {
-    try {
-      if (Array.isArray(tokenIdsByKey)) {
-        const newTokenList = {
-          [NETWORKS.FUTURENET]: tokenIdsByKey,
-        };
-        await localStore.setItem(TOKEN_ID_LIST, newTokenList);
-      }
-    } catch (error) {
+    if (Array.isArray(tokenIdsByKey)) {
       const newTokenList = {
-        [NETWORKS.FUTURENET]: [],
+        [NETWORKS.FUTURENET]: tokenIdsByKey,
       };
       await localStore.setItem(TOKEN_ID_LIST, newTokenList);
     }

--- a/extension/src/background/helpers/dataStorage.ts
+++ b/extension/src/background/helpers/dataStorage.ts
@@ -107,9 +107,16 @@ export const migrateTokenIdList = async () => {
   const storageVersion = (await localStore.getItem(STORAGE_VERSION)) as string;
 
   if (shouldRunMigration({ storageVersion, migrationVersion: "1.0.0" })) {
-    if (Array.isArray(tokenIdsByKey)) {
+    try {
+      if (Array.isArray(tokenIdsByKey)) {
+        const newTokenList = {
+          [NETWORKS.FUTURENET]: tokenIdsByKey,
+        };
+        await localStore.setItem(TOKEN_ID_LIST, newTokenList);
+      }
+    } catch (error) {
       const newTokenList = {
-        [NETWORKS.FUTURENET]: tokenIdsByKey,
+        [NETWORKS.FUTURENET]: [],
       };
       await localStore.setItem(TOKEN_ID_LIST, newTokenList);
     }
@@ -123,27 +130,31 @@ export const migrateTestnetSorobanRpcUrlNetworkDetails = async () => {
   const storageVersion = (await localStore.getItem(STORAGE_VERSION)) as string;
 
   if (shouldRunMigration({ storageVersion, migrationVersion: "2.0.0" })) {
-    const networksList: NetworkDetails[] =
-      (await localStore.getItem(NETWORKS_LIST_ID)) || DEFAULT_NETWORKS;
+    try {
+      const networksList: NetworkDetails[] =
+        (await localStore.getItem(NETWORKS_LIST_ID)) || DEFAULT_NETWORKS;
 
-    const migratedNetworkList = networksList.map((network) => {
-      if (network.network === NETWORKS.TESTNET) {
-        return {
-          ...TESTNET_NETWORK_DETAILS,
-          sorobanRpcUrl: SOROBAN_RPC_URLS[NETWORKS.TESTNET],
-        };
+      const migratedNetworkList = networksList.map((network) => {
+        if (network.network === NETWORKS.TESTNET) {
+          return {
+            ...TESTNET_NETWORK_DETAILS,
+            sorobanRpcUrl: SOROBAN_RPC_URLS[NETWORKS.TESTNET],
+          };
+        }
+
+        return network;
+      });
+
+      const currentNetwork = await localStore.getItem(NETWORK_ID);
+
+      if (currentNetwork && currentNetwork.network === NETWORKS.TESTNET) {
+        await localStore.setItem(NETWORK_ID, TESTNET_NETWORK_DETAILS);
       }
 
-      return network;
-    });
-
-    const currentNetwork = await localStore.getItem(NETWORK_ID);
-
-    if (currentNetwork && currentNetwork.network === NETWORKS.TESTNET) {
-      await localStore.setItem(NETWORK_ID, TESTNET_NETWORK_DETAILS);
+      await localStore.setItem(NETWORKS_LIST_ID, migratedNetworkList);
+    } catch (error) {
+      await localStore.setItem(NETWORKS_LIST_ID, DEFAULT_NETWORKS);
     }
-
-    await localStore.setItem(NETWORKS_LIST_ID, migratedNetworkList);
     await migrateDataStorageVersion("2.0.0");
   }
 };
@@ -164,27 +175,31 @@ export const migrateMainnetSorobanRpcUrlNetworkDetails = async () => {
   const storageVersion = (await localStore.getItem(STORAGE_VERSION)) as string;
 
   if (shouldRunMigration({ storageVersion, migrationVersion: "4.0.0" })) {
-    const networksList: NetworkDetails[] =
-      (await localStore.getItem(NETWORKS_LIST_ID)) || DEFAULT_NETWORKS;
+    try {
+      const networksList: NetworkDetails[] =
+        (await localStore.getItem(NETWORKS_LIST_ID)) || DEFAULT_NETWORKS;
 
-    const migratedNetworkList = networksList.map((network) => {
-      if (network.network === NETWORKS.PUBLIC) {
-        return {
-          ...MAINNET_NETWORK_DETAILS,
-          sorobanRpcUrl: SOROBAN_RPC_URLS[NETWORKS.PUBLIC],
-        };
+      const migratedNetworkList = networksList.map((network) => {
+        if (network.network === NETWORKS.PUBLIC) {
+          return {
+            ...MAINNET_NETWORK_DETAILS,
+            sorobanRpcUrl: SOROBAN_RPC_URLS[NETWORKS.PUBLIC],
+          };
+        }
+
+        return network;
+      });
+
+      const currentNetwork = await localStore.getItem(NETWORK_ID);
+
+      if (currentNetwork && currentNetwork.network === NETWORKS.PUBLIC) {
+        await localStore.setItem(NETWORK_ID, MAINNET_NETWORK_DETAILS);
       }
 
-      return network;
-    });
-
-    const currentNetwork = await localStore.getItem(NETWORK_ID);
-
-    if (currentNetwork && currentNetwork.network === NETWORKS.PUBLIC) {
-      await localStore.setItem(NETWORK_ID, MAINNET_NETWORK_DETAILS);
+      await localStore.setItem(NETWORKS_LIST_ID, migratedNetworkList);
+    } catch (error) {
+      await localStore.setItem(NETWORKS_LIST_ID, DEFAULT_NETWORKS);
     }
-
-    await localStore.setItem(NETWORKS_LIST_ID, migratedNetworkList);
     await migrateDataStorageVersion("4.0.0");
   }
 };
@@ -300,17 +315,25 @@ export const migrateAllowlistToKeyNetworkSchema = async () => {
     const lastUsedAccount = await localStore.getItem(LAST_USED_ACCOUNT);
     let allowlistByKey = {};
 
-    if (currentAllowlist && lastUsedAccount) {
-      const allowlistArr = currentAllowlist.split(",").slice(1);
+    try {
+      if (currentAllowlist && lastUsedAccount) {
+        const allowlistArr = currentAllowlist.split(",").slice(1);
 
-      allowlistByKey = {
-        [NETWORK_NAMES.PUBNET]: {},
-        [NETWORK_NAMES.TESTNET]: {
-          [lastUsedAccount]: allowlistArr,
-        },
-        [NETWORK_NAMES.FUTURENET]: {},
-      };
-    } else {
+        allowlistByKey = {
+          [NETWORK_NAMES.PUBNET]: {},
+          [NETWORK_NAMES.TESTNET]: {
+            [lastUsedAccount]: allowlistArr,
+          },
+          [NETWORK_NAMES.FUTURENET]: {},
+        };
+      } else {
+        allowlistByKey = {
+          [NETWORK_NAMES.PUBNET]: {},
+          [NETWORK_NAMES.TESTNET]: {},
+          [NETWORK_NAMES.FUTURENET]: {},
+        };
+      }
+    } catch (error) {
       allowlistByKey = {
         [NETWORK_NAMES.PUBNET]: {},
         [NETWORK_NAMES.TESTNET]: {},
@@ -329,30 +352,34 @@ export const migratePubnetRpcUrl = async () => {
   const storageVersion = (await localStore.getItem(STORAGE_VERSION)) as string;
 
   if (shouldRunMigration({ storageVersion, migrationVersion: "5.33.5" })) {
-    const networksList: NetworkDetails[] =
-      (await localStore.getItem(NETWORKS_LIST_ID)) || DEFAULT_NETWORKS;
+    try {
+      const networksList: NetworkDetails[] =
+        (await localStore.getItem(NETWORKS_LIST_ID)) || DEFAULT_NETWORKS;
 
-    const migratedNetworkList = networksList.map((network) => {
-      if (network.network === NETWORKS.PUBLIC) {
-        return {
+      const migratedNetworkList = networksList.map((network) => {
+        if (network.network === NETWORKS.PUBLIC) {
+          return {
+            ...MAINNET_NETWORK_DETAILS,
+            sorobanRpcUrl: SOROBAN_RPC_URLS[NETWORKS.PUBLIC],
+          };
+        }
+
+        return network;
+      });
+
+      const currentNetwork = await localStore.getItem(NETWORK_ID);
+
+      if (currentNetwork && currentNetwork.network === NETWORKS.PUBLIC) {
+        await localStore.setItem(NETWORK_ID, {
           ...MAINNET_NETWORK_DETAILS,
           sorobanRpcUrl: SOROBAN_RPC_URLS[NETWORKS.PUBLIC],
-        };
+        });
       }
 
-      return network;
-    });
-
-    const currentNetwork = await localStore.getItem(NETWORK_ID);
-
-    if (currentNetwork && currentNetwork.network === NETWORKS.PUBLIC) {
-      await localStore.setItem(NETWORK_ID, {
-        ...MAINNET_NETWORK_DETAILS,
-        sorobanRpcUrl: SOROBAN_RPC_URLS[NETWORKS.PUBLIC],
-      });
+      await localStore.setItem(NETWORKS_LIST_ID, migratedNetworkList);
+    } catch (error) {
+      await localStore.setItem(NETWORKS_LIST_ID, DEFAULT_NETWORKS);
     }
-
-    await localStore.setItem(NETWORKS_LIST_ID, migratedNetworkList);
     await migrateDataStorageVersion("5.33.5");
   }
 };


### PR DESCRIPTION
Description:
Users can have storage with bad or unexpected values, migrations that rely on these values and make assumptions on their schema can throw and result in subsequent migrations now running for that user. 

This adds error handling around all sequential migrations with default storage setters in the error handler which should result in all migrations running for all users.