### PR TITLE
[FIX] Removes hardcoded domain filter for asset search results

### DIFF
--- a/extension/src/popup/components/manageAssets/ManageAssetRowButton/index.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRowButton/index.tsx
@@ -14,6 +14,7 @@ interface ManageAssetRowButtonProps {
   code: string;
   issuer: string;
   isTrustlineActive: boolean;
+  isSac: boolean;
   isLoading: boolean;
   onClick: () => void;
 }
@@ -22,6 +23,7 @@ export const ManageAssetRowButton = ({
   code,
   issuer,
   isTrustlineActive,
+  isSac,
   isLoading,
   onClick,
 }: ManageAssetRowButtonProps) => {
@@ -69,28 +71,30 @@ export const ManageAssetRowButton = ({
                   </>
                 </CopyText>
               </div>
-              <div className="ManageAssetRowButton__dropdown__row">
-                <Button
-                  className="ManageAssetRowButton__remove"
-                  size="md"
-                  variant="secondary"
-                  disabled={isLoading}
-                  isLoading={isLoading}
-                  onClick={() => {
-                    setRowButtonShowing("");
-                    onClick();
-                  }}
-                  type="button"
-                  data-testid="ManageAssetRowButton"
-                >
-                  <div className="ManageAssetRowButton__label">
-                    {t("Remove asset")}
-                  </div>
-                  {isLoading ? null : (
-                    <img src={IconRemove} alt="icon remove" />
-                  )}
-                </Button>
-              </div>
+              {!isSac && (
+                <div className="ManageAssetRowButton__dropdown__row">
+                  <Button
+                    className="ManageAssetRowButton__remove"
+                    size="md"
+                    variant="secondary"
+                    disabled={isLoading}
+                    isLoading={isLoading}
+                    onClick={() => {
+                      setRowButtonShowing("");
+                      onClick();
+                    }}
+                    type="button"
+                    data-testid="ManageAssetRowButton"
+                  >
+                    <div className="ManageAssetRowButton__label">
+                      {t("Remove asset")}
+                    </div>
+                    {isLoading ? null : (
+                      <img src={IconRemove} alt="icon remove" />
+                    )}
+                  </Button>
+                </div>
+              )}
               {createPortal(
                 <div
                   className="ManageAssetRowButton__dropdown__background"

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/ChangeTrustInternal/SubmitTx/index.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/ChangeTrustInternal/SubmitTx/index.tsx
@@ -208,7 +208,7 @@ export const SubmitTransaction = ({
               )}
               {isFail && (
                 <>
-                  <Icon.CheckCircle className="SubmitTransaction__Title__Fail" />
+                  <Icon.XCircle className="SubmitTransaction__Title__Fail" />
                   <span>Failed!</span>
                 </>
               )}

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/ToggleTokenInternal/index.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/ToggleTokenInternal/index.tsx
@@ -13,6 +13,8 @@ import { navigateTo } from "popup/helpers/navigate";
 import { ROUTES } from "popup/constants/routes";
 
 import "./styles.scss";
+import { isSacContract } from "popup/helpers/soroban";
+import { truncateString } from "helpers/stellar";
 
 interface ToggleTokenInternalProps {
   asset: {
@@ -57,6 +59,10 @@ export const ToggleTokenInternal = ({
     }
     navigateTo(ROUTES.account, nav);
   };
+  const isSac =
+    !!asset.name &&
+    !!asset.contract &&
+    isSacContract(asset.name, asset.contract, networkDetails.networkPassphrase);
   return (
     <div className="ToggleToken__wrapper">
       <div className="ToggleToken__wrapper__body">
@@ -88,7 +94,7 @@ export const ToggleTokenInternal = ({
           )}
 
           <Text as="div" size="sm" weight="medium">
-            {asset.name || asset.code}
+            {isSac ? asset.code : asset.name || truncateString(asset.contract!)}
           </Text>
           <div className="ToggleToken__wrapper__badge">
             <Badge

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/index.tsx
@@ -22,6 +22,8 @@ import { ManageAssetRowButton } from "../ManageAssetRowButton";
 import { ToggleTokenInternal } from "./ToggleTokenInternal";
 
 import "./styles.scss";
+import { NetworkDetails } from "@shared/constants/stellar";
+import { getNativeContractDetails } from "popup/helpers/searchAsset";
 
 export type ManageAssetCurrency = {
   code?: string;
@@ -86,6 +88,7 @@ export const ManageAssetRows = ({
             accountBalances={balances}
             verifiedAssetRows={verifiedAssetRows}
             unverifiedAssetRows={unverifiedAssetRows}
+            networkDetails={networkDetails}
             shouldSplitAssetsByVerificationStatus={
               shouldSplitAssetsByVerificationStatus
             }
@@ -96,6 +99,7 @@ export const ManageAssetRows = ({
               image,
               issuer,
               isSuspicious,
+              isSac,
               isTrustlineActive,
               name,
             }) => (
@@ -112,6 +116,7 @@ export const ManageAssetRows = ({
                   code={code}
                   issuer={issuer}
                   isTrustlineActive={!!isTrustlineActive}
+                  isSac={isSac}
                   isLoading={false}
                   onClick={async () => {
                     setSelectedAsset({
@@ -178,11 +183,13 @@ const AssetRows = ({
   shouldSplitAssetsByVerificationStatus,
   unverifiedAssetRows,
   verifiedAssetRows,
+  networkDetails,
 }: {
   accountBalances: AccountBalances;
   shouldSplitAssetsByVerificationStatus?: boolean;
   unverifiedAssetRows: ManageAssetCurrency[];
   verifiedAssetRows: ManageAssetCurrency[];
+  networkDetails: NetworkDetails;
   renderAssetRow: ({
     code,
     domain,
@@ -193,6 +200,7 @@ const AssetRows = ({
     isContract,
     isTrustlineActive,
     isSuspicious,
+    isSac,
   }: {
     code: string;
     domain: string;
@@ -203,6 +211,7 @@ const AssetRows = ({
     isContract: boolean;
     isTrustlineActive: boolean;
     isSuspicious?: boolean;
+    isSac: boolean;
   }) => React.ReactNode;
 }) => {
   const { t } = useTranslation();
@@ -242,12 +251,22 @@ const AssetRows = ({
             if (!accountBalances.balances) {
               return null;
             }
+            const nativeContract = getNativeContractDetails(networkDetails);
             const isContract = isContractId(contract);
             const canonicalAsset = getCanonicalFromAsset(code, issuer);
             const isTrustlineActive = findAssetBalance(
               accountBalances.balances,
               { code, issuer },
             );
+            const isSac =
+              contract === nativeContract.contract ||
+              (!!name &&
+                !!contract &&
+                isSacContract(
+                  name,
+                  contract,
+                  networkDetails.networkPassphrase,
+                ));
             return (
               <div
                 className="ManageAssetRows__row"
@@ -262,7 +281,10 @@ const AssetRows = ({
                   isContract,
                   issuer,
                   isSuspicious,
-                  isTrustlineActive: isTrustlineActive !== undefined,
+                  isSac,
+                  isTrustlineActive:
+                    isTrustlineActive !== undefined ||
+                    contract === nativeContract.contract,
                   name,
                 })}
               </div>
@@ -301,12 +323,24 @@ const AssetRows = ({
             if (!accountBalances.balances) {
               return null;
             }
+            const nativeContract = getNativeContractDetails(networkDetails);
             const isContract = isContractId(contract);
             const canonicalAsset = getCanonicalFromAsset(code, issuer);
             const isTrustlineActive = findAssetBalance(
               accountBalances.balances,
               { code, issuer },
             );
+            const isSac =
+              contract === nativeContract.contract ||
+              (!!name &&
+                !!contract &&
+                isSacContract(
+                  name,
+                  contract,
+                  networkDetails.networkPassphrase,
+                ));
+            console.log(name, issuer, contract, nativeContract);
+
             return (
               <div
                 className="ManageAssetRows__row"
@@ -321,7 +355,10 @@ const AssetRows = ({
                   isContract,
                   issuer,
                   isSuspicious,
-                  isTrustlineActive: isTrustlineActive !== undefined,
+                  isSac,
+                  isTrustlineActive:
+                    isTrustlineActive !== undefined ||
+                    contract === nativeContract.contract,
                   name,
                 })}
               </div>
@@ -347,12 +384,18 @@ const AssetRows = ({
           if (!accountBalances.balances) {
             return null;
           }
+          const nativeContract = getNativeContractDetails(networkDetails);
           const isContract = isContractId(contract);
           const canonicalAsset = getCanonicalFromAsset(code, issuer);
           const isTrustlineActive = findAssetBalance(accountBalances.balances, {
             code,
             issuer,
           });
+          const isSac =
+            contract === nativeContract.contract ||
+            (!!name &&
+              !!contract &&
+              isSacContract(name, contract, networkDetails.networkPassphrase));
           return (
             <div
               className="ManageAssetRows__row"
@@ -367,7 +410,10 @@ const AssetRows = ({
                 isContract,
                 issuer,
                 isSuspicious,
-                isTrustlineActive: isTrustlineActive !== undefined,
+                isSac,
+                isTrustlineActive:
+                  isTrustlineActive !== undefined ||
+                  contract === nativeContract.contract,
                 name,
               })}
             </div>

--- a/extension/src/popup/components/manageAssets/SearchAsset/hooks/useAssetLookup.ts
+++ b/extension/src/popup/components/manageAssets/SearchAsset/hooks/useAssetLookup.ts
@@ -150,8 +150,10 @@ const useAssetLookup = () => {
       assetRows = [
         {
           code: nativeContractDetails.code,
-          issuer: contractId,
+          issuer: nativeContractDetails.issuer,
+          contract: contractId,
           domain: nativeContractDetails.domain,
+          name: `${nativeContractDetails.code}:${nativeContractDetails.issuer}`,
         },
       ];
 

--- a/extension/src/popup/components/manageAssets/SearchAsset/hooks/useAssetLookup.ts
+++ b/extension/src/popup/components/manageAssets/SearchAsset/hooks/useAssetLookup.ts
@@ -325,12 +325,6 @@ const useAssetLookup = () => {
         dispatch({ type: "FETCH_DATA_ERROR", payload: DEFAULT_PAYLOAD });
         return;
       }
-
-      // Only show records that have a domain and domains that don't have just whitespace
-      // We omit these results as a safety precaution and to encourage asset issuers to add a domain to their asset
-      assetRows = assetRows.filter(
-        (record) => record.domain && /\S/.test(record.domain),
-      );
     }
 
     const assetsListsData = await getCombinedAssetListData({


### PR DESCRIPTION
Closes #2218 

Removes an old hardcoded filter that removes search results without the `domain` key.
This filter can remove assets that users are looking for, and I don't think we always know why the domain key could be missing. I'm not aware of this being a good indicator of an asset not being safe or legitimate.