### PR TITLE
Add ref_name input to beta and production deploy workflows

### DIFF
--- a/.github/workflows/submitBeta.yml
+++ b/.github/workflows/submitBeta.yml
@@ -13,6 +13,11 @@ on:
         description: Beta version
         default: "0"
         required: true
+      ref_name:
+        description:
+          A git ref to checkout (branch/tag/sha). Defaults to release/<release>
+        type: string
+        default: ""
 jobs:
   bump-version:
     name: Bump Package Version and Submit Extension
@@ -28,10 +33,17 @@ jobs:
           echo "Missing INDEXER_V2_URL"
           gh run cancel ${{ github.run_id }}
           gh run watch ${{ github.run_id }}
+      - name: Set ref
+        run: |
+          if [[ "${{ github.event.inputs.ref_name }}" != "" ]]; then
+            echo "REF_NAME=${{ github.event.inputs.ref_name }}" >> $GITHUB_ENV
+          else
+            echo "REF_NAME=release/${{ github.event.inputs.release }}" >> $GITHUB_ENV
+          fi
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: release/${{ github.event.inputs.release }}
+          ref: ${{ env.REF_NAME }}
       - name: Update manifest-v2.json name
         uses: jossef/action-set-json-field@2a0f7d953b580b828717daf4de7fafc7e4135e97 #v2
         with:

--- a/.github/workflows/submitBeta.yml
+++ b/.github/workflows/submitBeta.yml
@@ -33,17 +33,13 @@ jobs:
           echo "Missing INDEXER_V2_URL"
           gh run cancel ${{ github.run_id }}
           gh run watch ${{ github.run_id }}
-      - name: Set ref
-        run: |
-          if [[ "${{ github.event.inputs.ref_name }}" != "" ]]; then
-            echo "REF_NAME=${{ github.event.inputs.ref_name }}" >> $GITHUB_ENV
-          else
-            echo "REF_NAME=release/${{ github.event.inputs.release }}" >> $GITHUB_ENV
-          fi
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ env.REF_NAME }}
+          ref: ${{ github.event.inputs.ref_name != '' && github.event.inputs.ref_name || format('release/{0}', github.event.inputs.release) }}
+      - name: Get checkout SHA
+        id: checkout_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Update manifest-v2.json name
         uses: jossef/action-set-json-field@2a0f7d953b580b828717daf4de7fafc7e4135e97 #v2
         with:
@@ -130,6 +126,7 @@ jobs:
             github.event.inputs.version }}
           draft: false
           prerelease: true
+          target_commitish: ${{ steps.checkout_sha.outputs.sha }}
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/submitProduction.yml
+++ b/.github/workflows/submitProduction.yml
@@ -5,6 +5,11 @@ env:
   HUSKY: 0
 on:
   workflow_dispatch:
+    inputs:
+      ref_name:
+        description: A git commit/hash/tag (optional, defaults to master)
+        type: string
+        default: ""
 jobs:
   bump-version:
     name: Bump Package Version and Submit Extension
@@ -20,8 +25,17 @@ jobs:
           echo "Missing INDEXER_V2_URL"
           gh run cancel ${{ github.run_id }}
           gh run watch ${{ github.run_id }}
+      - name: Set ref
+        run: |
+          if [[ "${{ github.event.inputs.ref_name }}" != "" ]]; then
+            echo "REF_NAME=${{ github.event.inputs.ref_name }}" >> $GITHUB_ENV
+          else
+            echo "REF_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
+          fi
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ env.REF_NAME }}
       - name: Get version from package.json
         id: package_version
         run: |
@@ -36,9 +50,8 @@ jobs:
           node-version: 22
       - run: >
           yarn && yarn build:freighter-api && yarn build:extension:production
-          --env AMPLITUDE_KEY="${{ secrets.AMPLITUDE_KEY }}"
-          SENTRY_KEY="${{ secrets.SENTRY_KEY }}"
-          BUILD_TYPE="production"
+          --env AMPLITUDE_KEY="${{ secrets.AMPLITUDE_KEY }}" SENTRY_KEY="${{
+          secrets.SENTRY_KEY }}" BUILD_TYPE="production"
       - name: Install zip
         uses: montudor/action-zip@0852c26906e00f8a315c704958823928d8018b28 #v1.0.0
       - name: Create git tag

--- a/.github/workflows/submitProduction.yml
+++ b/.github/workflows/submitProduction.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       ref_name:
-        description: A git commit/hash/tag (optional, defaults to master)
+        description: A git commit/hash/tag (optional, defaults to the selected branch or tag)
         type: string
         default: ""
 jobs:
@@ -25,17 +25,13 @@ jobs:
           echo "Missing INDEXER_V2_URL"
           gh run cancel ${{ github.run_id }}
           gh run watch ${{ github.run_id }}
-      - name: Set ref
-        run: |
-          if [[ "${{ github.event.inputs.ref_name }}" != "" ]]; then
-            echo "REF_NAME=${{ github.event.inputs.ref_name }}" >> $GITHUB_ENV
-          else
-            echo "REF_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
-          fi
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ env.REF_NAME }}
+          ref: ${{ github.event.inputs.ref_name != '' && github.event.inputs.ref_name || github.ref_name }}
+      - name: Get checkout SHA
+        id: checkout_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Get version from package.json
         id: package_version
         run: |
@@ -67,6 +63,7 @@ jobs:
           body: ${{ steps.package_version.outputs.version }}
           draft: false
           prerelease: false
+          target_commitish: ${{ steps.checkout_sha.outputs.sha }}
       - name: Build for Firefox
         id: web-ext-build
         uses: kewisch/action-web-ext@fe10addf5d5e5ba6b78ffde720dd488a27d10e8c #v1


### PR DESCRIPTION
- [x] Fix `ref_name` description in submitProduction.yml (was "defaults to master", now "defaults to the selected branch or tag")
- [x] Remove env-file injection risk: replace `echo REF_NAME=... >> $GITHUB_ENV` with inline GitHub expression in `actions/checkout` `ref` field (both workflows)
- [x] Add `target_commitish` (checked-out SHA via `git rev-parse HEAD`) to `actions/create-release@v1` in both workflows to ensure releases point to the correct commit