### PR TITLE
Min release age

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,7 +1,6 @@
 enableScripts: false
 
-# 7 days in minutes (7 * 24 * 60)
-npmMinimalAgeGate: 10080
+npmMinimalAgeGate: 7d
 
 # Uncomment to bypass the age gate when we need a stellar-sdk release immediately
 # (e.g. critical bug fix or new Stellar protocol upgrade that Freighter must support on day one)

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,7 @@
 enableScripts: false
 
-npmMinimalAgeGate: 7d
+# 7 days in minutes (7 * 24 * 60)
+npmMinimalAgeGate: 10080
 
 # Uncomment to bypass the age gate when we need a stellar-sdk release immediately
 # (e.g. critical bug fix or new Stellar protocol upgrade that Freighter must support on day one)

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,10 @@
 enableScripts: false
 
+npmMinimalAgeGate: 7d
+
+# Uncomment to bypass the age gate when we need a stellar-sdk release immediately
+# (e.g. critical bug fix or new Stellar protocol upgrade that Freighter must support on day one)
+# npmPreapprovedPackages:
+#   - "@stellar/stellar-sdk"
+
 nodeLinker: node-modules

--- a/package.json
+++ b/package.json
@@ -144,5 +144,5 @@
     "debug@4.4.2": "4.4.1",
     "ansi-styles@6.2.2": "6.2.3"
   },
-  "packageManager": "yarn@4.9.4"
+  "packageManager": "yarn@4.10.0"
 }


### PR DESCRIPTION
This pull request introduces a configuration change to slow down the adoption of new npm package versions by setting a minimal age gate, and updates the Yarn package manager version used in the project.

Dependency management improvements:

* Added `npmMinimalAgeGate: 7d` to `.yarnrc.yml` to ensure that only npm packages published at least 7 days ago can be installed, reducing the risk of supply chain attacks from newly published, potentially malicious packages.
* Updated the Yarn version in `package.json` from `4.9.4` to `4.10.0` to keep the package manager up to date.

Configuration flexibility:

* Added commented-out configuration in `.yarnrc.yml` to allow bypassing the age gate for urgent `@stellar/stellar-sdk` releases if necessary.