### PR TITLE
stringify errors rather than using `cause`

### DIFF
--- a/extension/src/helpers/hooks/useGetAppData.tsx
+++ b/extension/src/helpers/hooks/useGetAppData.tsx
@@ -91,7 +91,7 @@ function useGetAppData() {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
       reduxDispatch(saveAccountError(error));
       Sentry.captureException(`Error loading app data: ${error}`);
-      throw new Error("Failed to fetch app data", { cause: error });
+      throw new Error(`Failed to fetch app data - ${error}`);
     }
   };
 

--- a/extension/src/helpers/hooks/useGetAssetDomainsWithBalances.ts
+++ b/extension/src/helpers/hooks/useGetAssetDomainsWithBalances.ts
@@ -191,7 +191,7 @@ export function useGetAssetDomainsWithBalances(getBalancesOptions: {
       return payload;
     } catch (error) {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
-      throw new Error("Failed to fetch domains", { cause: error });
+      throw new Error(`Failed to fetch domains - ${error}`);
     }
   };
 

--- a/extension/src/helpers/hooks/useGetBalances.tsx
+++ b/extension/src/helpers/hooks/useGetBalances.tsx
@@ -134,7 +134,7 @@ function useGetBalances(options: {
       return payload;
     } catch (error) {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
-      throw new Error("Failed to fetch balances", { cause: error });
+      throw new Error(`Failed to fetch balances - ${error}`);
     }
   };
 

--- a/extension/src/helpers/hooks/useGetHistory.tsx
+++ b/extension/src/helpers/hooks/useGetHistory.tsx
@@ -38,7 +38,7 @@ function useGetHistory() {
       return data;
     } catch (error) {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
-      throw new Error("Failed to fetch history", { cause: error });
+      throw new Error(`Failed to fetch history - ${error}`);
     }
   };
 

--- a/extension/src/helpers/hooks/useTokenDetails.tsx
+++ b/extension/src/helpers/hooks/useTokenDetails.tsx
@@ -56,7 +56,7 @@ function useTokenDetails() {
       return data;
     } catch (error) {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
-      throw new Error("Failed to fetch token details", { cause: error });
+      throw new Error(`Failed to fetch token details - ${error}`);
     }
   };
 

--- a/extension/src/popup/components/manageAssets/SearchAsset/hooks/useSearchData.tsx
+++ b/extension/src/popup/components/manageAssets/SearchAsset/hooks/useSearchData.tsx
@@ -77,7 +77,7 @@ function useGetSearchData(options: {
       return payload;
     } catch (error) {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
-      throw new Error("Failed to fetch search data", { cause: error });
+      throw new Error(`Failed to fetch search data - ${error}`);
     }
   };
 

--- a/extension/src/popup/components/sendPayment/SendDestinationAsset/hooks/useGetDestAssetData.tsx
+++ b/extension/src/popup/components/sendPayment/SendDestinationAsset/hooks/useGetDestAssetData.tsx
@@ -78,7 +78,7 @@ export function useGetDestAssetData(getBalancesOptions: {
       return payload;
     } catch (error) {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
-      throw new Error("Failed to fetch domains", { cause: error });
+      throw new Error(`Failed to fetch domains - ${error}`);
     }
   };
 

--- a/extension/src/popup/components/swap/SwapAsset/hooks/useSwapFromData.tsx
+++ b/extension/src/popup/components/swap/SwapAsset/hooks/useSwapFromData.tsx
@@ -80,7 +80,7 @@ export function useGetSwapFromData(getBalancesOptions: {
       return payload;
     } catch (error) {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
-      throw new Error("Failed to fetch data", { cause: error });
+      throw new Error(`Failed to fetch data - ${error}`);
     }
   };
 


### PR DESCRIPTION
I noticed in Sentry, many of our errors are not coming in with additional context.

For example, this [issue](https://stellarorg.sentry.io/issues/6921618605/?project=5599259&query=is%3Aunresolved%20failed%20to%20fetch%20balances&referrer=issue-stream) is just coming back with the string of `Error loading account data on Account - Error: Failed to fetch balances` when the codebase should be emitting the cause of the error.

Looks like `Error`'s `cause` parameter doesn't get properly stringified when the error is caught by the caller. I checked out the API for this, and for whatever reason, there is no built-in method to concat the Error string and cause (though you would expect `Error.toString()` or something similar to do this). The solution appears to be to manually do this concat yourself. I propose rather than using this `cause` param, we just concat the error string and `cause` together to make sure we get this information into Sentry.

Bummer because the `cause` is a tidy way to organize Error info