### PR TITLE
Forward `AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY` to production builds

### DIFF
--- a/.github/workflows/submitProduction.yml
+++ b/.github/workflows/submitProduction.yml
@@ -52,7 +52,9 @@ jobs:
           node-version: 22
       - run: >
           yarn && yarn build:freighter-api && yarn build:extension:production
-          --env AMPLITUDE_KEY="${{ secrets.AMPLITUDE_KEY }}" SENTRY_KEY="${{
+          --env AMPLITUDE_KEY="${{ secrets.AMPLITUDE_KEY }}"
+          AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY="${{
+          secrets.AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY }}" SENTRY_KEY="${{
           secrets.SENTRY_KEY }}" BUILD_TYPE="production"
       - name: Install zip
         uses: montudor/action-zip@0852c26906e00f8a315c704958823928d8018b28 #v1.0.0

--- a/.github/workflows/submitSafari.yml
+++ b/.github/workflows/submitSafari.yml
@@ -62,7 +62,9 @@ jobs:
       - run:
           yarn setup && yarn build:freighter-api && yarn
           build:extension:production --env AMPLITUDE_KEY="${{
-          secrets.AMPLITUDE_KEY }}" SENTRY_KEY="${{ secrets.SENTRY_KEY }}"
+          secrets.AMPLITUDE_KEY }}" AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY="${{
+          secrets.AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY }}" SENTRY_KEY="${{
+          secrets.SENTRY_KEY }}"
       - name: Convert extension to Xcode project
         run:
           xcrun safari-web-extension-converter ./extension/build


### PR DESCRIPTION
## Summary

- The production release workflow (`submitProduction.yml`) was invoking `yarn build:extension:production` without `AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY`. With no key forwarded, webpack's `DefinePlugin` baked in an empty string, so at runtime `initExperimentClient` short-circuited and every feature flag evaluated to its default in the shipped extension — even though analytics events continued to flow because `AMPLITUDE_KEY` was still being passed.
- The beta workflow (`submitBeta.yml`) already referenced this key; production now matches it. All environments use the same `AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY` value.
- Also adding it to `submitSafari.yml` for consistency. We aren't currently running that workflow, but wiring it up now means flags will work out of the box if we ever revive Safari builds.
- Separately, the `AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY` GitHub Actions secret was not actually set in the repository until now — it has just been added. Without this secret, even the beta workflow (which already referenced it) would have been interpolating an empty string into its build command, so feature flags were effectively disabled across all shipped builds. Setting the secret + this PR together is what restores flag evaluation end-to-end.

## Test plan

- [ ] Verify beta release also starts seeing flag evaluations now that the secret exists (previously silent).
- [ ] Verify Amplitude analytics events continue to flow normally (no regression).
- [ ] On next production release verify a known-active feature flag (e.g. `maintenance_banner`) evaluates correctly in the popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)