### PR TITLE
default to empty object if request fails

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -1979,7 +1979,7 @@ export const getHiddenAssets = async ({
     activePublicKey,
   });
 
-  return { hiddenAssets: response.hiddenAssets, error: response.error };
+  return { hiddenAssets: response.hiddenAssets || {}, error: response.error };
 };
 
 export const changeAssetVisibility = async ({


### PR DESCRIPTION
Closes #2311 

This is related to the alert that has been popping up in our alerts channel for the last couple of weeks since I increased the Sentry coverage. This fixes a bug where if a user has the app open in fullscreen mode, goes into the extension and changes the account, polling in the fullscreen window errors because it's trying to retrieve information from Freighter's Background from a non-active account. The security team requested that we implement this to prevent non-active account windows from being able to access Freighter's Background.

This is expected behavior and does not surface any error to the user. Polling just silently stops working. However, this does trigger a TypeError in the code that Sentry correctly reports. This occasionally blasts our alerts channel because of this Sentry alert. My fix here merely fixes the TypeError. Fixing this will make sure if we receive future alerts, we can be confident that there is actually an issue and not this specific TypeError that is being swallowed here.

At one time, this type of account mismatch would automatically trigger a warning notification letting the user know they needed to refresh their window. However, this was based on Redux middleware and since we've moved away from routing requests to Background through Redux, we need to reconsider how we would let the user know that they should refresh their window.

More information: https://stellarfoundation.slack.com/archives/C06MNK4TC22/p1760635333843599