### PR TITLE
Dropdown menu option to copy wallet address

### DIFF
--- a/extension/src/popup/components/account/AccountHeader/index.tsx
+++ b/extension/src/popup/components/account/AccountHeader/index.tsx
@@ -110,6 +110,16 @@ export const AccountHeader = ({
                   }
                 >
                   <>
+                    <div className="AccountHeader__options__item">
+                      <CopyText textToCopy={publicKey} doneLabel={t("Copied!")}>
+                        <Text as="div" size="sm" weight="medium">
+                          {t("Copy address")}
+                        </Text>
+                      </CopyText>
+                      <div className="AccountHeader__options__item__icon">
+                        <Icon.Copy01 />
+                      </div>
+                    </div>
                     {isFunded && (
                       <div
                         className="AccountHeader__options__item"
@@ -126,16 +136,7 @@ export const AccountHeader = ({
                         </div>
                       </div>
                     )}
-                    <div className="AccountHeader__options__item">
-                      <CopyText textToCopy={publicKey} doneLabel={t("Copied!")}>
-                        <Text as="div" size="sm" weight="medium">
-                          {t("Copy address")}
-                        </Text>
-                      </CopyText>
-                      <div className="AccountHeader__options__item__icon">
-                        <Icon.Copy01 />
-                      </div>
-                    </div>
+
                     <div
                       className="AccountHeader__options__item"
                       onClick={() => navigateTo(ROUTES.viewPublicKey, navigate)}


### PR DESCRIPTION
Closes #2289 

Dropdown option to copy address

Currently it's added to the second position to nudge the user that they can copy the address, before they click on the Account details

Also to check if the icon fits - from original issue - Otherwise can update it

Second position (Current):
<div>
<img width="352" height="585" alt="Screenshot 2025-10-20 at 14 18 49" src="https://github.com/user-attachments/assets/a8d6b14e-979c-4182-8605-54f151472986" />

</div>

Alternatively could also add below the account for a quick copy without disrupting much the current UI @sdfcharles
<img width="356" height="606" alt="Screenshot 2025-10-21 at 11 07 08" src="https://github.com/user-attachments/assets/1bb6477e-3626-4c8e-83b1-4f35e088f326" />

-----

On First position:
<img width="401"  alt="Screenshot 2025-10-20 at 14 20 25" src="https://github.com/user-attachments/assets/3d2ff7f4-9526-4cd4-b570-8f1f3756d275" />

Last position:
<img width="377" alt="Screenshot 2025-10-20 at 14 19 56" src="https://github.com/user-attachments/assets/0bdf6e5b-55d9-42d3-9160-5923d0e0c80f" />

Third position:
<img width="360" alt="Screenshot 2025-10-20 at 14 19 39" src="https://github.com/user-attachments/assets/abdf2e43-b63b-4fae-8c05-77d32a532372" />

<img width="611" alt="Screenshot 2025-10-20 at 14 18 38" src="https://github.com/user-attachments/assets/8210f19c-a7ee-44fa-bde8-125a0a6d353d" />
