### PR TITLE
fix: SAC check for add asset flow in submit transaction

### DIFF
--- a/extension/src/popup/components/manageAssets/AddAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/AddAsset/index.tsx
@@ -145,6 +145,7 @@ export const AddAsset = () => {
       const issuer = isSacContract
         ? tokenDetailsResponse.name.split(":")[1] || ""
         : contractId; // get the issuer name, if applicable ,
+
       const scannedAsset = await scanAsset(
         `${tokenDetailsResponse.symbol}-${issuer}`,
         networkDetails,

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/ChangeTrustInternal/hooks/useChangeTrustData.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/ChangeTrustInternal/hooks/useChangeTrustData.tsx
@@ -61,6 +61,7 @@ function useGetChangeTrustData({
         },
         networkDetails,
       });
+
       if (!asset.contract || isSac) {
         const server = stellarSdkServer(
           networkDetails.networkUrl,


### PR DESCRIPTION
Closes #2537 

What
Fixes a regression in the submit transaction flow of asset management. It now correctly identifies a SAC and submits a transaction to change the trustline in those cases.

Why
SACs were being treated as SEP-41 tokens, resulting in no new trustline being added.