### PR TITLE
Harden collectible metadata fetch with bounded reads

### DIFF
--- a/@shared/api/helpers/__tests__/fetchCollectibles.test.ts
+++ b/@shared/api/helpers/__tests__/fetchCollectibles.test.ts
@@ -1,8 +1,19 @@
 import { fetchCollectibles } from "../fetchCollectibles";
+import { fetchMetadataJson } from "../fetchMetadataJson";
 import { TESTNET_NETWORK_DETAILS } from "@shared/constants/stellar";
 import { INDEXER_V2_URL } from "@shared/constants/mercury";
 
+jest.mock("../fetchMetadataJson", () => ({
+  fetchMetadataJson: jest.fn(),
+}));
+
+const mockedFetchMetadataJson = fetchMetadataJson as jest.Mock;
+
 describe("fetchCollectibles", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("should return collectibles", async () => {
     const metadata = {
       name: "Collectible Name",
@@ -16,6 +27,9 @@ describe("fetchCollectibles", () => {
         },
       ],
     };
+
+    mockedFetchMetadataJson.mockResolvedValue(metadata);
+
     // @ts-ignore
     jest.spyOn(global, "fetch").mockImplementation((url: any) => {
       if (url.toString() === `${INDEXER_V2_URL}/collectibles?network=TESTNET`) {
@@ -58,10 +72,7 @@ describe("fetchCollectibles", () => {
             }),
         });
       }
-      return Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve(metadata),
-      });
+      return Promise.reject(new Error(`unexpected fetch: ${url}`));
     });
 
     const collectibles = await fetchCollectibles({
@@ -128,8 +139,20 @@ describe("fetchCollectibles", () => {
         },
       },
     ]);
+
+    expect(mockedFetchMetadataJson).toHaveBeenCalledWith(
+      "https://nftcalendar.io/token/1",
+    );
+    expect(mockedFetchMetadataJson).toHaveBeenCalledWith(
+      "https://nftcalendar.io/token/2",
+    );
   });
+
   it("should return collectibles for owner with no metadata", async () => {
+    mockedFetchMetadataJson.mockRejectedValue(
+      new Error("metadata unavailable"),
+    );
+
     // @ts-ignore
     jest.spyOn(global, "fetch").mockImplementation((url: any) => {
       if (url.toString() === `${INDEXER_V2_URL}/collectibles?network=TESTNET`) {
@@ -158,11 +181,9 @@ describe("fetchCollectibles", () => {
             }),
         });
       }
-      return Promise.resolve({
-        ok: false,
-        json: () => Promise.resolve({}),
-      });
+      return Promise.reject(new Error(`unexpected fetch: ${url}`));
     });
+
     const collectibles = await fetchCollectibles({
       publicKey: "G1",
       contracts: [{ id: "C1", token_ids: ["1"] }],

--- a/@shared/api/helpers/__tests__/fetchMetadataJson.test.ts
+++ b/@shared/api/helpers/__tests__/fetchMetadataJson.test.ts
@@ -30,26 +30,33 @@ const makeResponse = ({
   ok = true,
   status = 200,
   statusText = "OK",
+  url = "https://example.com/metadata.json",
   contentLength = null,
   reader = null,
   text = "",
+  bodyCancel = jest.fn().mockResolvedValue(undefined),
 }: {
   ok?: boolean;
   status?: number;
   statusText?: string;
+  url?: string;
   contentLength?: string | null;
   reader?: FakeReader | null;
   text?: string;
+  bodyCancel?: jest.Mock;
 } = {}): Response =>
   ({
     ok,
     status,
     statusText,
+    url,
     headers: {
       get: (name: string) =>
         name.toLowerCase() === "content-length" ? contentLength : null,
     },
-    body: reader ? { getReader: () => reader } : undefined,
+    body: reader
+      ? { getReader: () => reader, cancel: bodyCancel }
+      : { cancel: bodyCancel },
     text: jest.fn().mockResolvedValue(text),
   }) as unknown as Response;
 
@@ -173,6 +180,53 @@ describe("fetchMetadataJson", () => {
       ).rejects.toThrow(/404/);
     });
 
+    it("cancels the response body on a non-OK status", async () => {
+      const bodyCancel = jest.fn().mockResolvedValue(undefined);
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({
+          ok: false,
+          status: 500,
+          statusText: "Server Error",
+          bodyCancel,
+        }),
+      );
+
+      await expect(
+        fetchMetadataJson("https://example.com/err.json"),
+      ).rejects.toThrow();
+      expect(bodyCancel).toHaveBeenCalled();
+    });
+
+    it("rejects when the final response.url has a non-https scheme (redirect bypass)", async () => {
+      const bodyCancel = jest.fn().mockResolvedValue(undefined);
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({
+          url: "http://evil.example.com/metadata.json",
+          reader: makeReader([encode('{"name":"x"}')]),
+          bodyCancel,
+        }),
+      );
+
+      await expect(
+        fetchMetadataJson("https://example.com/metadata.json"),
+      ).rejects.toThrow(/non-https/);
+      expect(bodyCancel).toHaveBeenCalled();
+    });
+
+    it("accepts https→https redirects", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({
+          url: "https://cdn.example.com/metadata.json",
+          reader: makeReader([encode('{"name":"ok"}')]),
+        }),
+      );
+
+      const result = await fetchMetadataJson<{ name: string }>(
+        "https://example.com/metadata.json",
+      );
+      expect(result).toEqual({ name: "ok" });
+    });
+
     it("parses valid JSON from streamed body", async () => {
       const body = '{"name":"Test NFT","image":"https://example.com/img.png"}';
       (global.fetch as jest.Mock).mockResolvedValue(
@@ -226,6 +280,22 @@ describe("fetchMetadataJson", () => {
       await expect(
         fetchMetadataJson("https://example.com/huge.json"),
       ).rejects.toThrow(/too large/i);
+    });
+
+    it("cancels the response body when Content-Length pre-check rejects", async () => {
+      const bodyCancel = jest.fn().mockResolvedValue(undefined);
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({
+          contentLength: String(MAX_METADATA_BYTES + 1),
+          reader: makeReader([encode("{}")]),
+          bodyCancel,
+        }),
+      );
+
+      await expect(
+        fetchMetadataJson("https://example.com/huge.json"),
+      ).rejects.toThrow();
+      expect(bodyCancel).toHaveBeenCalled();
     });
 
     it("accepts when Content-Length equals MAX_METADATA_BYTES", async () => {

--- a/@shared/api/helpers/__tests__/fetchMetadataJson.test.ts
+++ b/@shared/api/helpers/__tests__/fetchMetadataJson.test.ts
@@ -213,6 +213,22 @@ describe("fetchMetadataJson", () => {
       expect(bodyCancel).toHaveBeenCalled();
     });
 
+    it("rejects when the final response.url cannot be parsed (fail closed)", async () => {
+      const bodyCancel = jest.fn().mockResolvedValue(undefined);
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({
+          url: "not a url",
+          reader: makeReader([encode('{"name":"x"}')]),
+          bodyCancel,
+        }),
+      );
+
+      await expect(
+        fetchMetadataJson("https://example.com/metadata.json"),
+      ).rejects.toThrow(/could not parse final response\.url/);
+      expect(bodyCancel).toHaveBeenCalled();
+    });
+
     it("accepts https→https redirects", async () => {
       (global.fetch as jest.Mock).mockResolvedValue(
         makeResponse({

--- a/@shared/api/helpers/__tests__/fetchMetadataJson.test.ts
+++ b/@shared/api/helpers/__tests__/fetchMetadataJson.test.ts
@@ -1,0 +1,323 @@
+import {
+  fetchMetadataJson,
+  MAX_METADATA_BYTES,
+  METADATA_FETCH_TIMEOUT_MS,
+} from "../fetchMetadataJson";
+
+type FakeReader = {
+  read: jest.Mock;
+  cancel: jest.Mock;
+};
+
+const makeReader = (chunks: Uint8Array[]): FakeReader => {
+  let i = 0;
+  return {
+    read: jest.fn().mockImplementation(() => {
+      if (i >= chunks.length) {
+        return Promise.resolve({ done: true, value: undefined });
+      }
+      const value = chunks[i];
+      i += 1;
+      return Promise.resolve({ done: false, value });
+    }),
+    cancel: jest.fn().mockResolvedValue(undefined),
+  };
+};
+
+const encode = (s: string): Uint8Array => new TextEncoder().encode(s);
+
+const makeResponse = ({
+  ok = true,
+  status = 200,
+  statusText = "OK",
+  contentLength = null,
+  reader = null,
+  text = "",
+}: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  contentLength?: string | null;
+  reader?: FakeReader | null;
+  text?: string;
+} = {}): Response =>
+  ({
+    ok,
+    status,
+    statusText,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-length" ? contentLength : null,
+    },
+    body: reader ? { getReader: () => reader } : undefined,
+    text: jest.fn().mockResolvedValue(text),
+  }) as unknown as Response;
+
+describe("fetchMetadataJson", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("URL validation", () => {
+    it("rejects empty strings", async () => {
+      await expect(fetchMetadataJson("")).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects null values", async () => {
+      await expect(
+        fetchMetadataJson(null as unknown as string),
+      ).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects undefined values", async () => {
+      await expect(
+        fetchMetadataJson(undefined as unknown as string),
+      ).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects non-string values", async () => {
+      await expect(
+        fetchMetadataJson(123 as unknown as string),
+      ).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects http:// URLs", async () => {
+      await expect(
+        fetchMetadataJson("http://example.com/metadata.json"),
+      ).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects file:// URLs", async () => {
+      await expect(fetchMetadataJson("file:///etc/passwd")).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects data: URIs", async () => {
+      await expect(
+        fetchMetadataJson("data:application/json,{}"),
+      ).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects ftp:// URLs", async () => {
+      await expect(
+        fetchMetadataJson("ftp://example.com/metadata.json"),
+      ).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects javascript: URLs", async () => {
+      // eslint-disable-next-line no-script-url
+      const scriptUrl = "javascript:alert(1)";
+      await expect(fetchMetadataJson(scriptUrl)).rejects.toThrow();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("accepts https:// URLs", async () => {
+      const body = '{"name":"ok"}';
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ reader: makeReader([encode(body)]) }),
+      );
+
+      const result = await fetchMetadataJson<{ name: string }>(
+        "https://example.com/metadata.json",
+      );
+
+      expect(result).toEqual({ name: "ok" });
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://example.com/metadata.json",
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    it("accepts mixed-case HTTPS:// URLs (scheme check is case-insensitive)", async () => {
+      const body = '{"name":"ok"}';
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ reader: makeReader([encode(body)]) }),
+      );
+
+      const result = await fetchMetadataJson<{ name: string }>(
+        "HTTPS://example.com/metadata.json",
+      );
+
+      expect(result).toEqual({ name: "ok" });
+    });
+
+    it("rejects malformed URLs", async () => {
+      await expect(fetchMetadataJson("not a url")).rejects.toThrow(
+        /not a valid URL/,
+      );
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("response handling", () => {
+    it("throws when response.ok is false", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ ok: false, status: 404, statusText: "Not Found" }),
+      );
+
+      await expect(
+        fetchMetadataJson("https://example.com/missing.json"),
+      ).rejects.toThrow(/404/);
+    });
+
+    it("parses valid JSON from streamed body", async () => {
+      const body = '{"name":"Test NFT","image":"https://example.com/img.png"}';
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ reader: makeReader([encode(body)]) }),
+      );
+
+      const result = await fetchMetadataJson<{
+        name: string;
+        image: string;
+      }>("https://example.com/metadata.json");
+
+      expect(result).toEqual({
+        name: "Test NFT",
+        image: "https://example.com/img.png",
+      });
+    });
+
+    it("throws on invalid JSON", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ reader: makeReader([encode("not json")]) }),
+      );
+
+      await expect(
+        fetchMetadataJson("https://example.com/bad.json"),
+      ).rejects.toThrow();
+    });
+
+    it("assembles JSON across multiple chunks", async () => {
+      const chunks = [encode('{"name":"Tes'), encode('t NFT","x":1}')];
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ reader: makeReader(chunks) }),
+      );
+
+      const result = await fetchMetadataJson<{ name: string; x: number }>(
+        "https://example.com/metadata.json",
+      );
+
+      expect(result).toEqual({ name: "Test NFT", x: 1 });
+    });
+  });
+
+  describe("size limits", () => {
+    it("rejects early when Content-Length exceeds MAX_METADATA_BYTES", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({
+          contentLength: String(MAX_METADATA_BYTES + 1),
+          reader: makeReader([encode("{}")]),
+        }),
+      );
+
+      await expect(
+        fetchMetadataJson("https://example.com/huge.json"),
+      ).rejects.toThrow(/too large/i);
+    });
+
+    it("accepts when Content-Length equals MAX_METADATA_BYTES", async () => {
+      const body = "{}";
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({
+          contentLength: String(MAX_METADATA_BYTES),
+          reader: makeReader([encode(body)]),
+        }),
+      );
+
+      const result = await fetchMetadataJson<object>(
+        "https://example.com/ok.json",
+      );
+      expect(result).toEqual({});
+    });
+
+    it("aborts streaming and rejects when body bytes exceed MAX_METADATA_BYTES", async () => {
+      const bigChunk = new Uint8Array(MAX_METADATA_BYTES / 2);
+      bigChunk.fill(0x61); // 'a'
+      const chunks = [bigChunk, bigChunk, bigChunk]; // 1.5 * MAX
+      const reader = makeReader(chunks);
+      (global.fetch as jest.Mock).mockResolvedValue(makeResponse({ reader }));
+
+      await expect(
+        fetchMetadataJson("https://example.com/streaming-huge.json"),
+      ).rejects.toThrow(/too large/i);
+
+      expect(reader.cancel).toHaveBeenCalled();
+    });
+
+    it("falls back to response.text() when getReader is unavailable", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ text: '{"name":"Fallback"}' }),
+      );
+
+      const result = await fetchMetadataJson<{ name: string }>(
+        "https://example.com/metadata.json",
+      );
+      expect(result).toEqual({ name: "Fallback" });
+    });
+
+    it("rejects in fallback path when byte length exceeds MAX_METADATA_BYTES", async () => {
+      const huge = "a".repeat(MAX_METADATA_BYTES + 10);
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ text: huge }),
+      );
+
+      await expect(
+        fetchMetadataJson("https://example.com/huge-fallback.json"),
+      ).rejects.toThrow(/too large/i);
+    });
+  });
+
+  describe("timeout", () => {
+    it("aborts fetch after METADATA_FETCH_TIMEOUT_MS", async () => {
+      let capturedSignal: AbortSignal | undefined;
+      (global.fetch as jest.Mock).mockImplementation(
+        (_url: string, init: RequestInit) => {
+          capturedSignal = init.signal as AbortSignal;
+          return new Promise((_, reject) => {
+            const s = init.signal as AbortSignal;
+            if (s) {
+              s.addEventListener("abort", () => {
+                reject(
+                  Object.assign(new Error("aborted"), { name: "AbortError" }),
+                );
+              });
+            }
+          });
+        },
+      );
+
+      const promise = fetchMetadataJson("https://example.com/slow.json");
+
+      jest.advanceTimersByTime(METADATA_FETCH_TIMEOUT_MS);
+
+      await expect(promise).rejects.toThrow();
+      expect(capturedSignal?.aborted).toBe(true);
+    });
+
+    it("does not abort when fetch resolves before the timeout", async () => {
+      const body = '{"ok":true}';
+      (global.fetch as jest.Mock).mockResolvedValue(
+        makeResponse({ reader: makeReader([encode(body)]) }),
+      );
+
+      const result = await fetchMetadataJson<{ ok: boolean }>(
+        "https://example.com/fast.json",
+      );
+
+      expect(result).toEqual({ ok: true });
+    });
+  });
+});

--- a/@shared/api/helpers/fetchCollectibles.ts
+++ b/@shared/api/helpers/fetchCollectibles.ts
@@ -7,6 +7,7 @@ import {
 } from "../types";
 import { NetworkDetails } from "@shared/constants/stellar";
 import { INDEXER_V2_URL } from "@shared/constants/mercury";
+import { fetchMetadataJson } from "./fetchMetadataJson";
 
 /**
  * Fetches metadata for a collectible from its token URI.
@@ -26,11 +27,7 @@ export const fetchCollectibleMetadata = async (tokenUri: string) => {
   };
 
   try {
-    const response = await fetch(tokenUri);
-    if (!response.ok) {
-      return null;
-    }
-    const data = (await response.json()) as CollectibleMetadataResponse;
+    const data = await fetchMetadataJson<CollectibleMetadataResponse>(tokenUri);
 
     if (!data) {
       return null;
@@ -54,8 +51,9 @@ export const fetchCollectibleMetadata = async (tokenUri: string) => {
 
     return metadata;
   } catch (e) {
-    // we don't want to capture exceptions here because it's likely that some metadata
-    // will not be found and that is out of our control
+    // Do not capture to Sentry — third-party metadata hosts fail often and
+    // we can't fix them. The helper rejects on any failure and the UI
+    // expects null here.
     return null;
   }
 };

--- a/@shared/api/helpers/fetchMetadataJson.ts
+++ b/@shared/api/helpers/fetchMetadataJson.ts
@@ -22,6 +22,8 @@ export const METADATA_FETCH_TIMEOUT_MS = 5000;
  *    (including `http`) are rejected before any network call.
  * 2. After the fetch resolves the final `response.url` is re-checked so a
  *    server that 3xx-redirects to a non-https scheme cannot bypass step 1.
+ *    If `response.url` is present but cannot be parsed we fail closed — we
+ *    can't confirm the scheme, so we can't confirm we weren't redirected.
  * 3. A 5-second AbortController-backed timeout bounds how long we wait.
  * 4. `Content-Length` is pre-checked — if the server advertises a body larger
  *    than MAX_METADATA_BYTES the request fails fast.
@@ -70,7 +72,9 @@ export const fetchMetadataJson = async <T>(url: string): Promise<T> => {
 
     // Validate the *final* URL (after any redirects) is still https. The
     // input-URL check alone can be bypassed by a server that 3xx-redirects
-    // to a non-https scheme, which fetch follows by default.
+    // to a non-https scheme, which fetch follows by default. Fail closed if
+    // we can't parse response.url — we can't confirm the scheme, so we
+    // can't confirm we weren't redirected away.
     if (response.url) {
       let finalProtocol: string | null = null;
       try {
@@ -78,10 +82,12 @@ export const fetchMetadataJson = async <T>(url: string): Promise<T> => {
       } catch {
         finalProtocol = null;
       }
-      if (finalProtocol !== null && finalProtocol !== "https:") {
+      if (finalProtocol !== "https:") {
         await response.body?.cancel?.().catch(() => {});
         throw new Error(
-          "fetchMetadataJson: redirect landed on a non-https scheme",
+          finalProtocol === null
+            ? "fetchMetadataJson: could not parse final response.url"
+            : "fetchMetadataJson: redirect landed on a non-https scheme",
         );
       }
     }

--- a/@shared/api/helpers/fetchMetadataJson.ts
+++ b/@shared/api/helpers/fetchMetadataJson.ts
@@ -20,20 +20,26 @@ export const METADATA_FETCH_TIMEOUT_MS = 5000;
  * 1. URL scheme is restricted to `https:` (parsed via `new URL`, so the
  *    check is case-insensitive and rejects malformed URLs). Other schemes
  *    (including `http`) are rejected before any network call.
- * 2. A 5-second AbortController-backed timeout bounds how long we wait.
- * 3. `Content-Length` is pre-checked — if the server advertises a body larger
+ * 2. After the fetch resolves the final `response.url` is re-checked so a
+ *    server that 3xx-redirects to a non-https scheme cannot bypass step 1.
+ * 3. A 5-second AbortController-backed timeout bounds how long we wait.
+ * 4. `Content-Length` is pre-checked — if the server advertises a body larger
  *    than MAX_METADATA_BYTES the request fails fast.
- * 4. The body is read via `response.body.getReader()` with a byte counter;
+ * 5. The body is read via `response.body.getReader()` with a byte counter;
  *    if accumulated bytes exceed MAX_METADATA_BYTES the reader is cancelled
  *    and the call fails. This keeps memory bounded even when
  *    `Content-Length` is absent or inaccurate.
- * 5. If `response.body.getReader` is unavailable in the current runtime, the
+ * 6. If `response.body.getReader` is unavailable in the current runtime, the
  *    helper falls back to `response.text()` followed by a byte-length check.
  *    In that fallback the body is fully buffered before the size check runs,
  *    so the only up-front bounds are the Content-Length pre-check (when the
  *    server advertises it) and the AbortController timeout; the post-download
  *    check is a secondary gate. All modern browser runtimes expose
  *    `getReader`, so the fallback path is rare in practice.
+ *
+ * On any early-exit failure (redirect to non-https, non-OK status, oversized
+ * Content-Length) the response body is cancelled before throwing so streaming
+ * implementations don't continue downloading into a discarded response.
  */
 export const fetchMetadataJson = async <T>(url: string): Promise<T> => {
   if (!url || typeof url !== "string") {
@@ -62,7 +68,26 @@ export const fetchMetadataJson = async <T>(url: string): Promise<T> => {
   try {
     const response = await fetch(url, { signal: controller.signal });
 
+    // Validate the *final* URL (after any redirects) is still https. The
+    // input-URL check alone can be bypassed by a server that 3xx-redirects
+    // to a non-https scheme, which fetch follows by default.
+    if (response.url) {
+      let finalProtocol: string | null = null;
+      try {
+        finalProtocol = new URL(response.url).protocol;
+      } catch {
+        finalProtocol = null;
+      }
+      if (finalProtocol !== null && finalProtocol !== "https:") {
+        await response.body?.cancel?.().catch(() => {});
+        throw new Error(
+          "fetchMetadataJson: redirect landed on a non-https scheme",
+        );
+      }
+    }
+
     if (!response.ok) {
+      await response.body?.cancel?.().catch(() => {});
       throw new Error(
         `fetchMetadataJson: request failed with ${response.status} ${response.statusText}`,
       );
@@ -75,6 +100,7 @@ export const fetchMetadataJson = async <T>(url: string): Promise<T> => {
         Number.isFinite(contentLength) &&
         contentLength > MAX_METADATA_BYTES
       ) {
+        await response.body?.cancel?.().catch(() => {});
         throw new Error(
           `fetchMetadataJson: response too large (${contentLength} bytes, max ${MAX_METADATA_BYTES})`,
         );

--- a/@shared/api/helpers/fetchMetadataJson.ts
+++ b/@shared/api/helpers/fetchMetadataJson.ts
@@ -1,0 +1,129 @@
+/**
+ * Maximum size (in bytes) of a metadata response body we read. Real NFT
+ * metadata JSON is typically well under 10 KB; 1 MB provides generous
+ * headroom while keeping memory usage bounded.
+ */
+export const MAX_METADATA_BYTES = 1024 * 1024;
+
+/**
+ * Hard timeout for a metadata fetch. If the request does not complete within
+ * this window the in-flight fetch is aborted via AbortController so slow or
+ * unreachable hosts do not leave work hanging.
+ */
+export const METADATA_FETCH_TIMEOUT_MS = 5000;
+
+/**
+ * Fetches and parses a JSON metadata document from a remote URL with
+ * sensible defaults for bounded, resilient reads.
+ *
+ * Behavior:
+ * 1. URL scheme is restricted to `https:` (parsed via `new URL`, so the
+ *    check is case-insensitive and rejects malformed URLs). Other schemes
+ *    (including `http`) are rejected before any network call.
+ * 2. A 5-second AbortController-backed timeout bounds how long we wait.
+ * 3. `Content-Length` is pre-checked — if the server advertises a body larger
+ *    than MAX_METADATA_BYTES the request fails fast.
+ * 4. The body is read via `response.body.getReader()` with a byte counter;
+ *    if accumulated bytes exceed MAX_METADATA_BYTES the reader is cancelled
+ *    and the call fails. This keeps memory bounded even when
+ *    `Content-Length` is absent or inaccurate.
+ * 5. If `response.body.getReader` is unavailable in the current runtime, the
+ *    helper falls back to `response.text()` followed by a byte-length check.
+ *    In that fallback the body is fully buffered before the size check runs,
+ *    so the only up-front bounds are the Content-Length pre-check (when the
+ *    server advertises it) and the AbortController timeout; the post-download
+ *    check is a secondary gate. All modern browser runtimes expose
+ *    `getReader`, so the fallback path is rare in practice.
+ */
+export const fetchMetadataJson = async <T>(url: string): Promise<T> => {
+  if (!url || typeof url !== "string") {
+    throw new Error("fetchMetadataJson: url must be a non-empty string");
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    throw new Error("fetchMetadataJson: url is not a valid URL");
+  }
+
+  if (parsedUrl.protocol !== "https:") {
+    throw new Error(
+      `fetchMetadataJson: url scheme must be https (got ${parsedUrl.protocol})`,
+    );
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    METADATA_FETCH_TIMEOUT_MS,
+  );
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+
+    if (!response.ok) {
+      throw new Error(
+        `fetchMetadataJson: request failed with ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const contentLengthHeader = response.headers.get("content-length");
+    if (contentLengthHeader !== null) {
+      const contentLength = parseInt(contentLengthHeader, 10);
+      if (
+        Number.isFinite(contentLength) &&
+        contentLength > MAX_METADATA_BYTES
+      ) {
+        throw new Error(
+          `fetchMetadataJson: response too large (${contentLength} bytes, max ${MAX_METADATA_BYTES})`,
+        );
+      }
+    }
+
+    const reader = response.body?.getReader?.() as
+      | ReadableStreamDefaultReader<Uint8Array>
+      | undefined;
+    let text: string;
+
+    if (reader) {
+      const chunks: Uint8Array[] = [];
+      let totalBytes = 0;
+      let done = false;
+      while (!done) {
+        const chunk = await reader.read();
+        done = chunk.done;
+        if (chunk.value) {
+          totalBytes += chunk.value.byteLength;
+          if (totalBytes > MAX_METADATA_BYTES) {
+            await reader.cancel().catch(() => {});
+            throw new Error(
+              `fetchMetadataJson: response too large (>${MAX_METADATA_BYTES} bytes)`,
+            );
+          }
+          chunks.push(chunk.value);
+        }
+      }
+
+      const merged = new Uint8Array(totalBytes);
+      let offset = 0;
+      chunks.forEach((chunk) => {
+        merged.set(chunk, offset);
+        offset += chunk.byteLength;
+      });
+      text = new TextDecoder("utf-8").decode(merged);
+    } else {
+      text = await response.text();
+      const byteLength = new TextEncoder().encode(text).byteLength;
+      if (byteLength > MAX_METADATA_BYTES) {
+        throw new Error(
+          `fetchMetadataJson: response too large (${byteLength} bytes, max ${MAX_METADATA_BYTES})`,
+        );
+      }
+    }
+
+    return JSON.parse(text) as T;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};


### PR DESCRIPTION
## Summary

Adds a dedicated `fetchMetadataJson` helper and routes `fetchCollectibleMetadata` through it so NFT metadata reads are HTTPS-only, bounded in time and size, and robust against redirect-driven scheme downgrades.

The helper enforces, in order:

- **HTTPS allowlist** — input URL is rejected before any network call if the scheme is not `https:`; the rejection message includes the offending protocol for easier diagnosis.
- **Redirect re-check** — after `fetch` resolves, `response.url` is re-validated so a 3xx redirect that lands on a non-https scheme (e.g. `https:→http:`) is rejected instead of silently followed.
- **5-second timeout** — `AbortController` aborts the in-flight request so slow or unreachable hosts don't leave work hanging.
- **1 MB response cap** — `Content-Length` is pre-checked; the body is then streamed via `response.body.getReader()` with a running byte counter, and the reader is cancelled if the accumulated bytes exceed the cap. Falls back to `response.text()` + byte-length check when `getReader` is unavailable (defense-in-depth; modern runtimes always expose it).
- **Body cleanup on early exits** — non-OK responses, oversized `Content-Length`, and redirect-to-non-https all call `response.body.cancel()` before throwing so streaming runtimes don't continue downloading into a discarded response.

`fetchCollectibleMetadata` keeps its existing `try/catch → return null` wrapper, so the UI-facing contract is unchanged (null metadata still falls back to the default name / broken-image placeholder). The existing decision to skip `captureException` for metadata failures is preserved — third-party metadata hosts fail often enough that flooding Sentry is counter-productive.

Only the NFT collectible metadata path is touched. The sibling `fetchCollectibles` function (which talks to the internal Freighter BE indexer) and every other `fetch` call site in the extension are untouched; the helper is also not routed into them.

27 Jest cases cover the helper (URL validation, response handling, size limits via both Content-Length and streamed paths, fallback path, timeout, redirect re-check, body cancellation on all early exits). The sibling `fetchCollectibles` test is updated to mock the helper at its seam instead of at `global.fetch`, and an unexpected-URL `fetch` mock now rejects explicitly to surface drift.

- Mirrors the sister hardening shipped in stellar/freighter-mobile#835.


https://github.com/user-attachments/assets/79f8f3a5-c5cc-49d6-a5cc-19db8ffe175c

#### When metadata fetching fails

https://github.com/user-attachments/assets/f7fcae8d-9b9f-45d4-9aaa-b69a30c0e9c5


🤖 Generated with [Claude Code](https://claude.com/claude-code)