### PR TITLE
stringify errors before sending to Sentry

### DIFF
--- a/extension/src/helpers/hooks/useGetAppData.tsx
+++ b/extension/src/helpers/hooks/useGetAppData.tsx
@@ -91,7 +91,7 @@ function useGetAppData() {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
       reduxDispatch(saveAccountError(error));
       Sentry.captureException(`Error loading app data: ${error}`);
-      throw new Error("Failed to fetch app data", { cause: error });
+      throw new Error(`Failed to fetch app data - ${error}`);
     }
   };
 

--- a/extension/src/helpers/hooks/useGetAssetDomainsWithBalances.ts
+++ b/extension/src/helpers/hooks/useGetAssetDomainsWithBalances.ts
@@ -191,7 +191,7 @@ export function useGetAssetDomainsWithBalances(getBalancesOptions: {
       return payload;
     } catch (error) {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
-      throw new Error("Failed to fetch domains", { cause: error });
+      throw new Error(`Failed to fetch domains - ${error}`);
     }
   };
 

--- a/extension/src/helpers/hooks/useGetBalances.tsx
+++ b/extension/src/helpers/hooks/useGetBalances.tsx
@@ -134,7 +134,7 @@ function useGetBalances(options: {
       return payload;
     } catch (error) {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
-      throw new Error("Failed to fetch balances", { cause: error });
+      throw new Error(`Failed to fetch balances - ${error}`);
     }
   };
 

--- a/extension/src/helpers/hooks/useGetHistory.tsx
+++ b/extension/src/helpers/hooks/useGetHistory.tsx
@@ -24,7 +24,7 @@ function useGetHistory() {
       return data;
     } catch (error) {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
-      throw new Error("Failed to fetch history", { cause: error });
+      throw new Error(`Failed to fetch history - ${error}`);
     }
   };
 

--- a/extension/src/popup/components/manageAssets/SearchAsset/hooks/useSearchData.tsx
+++ b/extension/src/popup/components/manageAssets/SearchAsset/hooks/useSearchData.tsx
@@ -77,7 +77,7 @@ function useGetSearchData(options: {
       return payload;
     } catch (error) {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
-      throw new Error("Failed to fetch search data", { cause: error });
+      throw new Error(`Failed to fetch search data - ${error}`);
     }
   };
 

--- a/extension/src/popup/components/sendPayment/SendDestinationAsset/hooks/useGetDestAssetData.tsx
+++ b/extension/src/popup/components/sendPayment/SendDestinationAsset/hooks/useGetDestAssetData.tsx
@@ -78,7 +78,7 @@ export function useGetDestAssetData(getBalancesOptions: {
       return payload;
     } catch (error) {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
-      throw new Error("Failed to fetch domains", { cause: error });
+      throw new Error(`Failed to fetch domains - ${error}`);
     }
   };
 

--- a/extension/src/popup/components/swap/SwapAsset/hooks/useSwapFromData.tsx
+++ b/extension/src/popup/components/swap/SwapAsset/hooks/useSwapFromData.tsx
@@ -80,7 +80,7 @@ export function useGetSwapFromData(getBalancesOptions: {
       return payload;
     } catch (error) {
       dispatch({ type: "FETCH_DATA_ERROR", payload: error });
-      throw new Error("Failed to fetch data", { cause: error });
+      throw new Error(`Failed to fetch data - ${error}`);
     }
   };
 


### PR DESCRIPTION
Closes #2304

Add more context to Sentry alerts so we can properly diagnose issues. This is a re-roll of PR #2302 so we can release this without waiting for the rest of the performance improvements PR's