### PR TITLE
Bugfix/fix avail balance

### DIFF
--- a/@shared/api/types/account-balance.ts
+++ b/@shared/api/types/account-balance.ts
@@ -11,6 +11,7 @@ export interface NativeAsset {
   total: BigNumber;
   buyingLiabilities: string;
   sellingLiabilities: string;
+  minimumBalance: string;
   blockaidData: Blockaid.TokenScanResponse;
 }
 

--- a/extension/e2e-tests/sendPayment.test.ts
+++ b/extension/e2e-tests/sendPayment.test.ts
@@ -111,7 +111,7 @@ test("Swap shows correct balances for assets", async ({
           available: "999",
           sellingLiabilities: "0",
           buyingLiabilities: "0",
-          minimumBalance: "8",
+          minimumBalance: "1",
           blockaidData: {
             result_type: "Benign",
             malicious_score: "0.0",

--- a/extension/src/popup/components/InternalTransaction/TokenList/index.tsx
+++ b/extension/src/popup/components/InternalTransaction/TokenList/index.tsx
@@ -17,7 +17,6 @@ import "./styles.scss";
 interface TokenListProps {
   hiddenAssets?: string[];
   icons: AssetIcons;
-  subentryCount: number;
   tokens: AssetType[];
   tokenPrices: ApiTokenPrices;
   onClickAsset: (canonical: string, isContract: boolean) => unknown;
@@ -26,7 +25,6 @@ interface TokenListProps {
 export const TokenList = ({
   hiddenAssets = [],
   icons,
-  subentryCount,
   tokens,
   tokenPrices,
   onClickAsset,
@@ -68,7 +66,6 @@ export const TokenList = ({
               const availableBalance = getAvailableBalance({
                 assetCanonical: canonical,
                 balances: [balance],
-                subentryCount,
                 recommendedFee: "0",
               });
               const displayTotal =

--- a/extension/src/popup/components/sendPayment/SendAmount/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendAmount/index.tsx
@@ -256,7 +256,6 @@ export const SendAmount = ({
     assetCanonical: asset,
     balances: sendData.userBalances.balances,
     recommendedFee: fee,
-    subentryCount: sendData.userBalances.subentryCount,
   });
   const displayTotal =
     "decimals" in assetBalance

--- a/extension/src/popup/components/sendPayment/SendDestinationAsset/index.tsx
+++ b/extension/src/popup/components/sendPayment/SendDestinationAsset/index.tsx
@@ -134,7 +134,6 @@ export const SendDestinationAsset = ({
             tokens={balances.balances}
             hiddenAssets={[]}
             icons={icons}
-            subentryCount={balances.subentryCount}
             tokenPrices={tokenPrices}
             onClickAsset={(canonical, isContract) => {
               dispatch(saveAsset(canonical));

--- a/extension/src/popup/components/swap/SwapAmount/index.tsx
+++ b/extension/src/popup/components/swap/SwapAmount/index.tsx
@@ -278,7 +278,6 @@ export const SwapAmount = ({
     assetCanonical: asset,
     balances: sendData.userBalances.balances,
     recommendedFee: fee,
-    subentryCount: sendData.userBalances.subentryCount,
   });
   const displayTotal = `${formatAmount(availableBalance)}`;
   const dstDisplayTotal =

--- a/extension/src/popup/components/swap/SwapAsset/index.tsx
+++ b/extension/src/popup/components/swap/SwapAsset/index.tsx
@@ -91,7 +91,6 @@ export const SwapAsset = ({
   const icons = state.data?.balances.icons || {};
   const tokenPrices = state.data?.tokenPrices || {};
   const balances = state.data?.filteredBalances || [];
-  const subentryCount = state.data?.balances.subentryCount!;
 
   return (
     <>
@@ -124,7 +123,6 @@ export const SwapAsset = ({
               tokens={balances}
               hiddenAssets={hiddenAssets}
               icons={icons}
-              subentryCount={subentryCount}
               tokenPrices={tokenPrices}
               onClickAsset={onClickAsset}
             />

--- a/extension/src/popup/helpers/__tests__/soroban.test.js
+++ b/extension/src/popup/helpers/__tests__/soroban.test.js
@@ -94,35 +94,37 @@ describe("getInvocationArgs", () => {
       }
     }
   });
-  it("can calculate the available balance of XLM without subentries", () => {
+  it("can calculate the available balance of XLM", () => {
     const availableBalance = getAvailableBalance({
       assetCanonical: "native",
       balances: [
         {
           token: { type: "native", code: "XLM" },
-          total: new BigNumber("50"),
-          available: new BigNumber("50"),
+          total: new BigNumber("2.5"),
+          available: new BigNumber("2.5"),
+          minimumBalance: "1",
         },
       ],
       subentryCount: 0,
       recommendedFee: ".11",
     });
-    expect(availableBalance).toEqual("48.89");
+    expect(availableBalance).toEqual("1.39");
   });
-  it("can calculate the available balance of XLM with subentries", () => {
+  it("can calculate the available balance of XLM if the minimum balance is a BigNumber (custom network)", () => {
     const availableBalance = getAvailableBalance({
       assetCanonical: "native",
       balances: [
         {
           token: { type: "native", code: "XLM" },
-          total: new BigNumber("50"),
-          available: new BigNumber("50"),
+          total: new BigNumber("2.5"),
+          available: new BigNumber("2.5"),
+          minimumBalance: new BigNumber("1"),
         },
       ],
-      subentryCount: 1,
+      subentryCount: 0,
       recommendedFee: ".11",
     });
-    expect(availableBalance).toEqual("48.39");
+    expect(availableBalance).toEqual("1.39");
   });
   it("can calculate the available balance of XLM when there is not enough balance to cover the recommended fee", () => {
     const availableBalance = getAvailableBalance({
@@ -130,8 +132,9 @@ describe("getInvocationArgs", () => {
       balances: [
         {
           token: { type: "native", code: "XLM" },
-          total: new BigNumber("50"),
-          available: new BigNumber("50"),
+          total: new BigNumber("3"),
+          available: new BigNumber("3"),
+          minimumBalance: "1.5",
         },
       ],
       subentryCount: 1,
@@ -139,22 +142,7 @@ describe("getInvocationArgs", () => {
     });
     expect(availableBalance).toEqual("0");
   });
-  it("can calculate the available balance of XLM when there is not enough balance to cover the subentries", () => {
-    const availableBalance = getAvailableBalance({
-      assetCanonical: "native",
-      balances: [
-        {
-          token: { type: "native", code: "XLM" },
-          total: new BigNumber("2"),
-          available: new BigNumber("2"),
-        },
-      ],
-      subentryCount: 5,
-      recommendedFee: ".01",
-    });
-    expect(availableBalance).toEqual("0");
-  });
-  it.only("can calculate the available balance if the asset is not in the balances", () => {
+  it("can calculate the available balance if the asset is not in the balances", () => {
     const availableBalance = getAvailableBalance({
       assetCanonical:
         "USDC:GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM",

--- a/extension/src/popup/helpers/soroban.ts
+++ b/extension/src/popup/helpers/soroban.ts
@@ -14,7 +14,7 @@ import {
 } from "stellar-sdk";
 
 import { HorizonOperation, SorobanBalance } from "@shared/api/types";
-import { BASE_RESERVE, NetworkDetails } from "@shared/constants/stellar";
+import { NetworkDetails } from "@shared/constants/stellar";
 import {
   ArgsForTokenInvocation,
   SorobanTokenInterface,
@@ -63,12 +63,10 @@ export const getTokenBalance = (tokenBalance: SorobanBalance) =>
 export const getAvailableBalance = ({
   assetCanonical,
   balances,
-  subentryCount,
   recommendedFee,
 }: {
   assetCanonical: string;
   balances: AssetType[];
-  subentryCount: number;
   recommendedFee: string;
 }) => {
   const selectedCanonical = getAssetFromCanonical(assetCanonical);
@@ -79,9 +77,9 @@ export const getAvailableBalance = ({
     }
 
     const balance = selectedBalance.total;
-    if (assetCanonical === "native") {
+    if ("minimumBalance" in selectedBalance && selectedBalance.minimumBalance) {
       // take base reserve into account for XLM payments
-      const minBalance = new BigNumber((2 + subentryCount) * BASE_RESERVE);
+      const minBalance = selectedBalance.minimumBalance;
       const currentBal = new BigNumber(balance.toFixed());
       const available = currentBal
         .minus(minBalance)

--- a/extension/src/popup/helpers/soroban.ts
+++ b/extension/src/popup/helpers/soroban.ts
@@ -87,10 +87,8 @@ export const getAvailableBalance = ({
         .minus(minBalance)
         .minus(new BigNumber(Number(recommendedFee)));
 
-      if (available.lt(minBalance)) {
-        return "0";
-      }
-      return available.toFixed().toString();
+      // Ensure we don't go below zero
+      return BigNumber.max(available, new BigNumber(0)).toFixed().toString();
     } else {
       return new BigNumber(balance).toFixed().toString();
     }


### PR DESCRIPTION
Closes #2290 

Fixes 2 issues with calculating available balance:

1) we were incorrectly defaulting to 0 when we were trying to account for negative numbers (caused by a high fee). We are now using the same logic as freighter-mobile

2a) we were re-calculating minimum balance even though Freighter BE returns that value for us. Removing that extra logic

2b) for custom networks that just retrieve balances from Horizon or Quickstart, we have a [transformer](https://github.com/stellar/freighter/blob/master/%40shared/helpers/stellar.ts#L124) that does this already