### PR TITLE
disable swap button before user has selected dest

### DIFF
--- a/extension/src/popup/components/swap/SwapAmount/index.tsx
+++ b/extension/src/popup/components/swap/SwapAmount/index.tsx
@@ -346,20 +346,16 @@ export const SwapAmount = ({
               variant="secondary"
               isLoading={simulationState.state === RequestState.LOADING}
               disabled={
-                !!destinationAsset &&
-                ((inputType === "crypto" &&
+                !destinationAsset ||
+                (inputType === "crypto" &&
                   new BigNumber(formik.values.amount).isZero()) ||
-                  (inputType === "fiat" &&
-                    new BigNumber(formik.values.amountUsd).isZero()) ||
-                  isAmountTooHigh)
+                (inputType === "fiat" &&
+                  new BigNumber(formik.values.amountUsd).isZero()) ||
+                isAmountTooHigh
               }
               onClick={(e) => {
                 e.preventDefault();
-                if (destinationAsset) {
-                  formik.submitForm();
-                  return;
-                }
-                goToNext();
+                formik.submitForm();
               }}
             >
               {destinationAsset ? t("Review swap") : t("Select an asset")}

--- a/extension/src/popup/views/__tests__/Swap.test.tsx
+++ b/extension/src/popup/views/__tests__/Swap.test.tsx
@@ -972,4 +972,127 @@ describe.skip("Swap", () => {
       expect(within(dstTile).getByText("Choose asset")).toBeDefined();
     });
   });
+
+  describe("Select an asset button disabled state", () => {
+    it("Select an asset button is disabled when no destination asset is selected", async () => {
+      render(
+        <Wrapper
+          routes={[ROUTES.swap]}
+          state={{
+            auth: {
+              error: null,
+              applicationState: ApplicationState.PASSWORD_CREATED,
+              publicKey,
+              allAccounts: mockAccounts,
+              hasPrivateKey: true,
+            },
+            settings: {
+              networkDetails: TESTNET_NETWORK_DETAILS,
+              networksList: DEFAULT_NETWORKS,
+            },
+            transactionSubmission: {
+              ...transactionSubmissionInitialState,
+              accountBalances: swapMockBalances,
+            },
+          }}
+        >
+          <Swap />
+        </Wrapper>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("send-amount-amount-input")).toBeDefined();
+      });
+
+      const continueButton = screen.getByTestId("swap-amount-btn-continue");
+      expect(continueButton).toBeDisabled();
+      expect(continueButton).toHaveTextContent("Select an asset");
+    });
+
+    it("Button shows Review swap and is enabled when destination asset is selected and amount > 0", async () => {
+      const testAsset =
+        "SRT:GCDNJUBQSX7AJWLJACMJ7I4BC3Z47BQUTMHEICZLE6MU4KQBRYG5JY6B";
+      render(
+        <Wrapper
+          routes={[`${ROUTES.swap}?destination_asset=${testAsset}`]}
+          state={{
+            auth: {
+              error: null,
+              applicationState: ApplicationState.PASSWORD_CREATED,
+              publicKey,
+              allAccounts: mockAccounts,
+              hasPrivateKey: true,
+            },
+            settings: {
+              networkDetails: TESTNET_NETWORK_DETAILS,
+              networksList: DEFAULT_NETWORKS,
+            },
+            transactionSubmission: {
+              ...transactionSubmissionInitialState,
+              transactionData: {
+                ...transactionSubmissionInitialState.transactionData,
+                destinationAsset: testAsset,
+              },
+              accountBalances: swapMockBalances,
+            },
+          }}
+        >
+          <Swap />
+        </Wrapper>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("send-amount-amount-input")).toBeDefined();
+      });
+
+      const amountInput = screen.getByTestId("send-amount-amount-input");
+      fireEvent.change(amountInput, { target: { value: "10" } });
+
+      await waitFor(() => {
+        const continueButton = screen.getByTestId("swap-amount-btn-continue");
+        expect(continueButton).toBeEnabled();
+        expect(continueButton).toHaveTextContent("Review swap");
+      });
+    });
+
+    it("Button remains disabled with destination asset but zero amount", async () => {
+      const testAsset =
+        "SRT:GCDNJUBQSX7AJWLJACMJ7I4BC3Z47BQUTMHEICZLE6MU4KQBRYG5JY6B";
+      render(
+        <Wrapper
+          routes={[`${ROUTES.swap}?destination_asset=${testAsset}`]}
+          state={{
+            auth: {
+              error: null,
+              applicationState: ApplicationState.PASSWORD_CREATED,
+              publicKey,
+              allAccounts: mockAccounts,
+              hasPrivateKey: true,
+            },
+            settings: {
+              networkDetails: TESTNET_NETWORK_DETAILS,
+              networksList: DEFAULT_NETWORKS,
+            },
+            transactionSubmission: {
+              ...transactionSubmissionInitialState,
+              transactionData: {
+                ...transactionSubmissionInitialState.transactionData,
+                destinationAsset: testAsset,
+              },
+              accountBalances: swapMockBalances,
+            },
+          }}
+        >
+          <Swap />
+        </Wrapper>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("send-amount-amount-input")).toBeDefined();
+      });
+
+      const continueButton = screen.getByTestId("swap-amount-btn-continue");
+      expect(continueButton).toBeDisabled();
+    });
+  });
 });


### PR DESCRIPTION
Closes #2445 

Before:
<img width="364" height="595" alt="Screenshot 2026-02-09 at 10 03 36 PM" src="https://github.com/user-attachments/assets/914f4fe4-9ba1-43dd-9bd5-5bcad89d1c38" />

After:
<img width="362" height="600" alt="Screenshot 2026-02-09 at 10 03 15 PM" src="https://github.com/user-attachments/assets/6dcbd91d-8063-46ee-b295-e12a70e67e13" />

This pull request improves the logic and user experience for the swap amount continue button in the swap flow. The main change ensures the button is only enabled when the correct conditions are met, and adds thorough tests to confirm the new behavior.

**Swap button logic improvements:**

* Updated the disabled state for the continue button in `SwapAmount` so it is now disabled when no destination asset is selected, or when the entered amount is zero, or if the amount is too high. This ensures users cannot proceed without selecting an asset and entering a valid amount.

**Testing enhancements:**

* Added a new test suite to `Swap.test.tsx` that verifies the continue button is disabled when no destination asset is selected, enabled when a destination asset is selected and the amount is greater than zero, and remains disabled if the amount is zero, even with a destination asset.