### PR TITLE
add margin to fullscreen notification

### DIFF
--- a/extension/src/popup/views/Account/styles.scss
+++ b/extension/src/popup/views/Account/styles.scss
@@ -38,7 +38,7 @@
   }
 
   &__fullscreen {
-    margin-top: 1.5rem;
+    margin-top: pxToRem(24) pxToRem(24) 0;
   }
 
   &__fetch-fail {


### PR DESCRIPTION
This pull request makes a small adjustment to the styling of the `Account` popup view. It adds space around the notification to keep it from crashing into the sides. The margin for the `__fullscreen` class is now set using the `pxToRem` function for better consistency and scalability.

After:

<img width="847" height="996" alt="Screenshot 2026-02-25 at 12 51 06 PM" src="https://github.com/user-attachments/assets/58d1373c-db3a-4cd6-bea5-9804180d034a" />
