### PR TITLE
rm unnecessary calls to make flows even faster

### DIFF
--- a/@shared/api/__tests__/internal.test.ts
+++ b/@shared/api/__tests__/internal.test.ts
@@ -3,13 +3,17 @@ import * as GetLedgerKeyAccounts from "../helpers/getLedgerKeyAccounts";
 import * as internalApi from "../internal";
 
 describe("internalApi", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
   describe("getAssetDomains", () => {
     it("should return a list of domains from a list of issuers", async () => {
       jest
         .spyOn(GetLedgerKeyAccounts, "getLedgerKeyAccounts")
         .mockResolvedValue({
           G1: {
-            account_id: "G1",
+            account_id:
+              "GDF32CQINROD3E2LMCGZUDVMWTXCJFR5SBYVRJ7WAAIAS3P7DCVWZEFY",
             home_domain: "stellar1.org",
             balance: "1000000000000000000",
             seq_num: 1,
@@ -17,24 +21,39 @@ describe("internalApi", () => {
             inflation_dest: "G1",
             flags: 1,
             thresholds: "1000000000000000000",
-            signers: [{ key: "G1", weight: 1 }],
+            signers: [
+              {
+                key: "GDF32CQINROD3E2LMCGZUDVMWTXCJFR5SBYVRJ7WAAIAS3P7DCVWZEFY",
+                weight: 1,
+              },
+            ],
             sequence_number: 1,
           },
           G2: {
-            account_id: "G2",
+            account_id:
+              "GBKWMR7TJ7BBICOOXRY2SWXKCWPTOHZPI6MP4LNNE5A73VP3WADGG3CH",
             home_domain: "stellar2.org",
             balance: "1000000000000000000",
             seq_num: 1,
             num_sub_entries: 1,
-            inflation_dest: "G2",
+            inflation_dest:
+              "GBKWMR7TJ7BBICOOXRY2SWXKCWPTOHZPI6MP4LNNE5A73VP3WADGG3CH",
             flags: 1,
             thresholds: "1000000000000000000",
-            signers: [{ key: "G2", weight: 1 }],
+            signers: [
+              {
+                key: "GBKWMR7TJ7BBICOOXRY2SWXKCWPTOHZPI6MP4LNNE5A73VP3WADGG3CH",
+                weight: 1,
+              },
+            ],
             sequence_number: 1,
           },
         });
       const assetDomains = await internalApi.getAssetDomains({
-        assetIssuerDomainsToFetch: ["G1", "G2"],
+        assetIssuerDomainsToFetch: [
+          "GDF32CQINROD3E2LMCGZUDVMWTXCJFR5SBYVRJ7WAAIAS3P7DCVWZEFY",
+          "GBKWMR7TJ7BBICOOXRY2SWXKCWPTOHZPI6MP4LNNE5A73VP3WADGG3CH",
+        ],
         networkDetails: TESTNET_NETWORK_DETAILS,
       });
 
@@ -51,6 +70,20 @@ describe("internalApi", () => {
         assetIssuerDomainsToFetch: ["G1", "G2"],
         networkDetails: TESTNET_NETWORK_DETAILS,
       });
+      expect(assetDomains).toEqual({});
+    });
+    it("should return an empty object if not valid public keys are provided", async () => {
+      const getLedgerKeyAccountsSpy = jest.spyOn(
+        GetLedgerKeyAccounts,
+        "getLedgerKeyAccounts",
+      );
+      const assetDomains = await internalApi.getAssetDomains({
+        assetIssuerDomainsToFetch: [
+          "CAZXRTOKNUQ2JQQF3NCRU7GYMDJNZ2NMQN6IGN4FCT5DWPODMPVEXSND",
+        ],
+        networkDetails: TESTNET_NETWORK_DETAILS,
+      });
+      expect(getLedgerKeyAccountsSpy).not.toHaveBeenCalled();
       expect(assetDomains).toEqual({});
     });
   });

--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -1227,6 +1227,9 @@ export const getAssetDomains = async ({
   const filteredAssetIssuerDomainsToFetch = assetIssuerDomainsToFetch.filter(
     (domain) => StrKey.isValidEd25519PublicKey(domain),
   );
+  if (filteredAssetIssuerDomainsToFetch.length === 0) {
+    return assetDomains;
+  }
   try {
     const fetchedAccounts = await getLedgerKeyAccounts({
       accountList: filteredAssetIssuerDomainsToFetch,

--- a/extension/e2e-tests/sendPayment.test.ts
+++ b/extension/e2e-tests/sendPayment.test.ts
@@ -255,6 +255,17 @@ test("Send persists inputs and submits to network", async ({
   extensionId,
 }) => {
   test.slow();
+  let isScanSkiped = false;
+  page.on("request", (request) => {
+    if (
+      request
+        .url()
+        .includes("GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF")
+    ) {
+      isScanSkiped = request.url().includes("should_skip_scan=true");
+    }
+  });
+
   await loginAndFund({ page, extensionId });
   await page.getByTestId("nav-link-send").click({ force: true });
 
@@ -265,8 +276,9 @@ test("Send persists inputs and submits to network", async ({
   await page
     .getByTestId("send-to-input")
     .fill("GBTYAFHGNZSTE4VBWZYAGB3SRGJEPTI5I4Y22KZ4JTVAN56LESB6JZOF");
-  await page.getByText("Continue").click();
 
+  await page.getByText("Continue").click();
+  expect(isScanSkiped).toBeTruthy();
   await expect(page.getByTestId("send-amount-amount-input")).toBeVisible();
   await page.getByTestId("send-amount-amount-input").fill("1");
   await page.getByTestId("send-amount-btn-memo").click();

--- a/extension/src/popup/components/sendPayment/SendTo/hooks/useSendToData.tsx
+++ b/extension/src/popup/components/sendPayment/SendTo/hooks/useSendToData.tsx
@@ -95,6 +95,7 @@ function useSendToData() {
             _isMainnet,
             networkDetails,
             true,
+            true,
           );
           if (isError<AccountBalances>(destinationBalances)) {
             throw new Error(destinationBalances.message);


### PR DESCRIPTION
This PR makes 2 small adjustments to speed up 2 API calls:

1. Don't make a call to fetch ledger key accounts if the user is trying to fetch a home domain for a non-G address (contract address). The API handles this gracefully, but why make an extra an API call if not needed
2. When we fetch the balances of a destination address in the Send flow, no need to fetch the blockaid scan results. That needlessly slows us down