### PR TITLE
fix: Account for fee in Set Max calculation

### DIFF
--- a/@shared/helpers/stellar.ts
+++ b/@shared/helpers/stellar.ts
@@ -126,7 +126,8 @@ export const makeDisplayableBalances = async (
           .plus(num_sponsoring)
           .minus(num_sponsored)
           .times(BASE_RESERVE)
-          .plus(sellingLiabilities),
+          .plus(sellingLiabilities)
+          .plus(StellarSdk.stroopsToLumens(StellarSdk.BASE_FEE)),
         blockaidData: defaultBlockaidScanAssetResult,
       };
       continue;


### PR DESCRIPTION
## Summary

The 'Set Max' button in the send flow was not accounting for the transaction fee, causing 'not enough funds' errors when trying to send the maximum amount of XLM. This has been fixed by including a base transaction fee in the minimum balance calculation, effectively reducing the max sendable amount to cover the fee.

## Changes

- **@shared/helpers/stellar.ts**: In `makeDisplayableBalances`, the calculation for the native asset's `minimumBalance` now includes the base transaction fee. This ensures that when the 'Set Max' amount is calculated (as `total` - `minimumBalance`), it reserves enough XLM to cover the transaction fee, preventing an 'insufficient funds' error.

## Related Issue

Closes #2665

