### PR TITLE
Fix Sentry source map upload for production builds

### DIFF
--- a/.github/workflows/submitProduction.yml
+++ b/.github/workflows/submitProduction.yml
@@ -2,9 +2,6 @@ name: Production Deployment
 env:
   INDEXER_URL: ${{ secrets.INDEXER_URL }}
   INDEXER_V2_URL: ${{ secrets.INDEXER_V2_URL }}
-  SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-  SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
   HUSKY: 0
 on:
   workflow_dispatch:
@@ -30,6 +27,21 @@ jobs:
       - if: ${{ env.INDEXER_V2_URL == '' }}
         run: |
           echo "Missing INDEXER_V2_URL"
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
+      - if: ${{ secrets.SENTRY_ORG == '' }}
+        run: |
+          echo "Missing SENTRY_ORG"
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
+      - if: ${{ secrets.SENTRY_PROJECT == '' }}
+        run: |
+          echo "Missing SENTRY_PROJECT"
+          gh run cancel ${{ github.run_id }}
+          gh run watch ${{ github.run_id }}
+      - if: ${{ secrets.SENTRY_AUTH_TOKEN == '' }}
+        run: |
+          echo "Missing SENTRY_AUTH_TOKEN"
           gh run cancel ${{ github.run_id }}
           gh run watch ${{ github.run_id }}
       - name: Checkout code
@@ -59,6 +71,10 @@ jobs:
           AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY="${{
           secrets.AMPLITUDE_EXPERIMENT_DEPLOYMENT_KEY }}" SENTRY_KEY="${{
           secrets.SENTRY_KEY }}" BUILD_TYPE="production"
+        env:
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       - name: Install zip
         uses: montudor/action-zip@0852c26906e00f8a315c704958823928d8018b28 #v1.0.0
       - name: Create and push git tag

--- a/.github/workflows/submitProduction.yml
+++ b/.github/workflows/submitProduction.yml
@@ -2,6 +2,9 @@ name: Production Deployment
 env:
   INDEXER_URL: ${{ secrets.INDEXER_URL }}
   INDEXER_V2_URL: ${{ secrets.INDEXER_V2_URL }}
+  SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+  SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
   HUSKY: 0
 on:
   workflow_dispatch:

--- a/extension/webpack.extension.js
+++ b/extension/webpack.extension.js
@@ -7,6 +7,7 @@ const dotenv = require("dotenv");
 const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
 const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
+const packageJson = require("./package.json");
 
 // Load .env file and validate required variables (skip in CI - secrets are handled separately)
 dotenv.config();
@@ -97,9 +98,12 @@ const prodConfig = (
         : []),
       new Dotenv({ systemvars: true }),
       sentryWebpackPlugin({
-        org: env.SENTRY_ORG,
-        project: env.SENTRY_PROJECT,
-        authToken: env.SENTRY_KEY,
+        org: process.env.SENTRY_ORG,
+        project: process.env.SENTRY_PROJECT,
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+        release: {
+          name: packageJson.version,
+        },
       }),
     ],
     // This if to fine tune logged output. Since this is an extension, not a

--- a/extension/webpack.extension.js
+++ b/extension/webpack.extension.js
@@ -102,7 +102,7 @@ const prodConfig = (
         project: process.env.SENTRY_PROJECT,
         authToken: process.env.SENTRY_AUTH_TOKEN,
         release: {
-          name: packageJson.version,
+          name: `freighter@${packageJson.version}`,
         },
       }),
     ],


### PR DESCRIPTION
Closes #2570

## Summary

- Sentry webpack plugin was reading `org`/`project` from webpack `--env` (never passed in CI) and reusing the runtime DSN `SENTRY_KEY` as `authToken`, so source map upload silently no-op'd on every production build.
- Switched the plugin to read `SENTRY_ORG` / `SENTRY_PROJECT` / `SENTRY_AUTH_TOKEN` from `process.env` (the standard Sentry plugin convention) and pass them at the workflow `env:` level instead of as `--env` webpack args.
- Pinned `release.name` to `package.json` version so uploaded source maps match the runtime release set by `Sentry.init`.

## Required before merge

I've added the following secrets to the Freighter repo:
- `SENTRY_ORG`
- `SENTRY_PROJECT`
- `SENTRY_AUTH_TOKEN`

## Test plan

- [ ] Add the three secrets above
- [ ] Run the Production Deployment workflow and confirm the build logs show successful source map upload to Sentry
- [ ] Confirm the new release appears in the Sentry project with artifacts attached
- [ ] Trigger a test error in the released extension and confirm the stack trace is symbolicated in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)