### PR TITLE
fix(sign tx): Correct asset decimals for SEP-41 tokens in asset diffs

### DIFF
--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -669,8 +669,17 @@ const AssetDiffs = ({ assetDiffs, icons }: AssetDiffsProps) => {
       return null;
     }
 
+    const rawDecimals = asset.decimals;
+    if (
+      rawDecimals !== undefined &&
+      (typeof rawDecimals !== "number" ||
+        !Number.isFinite(rawDecimals) ||
+        rawDecimals < 0)
+    ) {
+      return null;
+    }
     const decimals =
-      (asset.decimals as number | undefined) ?? CLASSIC_ASSET_DECIMALS;
+      (rawDecimals as number | undefined) ?? CLASSIC_ASSET_DECIMALS;
 
     return (
       <div className="SignTransaction__AssetDiffRow">

--- a/extension/src/popup/views/__tests__/SignTransaction.test.tsx
+++ b/extension/src/popup/views/__tests__/SignTransaction.test.tsx
@@ -1550,4 +1550,168 @@ describe("SignTransactions", () => {
     expect(screen.getByText("E2E")).toBeInTheDocument();
     expect(screen.getByText("-0.5")).toBeInTheDocument();
   });
+
+  it("skips asset diffs when decimals is not a valid number", async () => {
+    let currentSignTxDataMock = {
+      state: {
+        state: RequestState.SUCCESS,
+        data: {
+          type: AppDataType.RESOLVED,
+          scanResult: {
+            simulation: {
+              status: "Success",
+              assets_diffs: {
+                [mockAccounts[0].publicKey]: [
+                  {
+                    // invalid: decimals is a string — should be skipped
+                    asset_type: "SEP41",
+                    asset: {
+                      symbol: "BAD",
+                      address:
+                        "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+                      decimals: "not-a-number",
+                      name: "Bad Token",
+                      type: "CONTRACT",
+                    },
+                    in: {
+                      raw_value: 1000,
+                      value: "1",
+                      usd_price: "0",
+                    },
+                    out: null,
+                  },
+                  {
+                    // valid SEP-41 entry — should render
+                    asset_type: "SEP41",
+                    asset: {
+                      symbol: "GOOD",
+                      address:
+                        "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+                      decimals: 3,
+                      name: "Good Token",
+                      type: "CONTRACT",
+                    },
+                    in: null,
+                    out: {
+                      raw_value: 500,
+                      value: "0.5",
+                      usd_price: "0",
+                    },
+                  },
+                ],
+              },
+            },
+          } as any,
+          validation: null,
+          request_id: "1",
+          icons: {},
+          balances: {
+            balances: sortBalances(mockBalances.balances),
+            isFunded: true,
+            subentryCount: 0,
+          },
+          publicKey: mockAccounts[1].publicKey,
+          signFlowState: {
+            allAccounts: mockAccounts,
+            accountNotFound: false,
+            currentAccount: mockAccounts[0],
+          },
+          applicationState: APPLICATION_STATE.MNEMONIC_PHRASE_CONFIRMED,
+          networkDetails: {
+            ...defaultSettingsState.networkDetails,
+            networkPassphrase: "Test SDF Network ; September 2015",
+          },
+          siteScanData: null,
+          blockaidOverrideState: null,
+        },
+        error: null,
+      },
+      fetchData: jest.fn(),
+    } as ReturnType<typeof SignTxDataHooks.useGetSignTxData>;
+    jest
+      .spyOn(SignTxDataHooks, "useGetSignTxData")
+      .mockReturnValue(currentSignTxDataMock);
+    jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+      Promise.resolve({
+        networkDetails: {
+          ...defaultSettingsState.networkDetails,
+          networkPassphrase: "Test SDF Network ; September 2015",
+          networkName: "Test Net",
+        },
+        networksList: DEFAULT_NETWORKS,
+        hiddenAssets: {},
+        allowList: {
+          "Test Net": {
+            [mockAccounts[0].publicKey]: ["laboratory.stellar.org"],
+          },
+        },
+        error: "",
+        isDataSharingAllowed: false,
+        isMemoValidationEnabled: false,
+        isHideDustEnabled: true,
+        settingsState: SettingsState.SUCCESS,
+        isSorobanPublicEnabled: false,
+        isRpcHealthy: true,
+        userNotification: {
+          enabled: false,
+          message: "",
+        },
+        isExperimentalModeEnabled: false,
+        isHashSigningEnabled: false,
+        isNonSSLEnabled: false,
+        experimentalFeaturesState: SettingsState.SUCCESS,
+        assetsLists: DEFAULT_ASSETS_LISTS,
+      }),
+    );
+    const transaction = TransactionBuilder.fromXDR(
+      transactions.classic,
+      Networks.TESTNET,
+    ) as Transaction<Memo<MemoType>, Operation.InvokeHostFunction[]>;
+    const op = transaction.operations[0];
+    jest.spyOn(Stellar, "getTransactionInfo").mockImplementation(() => ({
+      ...mockTransactionInfo,
+      transactionXdr: transactions.classic,
+      transaction: {
+        ...mockTransactionInfo.transaction,
+        _networkPassphrase: Networks.TESTNET,
+        _operations: [op],
+      },
+      isHttpsDomain: false,
+      domain: "laboratory.stellar.org",
+      uuid: "123-123-123-123-123",
+    }));
+    render(
+      <Wrapper
+        routes={[ROUTES.signTransaction]}
+        state={{
+          auth: {
+            allAccounts: mockAccounts,
+            publicKey: mockAccounts[0].publicKey,
+          },
+          settings: {
+            allowList: {
+              "Test Net": {
+                [mockAccounts[0].publicKey]: ["laboratory.stellar.org"],
+              },
+            },
+            isExperimentalModeEnabled: false,
+            networkDetails: {
+              ...defaultSettingsState.networkDetails,
+              networkPassphrase: "Test SDF Network ; September 2015",
+              networkName: "Test Net",
+            },
+          },
+        }}
+      >
+        <SignTransaction />
+      </Wrapper>,
+    );
+    await waitFor(() => screen.getByTestId("SignTransaction"));
+    // Invalid entry (non-numeric decimals) should be skipped
+    expect(screen.queryByText("BAD")).not.toBeInTheDocument();
+    expect(screen.queryByText("+1")).not.toBeInTheDocument();
+    // Valid entry should still render
+    expect(screen.getByText("GOOD")).toBeInTheDocument();
+    expect(screen.getByText("-0.5")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Closes #2633 

What
Blockaid returns SEP-41/Soroban token asset diffs with a different shape
than classic assets (symbol/address/decimals instead of code/issuer).
The previous code only handled NATIVE/ASSET types with hardcoded 7
decimals, causing incorrect amounts for SEP-41 tokens (e.g., displaying
0.00005 instead of 0.5 for a 3-decimal token).

Remove the switch statement and extract code/issuer/decimals uniformly
from all asset types, falling back to CLASSIC_ASSET_DECIMALS (7) when
decimals is not present.

Why
Incorrectly displaying decimals for Soroban tokens in the asset diff section from Blockaid data.

<img width="347" height="617" alt="Screenshot 2026-03-11 at 2 42 52 PM" src="https://github.com/user-attachments/assets/645ec5ce-9258-4ac6-b803-25052fa1ff99" />
