### PR TITLE
ensure center alignment for metadata

### DIFF
--- a/extension/src/popup/components/account/CollectibleDetail/styles.scss
+++ b/extension/src/popup/components/account/CollectibleDetail/styles.scss
@@ -78,15 +78,17 @@
     background: var(--sds-clr-gray-02);
     border-radius: pxToRem(16px);
     display: flex;
+    justify-content: center;
     flex-direction: column;
     padding: pxToRem(12px) pxToRem(24px);
     width: pxToRem(134px);
+    text-align: center;
   }
 
   &__attribute__trait {
     color: var(--sds-clr-gray-11);
     font-size: pxToRem(12px);
-    font-weight: var(--sds-fw-medium);
+    font-weight: var(--sds-fw-semi-bold);
     line-height: pxToRem(18px);
     max-width: 100%;
     overflow: scroll;


### PR DESCRIPTION
Related to release/5.37.0 QA:

This pull request makes minor improvements to the styling of collectible attributes in the `CollectibleDetail` component. The changes enhance layout and text appearance for better visual consistency. 

Styling enhancements:

* Centered the content and text within the collectible attribute container by adding `justify-content: center` and `text-align: center` to the relevant class in `styles.scss`.
* Increased the font weight of the attribute trait from medium to semi-bold for improved emphasis.

Before:
<img width="299" height="337" alt="image (2)" src="https://github.com/user-attachments/assets/a6f4aa6f-bfd5-4b7a-b513-d177093b54b5" />

After:
<img width="361" height="600" alt="Screenshot 2026-01-23 at 4 02 11 PM" src="https://github.com/user-attachments/assets/4c2ce106-e1a6-4971-b765-c40a9337564d" />
