### PR TITLE
Now that `Done` button properly shows, click it in tests

### DIFF
--- a/extension/e2e-tests/addAsset.test.ts
+++ b/extension/e2e-tests/addAsset.test.ts
@@ -181,6 +181,7 @@ test("Adding classic asset on Testnet", async ({ page, extensionId }) => {
     page.getByTestId("SignTransaction__TrustlineRow__Type"),
   ).toHaveText("Add Trustline");
   await page.getByRole("button", { name: "Confirm" }).click();
+  await page.getByText("Done").click();
   await expect(
     page.getByTestId("ManageAssetRowButton__ellipsis-USDC"),
   ).toBeVisible();
@@ -199,6 +200,7 @@ test("Adding classic asset on Testnet", async ({ page, extensionId }) => {
     page.getByTestId("SignTransaction__TrustlineRow__Type"),
   ).toHaveText("Remove Trustline");
   await page.getByRole("button", { name: "Confirm" }).click();
+  await page.getByText("Done").click();
   await expect(
     page.getByText(
       "You have no assets added. Get started by adding an asset below.",


### PR DESCRIPTION
My previous [PR](https://github.com/stellar/freighter/pull/2352) properly restored the `Done` button at the end of the Add Asset flow. So we need to make the sure the tests click it