### PR TITLE
Only use Blockaid API for mainnet transactions and tokens

### DIFF
--- a/extension/e2e-tests/test-fixtures.ts
+++ b/extension/e2e-tests/test-fixtures.ts
@@ -27,6 +27,15 @@ export const test = base.extend<{
       ],
     });
 
+    // Mark every page (including popups opened by the extension) as a
+    // Playwright test environment. Some helpers — e.g. the Blockaid mainnet
+    // gate in `popup/helpers/blockaid.ts` — rely on this flag to opt back
+    // into behavior that's otherwise mainnet-only, so it must apply to
+    // popup windows too, not just the main `page` fixture.
+    await context.addInitScript(() => {
+      (window as unknown as { IS_PLAYWRIGHT?: string }).IS_PLAYWRIGHT = "true";
+    });
+
     await use(context);
     await context.close();
   },

--- a/extension/src/popup/components/WarningMessages/index.tsx
+++ b/extension/src/popup/components/WarningMessages/index.tsx
@@ -18,11 +18,10 @@ import {
   BlockAidScanTxResult,
 } from "@shared/api/types";
 
-import { isMainnet, isTestnet } from "helpers/stellar";
-
 import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
 import { LoadingBackground } from "popup/basics/LoadingBackground";
 import {
+  isBlockaidEnabled,
   reportAssetWarning,
   reportTransactionWarning,
   useBlockaidOverrideState,
@@ -284,6 +283,7 @@ const BlockaidFeedbackForm = ({
         details: values.details,
         requestId,
         event: values.transactionIssue,
+        networkDetails,
       });
     } else if (address) {
       await reportAssetWarning({
@@ -453,7 +453,7 @@ export const BlockaidByLine = ({
           <span>{t("Blockaid")}</span>
         </Text>
       </div>
-      {isMainnet(networkDetails) || isTestnet(networkDetails) ? (
+      {isBlockaidEnabled(networkDetails) ? (
         <Text
           as="span"
           size="sm"

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/ChangeTrustInternal/hooks/useChangeTrustData.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/ChangeTrustInternal/hooks/useChangeTrustData.tsx
@@ -103,6 +103,7 @@ function useGetChangeTrustData({
         payload.isAssetUnableToScan = shouldTreatAssetAsUnableToScan(
           scannedAsset,
           blockaidOverrideState,
+          networkDetails,
         );
         // unable-to-scan takes precedence — never mark both at once
         payload.isAssetSuspicious =

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/ChangeTrustInternal/index.tsx
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/ChangeTrustInternal/index.tsx
@@ -7,7 +7,6 @@ import { NetworkDetails } from "@shared/constants/stellar";
 import { RequestState } from "constants/request";
 import {
   getCanonicalFromAsset,
-  isMainnet,
   stroopToXlm,
   xlmToStroop,
 } from "helpers/stellar";
@@ -164,13 +163,14 @@ export const ChangeTrustInternal = ({
     state.data?.scanResult?.result_type === "Malicious" ||
     blockaidOverrideState === SecurityLevel.MALICIOUS;
 
-  // Determine if blockaid warnings should be shown
-  // "Unable to scan" is only relevant on mainnet (scanning is not supported on other networks)
-  const isUnableToScanOnMainnet =
-    state.data.isAssetUnableToScan && isMainnet(networkDetails);
+  // Determine if blockaid warnings should be shown.
+  // shouldTreatAssetAsUnableToScan applies the network gate (only mainnet),
+  // so we no longer need to AND with isMainnet here.
   const shouldShowBlockaidWarning =
     state.data &&
-    (isMalicious || state.data.isAssetSuspicious || isUnableToScanOnMainnet);
+    (isMalicious ||
+      state.data.isAssetSuspicious ||
+      state.data.isAssetUnableToScan);
 
   /**
    * Pane state machine for blockaid warnings:
@@ -235,7 +235,7 @@ export const ChangeTrustInternal = ({
             blockaidData={state.data.scanResult}
             onClick={() => setActivePaneIndex(paneConfig.blockaidIndex ?? 0)}
           />
-        ) : isUnableToScanOnMainnet ? (
+        ) : state.data.isAssetUnableToScan ? (
           <BlockaidAssetWarning
             blockaidData={state.data.scanResult}
             onClick={() => setActivePaneIndex(paneConfig.blockaidIndex ?? 0)}

--- a/extension/src/popup/components/manageAssets/SearchAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/SearchAsset/index.tsx
@@ -10,6 +10,8 @@ import { FormRows } from "popup/basics/Forms";
 import { ROUTES } from "popup/constants/routes";
 import { isMainnet, isTestnet } from "helpers/stellar";
 
+import { isBlockaidEnabled as isBlockaidEnabledForNetwork } from "popup/helpers/blockaid";
+
 import { SubviewHeader } from "popup/components/SubviewHeader";
 import { View } from "popup/basics/layout/View";
 
@@ -88,7 +90,7 @@ export const SearchAsset = () => {
           publicKey,
           isAllowListVerificationEnabled,
           asset,
-          isBlockaidEnabled: isMainnet(networkDetails),
+          isBlockaidEnabled: isBlockaidEnabledForNetwork(networkDetails),
           networkDetails,
         });
       },

--- a/extension/src/popup/helpers/__tests__/blockaid.test.tsx
+++ b/extension/src/popup/helpers/__tests__/blockaid.test.tsx
@@ -5,15 +5,24 @@ import {
   isAssetUnableToScan,
   isTxUnableToScan,
   shouldTreatTxAsUnableToScan,
+  shouldTreatAssetAsUnableToScan,
   isTxSuspicious,
   useIsTxSuspicious,
   useShouldTreatTxAsUnableToScan,
+  isBlockaidEnabled,
+  getSiteSecurityStates,
 } from "../blockaid";
 import { SecurityLevel } from "popup/constants/blockaid";
 import {
   BlockAidScanAssetResult,
+  BlockAidScanSiteResult,
   BlockAidScanTxResult,
 } from "@shared/api/types";
+import {
+  MAINNET_NETWORK_DETAILS,
+  TESTNET_NETWORK_DETAILS,
+  FUTURENET_NETWORK_DETAILS,
+} from "@shared/constants/stellar";
 import { makeDummyStore } from "popup/__testHelpers__";
 
 // Mock process.env to control dev mode
@@ -79,6 +88,7 @@ describe("BlockAid Helper Functions", () => {
         shouldTreatTxAsUnableToScan(
           { simulation: {} } as BlockAidScanTxResult,
           SecurityLevel.UNABLE_TO_SCAN,
+          MAINNET_NETWORK_DETAILS,
         ),
       ).toBe(true);
     });
@@ -88,12 +98,15 @@ describe("BlockAid Helper Functions", () => {
         shouldTreatTxAsUnableToScan(
           { simulation: {} } as BlockAidScanTxResult,
           SecurityLevel.SAFE,
+          MAINNET_NETWORK_DETAILS,
         ),
       ).toBe(false);
     });
 
     it("should return true when blockaidData is unable to scan (no override)", () => {
-      expect(shouldTreatTxAsUnableToScan(null, null)).toBe(true);
+      expect(
+        shouldTreatTxAsUnableToScan(null, null, MAINNET_NETWORK_DETAILS),
+      ).toBe(true);
     });
 
     it("should return false when blockaidData is valid (no override)", () => {
@@ -101,8 +114,32 @@ describe("BlockAid Helper Functions", () => {
         shouldTreatTxAsUnableToScan(
           { simulation: {} } as BlockAidScanTxResult,
           null,
+          MAINNET_NETWORK_DETAILS,
         ),
       ).toBe(false);
+    });
+
+    it("should return false on non-mainnet networks even when scan data is missing", () => {
+      // Network gate trips before the missing-scan-data branch, so the UI
+      // does not show an "unable to scan" warning off mainnet.
+      expect(
+        shouldTreatTxAsUnableToScan(null, null, TESTNET_NETWORK_DETAILS),
+      ).toBe(false);
+      expect(
+        shouldTreatTxAsUnableToScan(null, null, FUTURENET_NETWORK_DETAILS),
+      ).toBe(false);
+    });
+
+    it("should respect dev override above the network gate", () => {
+      // Even on testnet, an explicit dev UNABLE_TO_SCAN override still
+      // forces the unable-to-scan UI so devs can exercise the path.
+      expect(
+        shouldTreatTxAsUnableToScan(
+          null,
+          SecurityLevel.UNABLE_TO_SCAN,
+          TESTNET_NETWORK_DETAILS,
+        ),
+      ).toBe(true);
     });
 
     it("should ignore debug override in production mode", () => {
@@ -117,6 +154,7 @@ describe("BlockAid Helper Functions", () => {
         testFn(
           { simulation: {} } as BlockAidScanTxResult,
           SecurityLevel.UNABLE_TO_SCAN,
+          MAINNET_NETWORK_DETAILS,
         ),
       ).toBe(false);
     });
@@ -255,6 +293,7 @@ describe("BlockAid Helper Functions", () => {
       const store = makeDummyStore({
         settings: {
           overriddenBlockaidResponse: SecurityLevel.SUSPICIOUS,
+          networkDetails: MAINNET_NETWORK_DETAILS,
         },
       });
 
@@ -301,6 +340,7 @@ describe("BlockAid Helper Functions", () => {
       const store = makeDummyStore({
         settings: {
           overriddenBlockaidResponse: SecurityLevel.UNABLE_TO_SCAN,
+          networkDetails: MAINNET_NETWORK_DETAILS,
         },
       });
 
@@ -329,8 +369,153 @@ describe("BlockAid Helper Functions", () => {
         testFn(
           { simulation: {} } as BlockAidScanTxResult,
           SecurityLevel.UNABLE_TO_SCAN,
+          MAINNET_NETWORK_DETAILS,
         ),
       ).toBe(false);
+    });
+  });
+
+  describe("isBlockaidEnabled", () => {
+    afterEach(() => {
+      delete (window as unknown as { IS_PLAYWRIGHT?: string }).IS_PLAYWRIGHT;
+    });
+
+    it("returns true on mainnet", () => {
+      expect(isBlockaidEnabled(MAINNET_NETWORK_DETAILS)).toBe(true);
+    });
+
+    it("returns false on testnet and futurenet by default", () => {
+      expect(isBlockaidEnabled(TESTNET_NETWORK_DETAILS)).toBe(false);
+      expect(isBlockaidEnabled(FUTURENET_NETWORK_DETAILS)).toBe(false);
+    });
+
+    it("returns true on testnet when running under Playwright", () => {
+      (window as unknown as { IS_PLAYWRIGHT?: string }).IS_PLAYWRIGHT = "true";
+      expect(isBlockaidEnabled(TESTNET_NETWORK_DETAILS)).toBe(true);
+    });
+  });
+
+  describe("shouldTreatAssetAsUnableToScan precedence", () => {
+    beforeEach(() => {
+      process.env.DEV_EXTENSION = "true";
+    });
+
+    it("returns false on testnet without an override (network gate)", () => {
+      expect(
+        shouldTreatAssetAsUnableToScan(null, null, TESTNET_NETWORK_DETAILS),
+      ).toBe(false);
+    });
+
+    it("respects dev override above the network gate", () => {
+      expect(
+        shouldTreatAssetAsUnableToScan(
+          null,
+          SecurityLevel.UNABLE_TO_SCAN,
+          TESTNET_NETWORK_DETAILS,
+        ),
+      ).toBe(true);
+    });
+
+    it("falls through to scan-data when override is benign and on mainnet", () => {
+      expect(
+        shouldTreatAssetAsUnableToScan(null, null, MAINNET_NETWORK_DETAILS),
+      ).toBe(true);
+    });
+  });
+
+  describe("getSiteSecurityStates network gate", () => {
+    it("returns all-false when networkDetails is null", () => {
+      expect(getSiteSecurityStates(undefined, null, null)).toEqual({
+        isMalicious: false,
+        isSuspicious: false,
+        isUnableToScan: false,
+      });
+    });
+
+    it("returns all-false on testnet without an override", () => {
+      expect(
+        getSiteSecurityStates(null, null, TESTNET_NETWORK_DETAILS),
+      ).toEqual({
+        isMalicious: false,
+        isSuspicious: false,
+        isUnableToScan: false,
+      });
+    });
+
+    it("dev override wins over the network gate", () => {
+      process.env.DEV_EXTENSION = "true";
+      jest.resetModules();
+      jest.doMock("@shared/helpers/dev", () => ({ isDev: true }));
+      const { getSiteSecurityStates: testFn } = require("../blockaid");
+      expect(
+        testFn(null, SecurityLevel.MALICIOUS, TESTNET_NETWORK_DETAILS),
+      ).toEqual({
+        isMalicious: true,
+        isSuspicious: false,
+        isUnableToScan: false,
+      });
+    });
+
+    it("uses scan data on mainnet", () => {
+      const scanData = {
+        status: "hit",
+        is_malicious: true,
+      } as unknown as BlockAidScanSiteResult;
+      expect(
+        getSiteSecurityStates(scanData, null, MAINNET_NETWORK_DETAILS),
+      ).toEqual({
+        isMalicious: true,
+        isSuspicious: false,
+        isUnableToScan: false,
+      });
+    });
+  });
+
+  describe("network-call gating (no fetch off mainnet)", () => {
+    let fetchSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      fetchSpy = jest
+        .spyOn(global, "fetch")
+        .mockResolvedValue(new Response("{}", { status: 200 }));
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+      delete (window as unknown as { IS_PLAYWRIGHT?: string }).IS_PLAYWRIGHT;
+    });
+
+    it("scanAssetBulk does not fetch off mainnet", async () => {
+      jest.resetModules();
+      const { scanAssetBulk } = require("../blockaid");
+      const result = await scanAssetBulk(["FOO-G..."], TESTNET_NETWORK_DETAILS);
+      expect(result).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("reportAssetWarning does not fetch off mainnet", async () => {
+      jest.resetModules();
+      const { reportAssetWarning } = require("../blockaid");
+      const result = await reportAssetWarning({
+        address: "FOO-G...",
+        details: "x",
+        networkDetails: TESTNET_NETWORK_DETAILS,
+      });
+      expect(result).toEqual({});
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("reportTransactionWarning does not fetch off mainnet", async () => {
+      jest.resetModules();
+      const { reportTransactionWarning } = require("../blockaid");
+      const result = await reportTransactionWarning({
+        details: "x",
+        requestId: "r",
+        event: "e",
+        networkDetails: TESTNET_NETWORK_DETAILS,
+      });
+      expect(result).toEqual({});
+      expect(fetchSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/extension/src/popup/helpers/blockaid.ts
+++ b/extension/src/popup/helpers/blockaid.ts
@@ -4,7 +4,6 @@ import { useSelector } from "react-redux";
 
 import { INDEXER_URL } from "@shared/constants/mercury";
 import { NetworkDetails } from "@shared/constants/stellar";
-import { isCustomNetwork } from "@shared/helpers/stellar";
 import {
   BlockAidScanAssetResult,
   BlockAidScanSiteResult,
@@ -22,6 +21,20 @@ import { isDev } from "@shared/helpers/dev";
 import { SecurityLevel } from "popup/constants/blockaid";
 import { fetchJson } from "./fetch";
 import { Action } from "constants/request";
+
+const isPlaywrightTestEnv = () =>
+  typeof window !== "undefined" &&
+  (window as unknown as { IS_PLAYWRIGHT?: string }).IS_PLAYWRIGHT === "true";
+
+/**
+ * Single source of truth for whether Blockaid scanning is applicable on
+ * the active network. Blockaid only meaningfully supports Stellar mainnet,
+ * so we suppress all client-side scanning, reporting, and "unable to scan"
+ * UI on every other network. The IS_PLAYWRIGHT carve-out lets e2e tests
+ * exercise the scan code paths against testnet fixtures.
+ */
+export const isBlockaidEnabled = (networkDetails: NetworkDetails) =>
+  isMainnet(networkDetails) || isPlaywrightTestEnv();
 
 export const ATTACK_TO_DISPLAY = {
   signature_farming:
@@ -46,9 +59,14 @@ export const useScanSite = () => {
   const [error, setError] = useState(null as string | null);
   const [isLoading, setLoading] = useState(true);
 
-  const scanSite = async (url: string) => {
+  const scanSite = async (url: string, networkDetails: NetworkDetails) => {
     setLoading(true);
     try {
+      if (!isBlockaidEnabled(networkDetails)) {
+        // Blockaid only supports mainnet; treat off-mainnet as a no-op.
+        setLoading(false);
+        return null;
+      }
       const res = await fetch(
         `${INDEXER_URL}/scan-dapp?url=${encodeURIComponent(url)}`,
       );
@@ -94,8 +112,8 @@ export const useScanTx = () => {
   ) => {
     setLoading(true);
     try {
-      if (isCustomNetwork(networkDetails)) {
-        setError("Scanning transactions is not supported on custom networks");
+      if (!isBlockaidEnabled(networkDetails)) {
+        setError("Scanning transactions is not supported on this network");
         setLoading(false);
         return null;
       }
@@ -178,10 +196,7 @@ export const scanAsset = async (
   signal?: AbortSignal,
 ): Promise<BlockAidScanAssetResult | null> => {
   try {
-    // Allow scanning in test environment (Playwright) even on testnet for e2e testing
-    const isTestEnv =
-      typeof window !== "undefined" && (window as any).IS_PLAYWRIGHT === "true";
-    if (!isMainnet(networkDetails) && !isTestEnv) {
+    if (!isBlockaidEnabled(networkDetails)) {
       /* Scanning assets is only supported on Mainnet */
       return null;
     }
@@ -301,10 +316,15 @@ export const useIsTxSuspicious = () => {
  */
 export const useShouldTreatAssetAsUnableToScan = () => {
   const blockaidOverrideState = useBlockaidOverrideState();
+  const networkDetails = useSelector(settingsNetworkDetailsSelector);
   return useCallback(
     (blockaidData?: BlockAidScanAssetResult | null) =>
-      shouldTreatAssetAsUnableToScan(blockaidData, blockaidOverrideState),
-    [blockaidOverrideState],
+      shouldTreatAssetAsUnableToScan(
+        blockaidData,
+        blockaidOverrideState,
+        networkDetails,
+      ),
+    [blockaidOverrideState, networkDetails],
   );
 };
 
@@ -314,10 +334,15 @@ export const useShouldTreatAssetAsUnableToScan = () => {
  */
 export const useShouldTreatTxAsUnableToScan = () => {
   const blockaidOverrideState = useBlockaidOverrideState();
+  const networkDetails = useSelector(settingsNetworkDetailsSelector);
   return useCallback(
     (blockaidData?: BlockAidScanTxResult | null) =>
-      shouldTreatTxAsUnableToScan(blockaidData, blockaidOverrideState),
-    [blockaidOverrideState],
+      shouldTreatTxAsUnableToScan(
+        blockaidData,
+        blockaidOverrideState,
+        networkDetails,
+      ),
+    [blockaidOverrideState, networkDetails],
   );
 };
 
@@ -379,26 +404,36 @@ const getSuspiciousFromBlockaidOverrideState = (
 
 /**
  * Checks if asset should be treated as unable to scan based on blockaid override state
+ * Precedence: dev override > network gate > scan data.
  */
 export const shouldTreatAssetAsUnableToScan = (
-  blockaidData?: BlockAidScanAssetResult | null,
-  blockaidOverrideState?: string | null,
+  blockaidData: BlockAidScanAssetResult | null | undefined,
+  blockaidOverrideState: string | null | undefined,
+  networkDetails: NetworkDetails,
 ): boolean => {
   if (isDev && blockaidOverrideState === SecurityLevel.UNABLE_TO_SCAN) {
     return true;
+  }
+  if (!isBlockaidEnabled(networkDetails)) {
+    return false;
   }
   return isAssetUnableToScan(blockaidData);
 };
 
 /**
  * Checks if transaction should be treated as unable to scan based on blockaid override state
+ * Precedence: dev override > network gate > scan data.
  */
 export const shouldTreatTxAsUnableToScan = (
-  blockaidData?: BlockAidScanTxResult | null,
-  blockaidOverrideState?: string | null,
+  blockaidData: BlockAidScanTxResult | null | undefined,
+  blockaidOverrideState: string | null | undefined,
+  networkDetails: NetworkDetails,
 ): boolean => {
   if (isDev && blockaidOverrideState === SecurityLevel.UNABLE_TO_SCAN) {
     return true;
+  }
+  if (!isBlockaidEnabled(networkDetails)) {
+    return false;
   }
   return isTxUnableToScan(blockaidData);
 };
@@ -470,6 +505,7 @@ export const isBlockaidWarning = (resultType: string) =>
 export const getSiteSecurityStates = (
   scanData: BlockAidScanSiteResult | null | undefined,
   blockaidOverrideState: string | null | undefined,
+  networkDetails: NetworkDetails | null,
 ): {
   isMalicious: boolean;
   isSuspicious: boolean;
@@ -481,6 +517,17 @@ export const getSiteSecurityStates = (
       isMalicious: blockaidOverrideState === SecurityLevel.MALICIOUS,
       isSuspicious: blockaidOverrideState === SecurityLevel.SUSPICIOUS,
       isUnableToScan: blockaidOverrideState === SecurityLevel.UNABLE_TO_SCAN,
+    };
+  }
+
+  // Network gate: when Blockaid is not applicable on the active network
+  // (or networkDetails has not resolved yet), suppress all security UI.
+  // This matches the "scan in-flight" branch below so UI stays neutral.
+  if (!networkDetails || !isBlockaidEnabled(networkDetails)) {
+    return {
+      isMalicious: false,
+      isSuspicious: false,
+      isUnableToScan: false,
     };
   }
 
@@ -526,13 +573,13 @@ export const useAsyncSiteScan = <T>(
   const { scanSite: scanSiteFn } = useScanSite();
 
   const scanSite = useCallback(
-    async (currentPayload: T) => {
+    async (currentPayload: T, networkDetails: NetworkDetails) => {
       if (!domain) {
         return;
       }
 
       // Scan asynchronously without blocking
-      scanSiteFn(domain)
+      scanSiteFn(domain, networkDetails)
         .then((scanResult) => {
           const updatedPayload = updatePayload(currentPayload, scanResult);
           dispatch({ type: "FETCH_DATA_SUCCESS", payload: updatedPayload });
@@ -593,7 +640,7 @@ export const scanAssetBulk = async (
   signal?: AbortSignal,
 ): Promise<BlockAidBulkScanAssetResult | null> => {
   try {
-    if (!isMainnet(networkDetails)) {
+    if (!isBlockaidEnabled(networkDetails)) {
       /* Scanning assets is only supported on Mainnet */
       return null;
     }
@@ -632,7 +679,7 @@ export const reportAssetWarning = async ({
   networkDetails,
 }: ReportAssetWarningParams) => {
   try {
-    if (!isMainnet(networkDetails)) {
+    if (!isBlockaidEnabled(networkDetails)) {
       /* Reporting assets is only supported on Mainnet */
       return {} as ReportAssetWarningResponse;
     }
@@ -662,14 +709,20 @@ interface ReportTransactionWarningParams {
   details: string;
   requestId: string;
   event: string;
+  networkDetails: NetworkDetails;
 }
 
 export const reportTransactionWarning = async ({
   details,
   requestId,
   event,
+  networkDetails,
 }: ReportTransactionWarningParams) => {
   try {
+    if (!isBlockaidEnabled(networkDetails)) {
+      /* Reporting transaction warnings is only supported on Mainnet */
+      return {} as ReportTransactionWarningResponse;
+    }
     const res = await fetchJson<ReportTransactionWarningResponse>(
       `${INDEXER_URL}/report-transaction-warning?details=${encodeURIComponent(
         details,

--- a/extension/src/popup/helpers/blockaid.ts
+++ b/extension/src/popup/helpers/blockaid.ts
@@ -497,10 +497,27 @@ export const isBlockaidWarning = (resultType: string) =>
   resultType === "Warning" || resultType === "Spam";
 
 /**
- * Determines site security states from scan data and override state
- * @param scanData - The site scan result from Blockaid
- * @param blockaidOverrideState - Override state for dev mode (takes precedence)
- * @returns Object with isMalicious, isSuspicious, and isUnableToScan flags
+ * Determines site security states from scan data and override state.
+ *
+ * Precedence (high → low): dev override > network gate > scan data.
+ *
+ * - When a dev override is set (and `isDev`), the override drives the
+ *   returned flags directly — useful for exercising UI states locally
+ *   without a real Blockaid result.
+ * - Otherwise, when `networkDetails` is null (not yet resolved) or the
+ *   active network is one where Blockaid is not applicable
+ *   (`!isBlockaidEnabled(...)`, e.g. testnet/futurenet/custom), all flags
+ *   are returned `false` so the caller renders no Blockaid-driven UI
+ *   (no malicious/suspicious banner, no "unable to scan" affordance).
+ * - Otherwise, the scan data drives the flags.
+ *
+ * @param scanData - The site scan result from Blockaid (undefined while a
+ *                   scan is in flight, null when the scan failed).
+ * @param blockaidOverrideState - Override state for dev mode (takes precedence).
+ * @param networkDetails - The active network. Pass null if it has not
+ *                         resolved yet; off-mainnet networks short-circuit
+ *                         to all-clear flags.
+ * @returns Object with isMalicious, isSuspicious, and isUnableToScan flags.
  */
 export const getSiteSecurityStates = (
   scanData: BlockAidScanSiteResult | null | undefined,

--- a/extension/src/popup/views/AddToken/index.tsx
+++ b/extension/src/popup/views/AddToken/index.tsx
@@ -158,7 +158,11 @@ export const AddToken = () => {
         scannedAsset &&
         (isAssetSuspicious(scannedAsset, overrideState) ||
           isAssetMalicious(scannedAsset, overrideState) ||
-          shouldTreatAssetAsUnableToScan(scannedAsset, overrideState))
+          shouldTreatAssetAsUnableToScan(
+            scannedAsset,
+            overrideState,
+            networkDetails,
+          ))
       ) {
         setBlockaidData(scannedAsset);
         setIsMaliciousAsset(isAssetMalicious(scannedAsset, overrideState));

--- a/extension/src/popup/views/GrantAccess/hooks/useGetGrantAccessData.ts
+++ b/extension/src/popup/views/GrantAccess/hooks/useGetGrantAccessData.ts
@@ -60,7 +60,7 @@ function useGetGrantAccessData(url: string) {
       dispatch({ type: "FETCH_DATA_SUCCESS", payload: initialPayload });
 
       // Fetch scan data asynchronously without blocking UI
-      scanSite(initialPayload);
+      scanSite(initialPayload, appData.settings.networkDetails);
 
       return initialPayload;
     } catch (error) {

--- a/extension/src/popup/views/GrantAccess/index.tsx
+++ b/extension/src/popup/views/GrantAccess/index.tsx
@@ -117,6 +117,7 @@ export const GrantAccess = () => {
   const { isMalicious, isUnableToScan } = getSiteSecurityStates(
     scanData,
     blockaidOverrideState,
+    networkDetails,
   );
 
   const shouldShowWarning = isMalicious || isUnableToScan;

--- a/extension/src/popup/views/SignAuthEntry/hooks/useGetSignAuthEntryData.tsx
+++ b/extension/src/popup/views/SignAuthEntry/hooks/useGetSignAuthEntryData.tsx
@@ -99,7 +99,7 @@ function useGetSignAuthEntryData(accountToSign?: string, url?: string) {
       dispatch({ type: "FETCH_DATA_SUCCESS", payload: initialPayload });
 
       // Fetch scan data asynchronously without blocking UI
-      scanSite(initialPayload);
+      scanSite(initialPayload, networkDetails);
 
       return initialPayload;
     } catch (error) {

--- a/extension/src/popup/views/SignMessage/hooks/useGetSignMessageData.tsx
+++ b/extension/src/popup/views/SignMessage/hooks/useGetSignMessageData.tsx
@@ -99,7 +99,7 @@ function useGetSignMessageData(accountToSign?: string, url?: string) {
       dispatch({ type: "FETCH_DATA_SUCCESS", payload: initialPayload });
 
       // Fetch scan data asynchronously without blocking UI
-      scanSite(initialPayload);
+      scanSite(initialPayload, networkDetails);
 
       return initialPayload;
     } catch (error) {

--- a/extension/src/popup/views/SignMessage/index.tsx
+++ b/extension/src/popup/views/SignMessage/index.tsx
@@ -190,11 +190,16 @@ export const SignMessage = () => {
     signMessageState.data?.type === AppDataType.RESOLVED
       ? signMessageState.data.blockaidOverrideState
       : null;
+  const networkDetails =
+    signMessageState.data?.type === AppDataType.RESOLVED
+      ? signMessageState.data.networkDetails
+      : null;
 
   // Determine security states with override support
   const { isMalicious, isSuspicious, isUnableToScan } = getSiteSecurityStates(
     scanData,
     blockaidOverrideState,
+    networkDetails,
   );
 
   const shouldShowWarning = isMalicious || isSuspicious || isUnableToScan;

--- a/extension/src/popup/views/SignTransaction/hooks/useGetSignTxData.tsx
+++ b/extension/src/popup/views/SignTransaction/hooks/useGetSignTxData.tsx
@@ -181,7 +181,7 @@ function useGetSignTxData(
       dispatch({ type: "FETCH_DATA_SUCCESS", payload: firstRenderPayload });
 
       // Fetch site scan data asynchronously without blocking UI
-      scanSite(firstRenderPayload);
+      scanSite(firstRenderPayload, networkDetails);
 
       // Add all icons needed for tx assets
       const icons = {} as { [code: string]: string };

--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -153,13 +153,21 @@ export const SignTransaction = () => {
     signTxState.data?.type === AppDataType.RESOLVED
       ? signTxState.data.blockaidOverrideState
       : null;
+  const signTxNetworkDetails =
+    signTxState.data?.type === AppDataType.RESOLVED
+      ? signTxState.data.networkDetails
+      : null;
 
   // Determine site security states with override support
   const {
     isMalicious: isSiteMalicious,
     isSuspicious: isSiteSuspicious,
     isUnableToScan: isSiteUnableToScan,
-  } = getSiteSecurityStates(siteScanData, blockaidOverrideState);
+  } = getSiteSecurityStates(
+    siteScanData,
+    blockaidOverrideState,
+    signTxNetworkDetails,
+  );
 
   const shouldShowSiteWarning =
     isSiteMalicious || isSiteSuspicious || isSiteUnableToScan;

--- a/extension/src/popup/views/__tests__/GrantAccess.test.tsx
+++ b/extension/src/popup/views/__tests__/GrantAccess.test.tsx
@@ -278,7 +278,16 @@ describe("Grant Access view", () => {
     ).toBeDefined();
   });
   it("suppresses Blockaid site warnings on custom networks (Mainnet-only feature)", async () => {
-    const fetchSpy = jest.spyOn(global, "fetch");
+    // Stub `fetch` to a benign success so that, if the network gate ever
+    // regresses and a `/scan-dapp` (or any other) call leaks through, the
+    // test doesn't attempt a real network request and become flaky in CI.
+    // The assertion below still verifies no `/scan-dapp` call was made.
+    const fetchSpy = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      } as Response);
     render(
       <Wrapper
         routes={[ROUTES.welcome]}

--- a/extension/src/popup/views/__tests__/GrantAccess.test.tsx
+++ b/extension/src/popup/views/__tests__/GrantAccess.test.tsx
@@ -178,7 +178,7 @@ describe("Grant Access view", () => {
             allAccounts: mockAccounts,
           },
           settings: {
-            networkDetails: TESTNET_NETWORK_DETAILS,
+            networkDetails: MAINNET_NETWORK_DETAILS,
             networksList: DEFAULT_NETWORKS,
           },
         }}
@@ -217,7 +217,7 @@ describe("Grant Access view", () => {
             allAccounts: mockAccounts,
           },
           settings: {
-            networkDetails: TESTNET_NETWORK_DETAILS,
+            networkDetails: MAINNET_NETWORK_DETAILS,
             networksList: DEFAULT_NETWORKS,
           },
         }}
@@ -277,7 +277,8 @@ describe("Grant Access view", () => {
       screen.getByTestId("grant-access-connect-anyway-button"),
     ).toBeDefined();
   });
-  it("shows unable to scan label when on custom network", async () => {
+  it("suppresses Blockaid site warnings on custom networks (Mainnet-only feature)", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch");
     render(
       <Wrapper
         routes={[ROUTES.welcome]}
@@ -314,12 +315,16 @@ describe("Grant Access view", () => {
 
     await waitFor(() => screen.getByTestId("grant-access-view"));
     expect(screen.getByTestId("grant-access-view")).toBeDefined();
-    await waitFor(() =>
-      expect(screen.getByTestId("blockaid-unable-to-scan-label")).toBeDefined(),
-    );
+    // No Blockaid label should be rendered, and the dapp scan endpoint should
+    // never be called on a non-Mainnet network.
+    expect(screen.queryByTestId("blockaid-unable-to-scan-label")).toBeNull();
+    expect(screen.queryByTestId("blockaid-malicious-label")).toBeNull();
+    expect(screen.queryByTestId("blockaid-miss-label")).toBeNull();
     expect(
-      screen.getByTestId("grant-access-connect-anyway-button"),
-    ).toBeDefined();
+      fetchSpy.mock.calls.some(
+        ([url]) => typeof url === "string" && url.includes("/scan-dapp"),
+      ),
+    ).toBe(false);
   });
   it("shows unable to scan label when scan site API returns an error", async () => {
     jest.spyOn(global, "fetch").mockImplementation(() =>


### PR DESCRIPTION
# Proposal: Only use Blockaid scanning APIs for mainnet

Closes stellar/freighter#2737.

## Problem

The Freighter extension calls Blockaid scanning endpoints (proxied via
`freighter-backend` at `INDEXER_URL`) for transactions, domains/dApps,
and assets. Today the gating policy is inconsistent:

| Entry point | File:line | Current gate |
|---|---|---|
| `scanAsset` | `popup/helpers/blockaid.ts:175` | `isMainnet \|\| IS_PLAYWRIGHT` |
| `scanAssetBulk` | `popup/helpers/blockaid.ts:590` | `isMainnet` |
| `reportAssetWarning` | `popup/helpers/blockaid.ts:629` | `isMainnet` |
| `scanTx` (`useScanTx`) | `popup/helpers/blockaid.ts:90` | `!isCustomNetwork` ❌ |
| `scanSite` (`useScanSite`) | `popup/helpers/blockaid.ts:44` | none ❌ |
| `reportTransactionWarning` | `popup/helpers/blockaid.ts:667` | none ❌ |
| `useAssetLookup` direct `/scan-asset-bulk` | `useAssetLookup.ts:79-128` | gated via caller-supplied `isBlockaidEnabled = isMainnet(...)` (`SearchAsset/index.tsx:91`) |
| `makeDisplayableBalances` direct `/scan-asset-bulk` | `@shared/helpers/stellar.ts:74` | `isMainnet` (param) |

Three concerns are entangled:

1. **Network calls** to Blockaid from non-mainnet networks.
2. **UI warnings** — when no scan ran, consumers compute
   `isUnableToScan = true` from `null`/empty results and surface
   "unable to scan" banners in `SignTransaction/index.tsx:282`,
   `InternalTransaction/ReviewTransaction/index.tsx:163-179`,
   `GrantAccess/index.tsx:122` (via `getSiteSecurityStates`),
   `SignMessage/index.tsx:200` (via `getSiteSecurityStates`), and
   `WarningMessages/index.tsx`'s `BlockAidScanExpanded`
   (lines 1158-1184). The `ChangeTrustInternal` flow already works
   around this with its own inline `isUnableToScanOnMainnet` check
   (`ChangeTrustInternal/index.tsx:169`); the rest of the app does
   not.
3. **Feedback UI** — `BlockaidByLine` exposes a "Feedback?"
   affordance whenever `isMainnet || isTestnet`
   (`WarningMessages/index.tsx:456`). After this change a non-mainnet
   transaction has no Blockaid `requestId` to report against.

## Proposed change

Single Blockaid-applicability policy, threaded through three layers:
network calls, UI helpers, and the feedback affordance.

### 1. Policy helper

In `extension/src/popup/helpers/blockaid.ts`:

```ts
const isPlaywrightTestEnv = () =>
  typeof window !== "undefined" && (window as any).IS_PLAYWRIGHT === "true";

/**
 * Single source of truth for whether Blockaid scanning is applicable
 * on the active network. Blockaid only meaningfully supports Stellar
 * mainnet; we suppress all client-side scanning, reporting, and
 * "unable to scan" UI on every other network. The IS_PLAYWRIGHT
 * carve-out lets e2e tests exercise the scan paths against testnet
 * fixtures.
 */
export const isBlockaidEnabled = (networkDetails: NetworkDetails) =>
  isMainnet(networkDetails) || isPlaywrightTestEnv();
```

`isBlockaidEnabled` is exported.

`@shared/helpers/stellar.ts:makeDisplayableBalances` runs in the
service-worker (no `window`); keep its existing
`isMainnet: boolean` parameter unchanged.

### 2. Layer 1 — Gate network calls

Update every Blockaid-bound network call to early-exit when
`isBlockaidEnabled(networkDetails)` is `false`. All call sites
already handle `null` / empty results.

- `scanAsset`, `scanAssetBulk`, `reportAssetWarning`: replace inline
  `isMainnet` with `isBlockaidEnabled` (gains Playwright carve-out
  for the latter two, matching `scanAsset`).
- `scanTx` (in `useScanTx`): replace `isCustomNetwork` with
  `!isBlockaidEnabled`. Also update the user-visible error string
  set on the early-exit branch — currently
  `"Scanning transactions is not supported on custom networks"`
  (`blockaid.ts:98`) — to a network-agnostic message such as
  `"Scanning transactions is not supported on this network"`,
  since testnet/futurenet will now hit the same branch.
- `useScanSite`: change `scanSite(url)` → `scanSite(url, networkDetails)`.
  Pass `networkDetails` explicitly to the *call*, not to the hook
  itself.
- `useAsyncSiteScan` (lines 521-551): keep the hook's construction
  signature as-is (`useAsyncSiteScan(domain, dispatch, updatePayload)`)
  and instead **add `networkDetails` as a second argument to the
  returned `scanSite` callback**:
  `scanSite(currentPayload, networkDetails)`. This is the only API
  shape that works — none of the four callers
  (`useGetGrantAccessData.ts:63`, `useGetSignMessageData.tsx:102`,
  `useGetSignTxData.tsx:184`, `useGetSignAuthEntryData.tsx:102`)
  has `networkDetails` available at hook *construction* time;
  they only obtain it inside `fetchData()` after awaiting
  `fetchAppData()` (e.g. `appData.settings.networkDetails`).
  All four callers already invoke `scanSite(initialPayload)` from
  inside `fetchData` after the appData await — they pass
  `appData.settings.networkDetails` as the new second argument.
- The legacy `fetchSiteScanData` (lines 553-588, `@deprecated`) has
  **no callers**; leave its signature unchanged.
- `reportTransactionWarning`: add `networkDetails` to its parameter
  object and gate. The single caller in
  `WarningMessages/index.tsx:283` (`BlockaidFeedbackForm`) already
  reads `networkDetails` at line 279.
- `useAssetLookup`'s direct `/scan-asset-bulk` fetch
  (`addBlockaidScanResults`, `useAssetLookup.ts:79-139`) is
  **already gated** by the caller-supplied `isBlockaidEnabled`
  flag at `useAssetLookup.ts:454`. The flag is supplied by
  `SearchAsset/index.tsx:91` as `isBlockaidEnabled: isMainnet(networkDetails)`.
  Update that one line to use the new helper:
  `isBlockaidEnabled: isBlockaidEnabledHelper(networkDetails)` (rename
  the import locally to avoid shadowing the destructured field name).
  No change is required inside `useAssetLookup` itself.

### 3. Layer 2 — Suppress "unable to scan" UI on non-mainnet

Push the gate into the central UI helpers with **explicit precedence:
override > network gate > scan data**.

- `shouldTreatTxAsUnableToScan(blockaidData, blockaidOverrideState, networkDetails)`
- `shouldTreatAssetAsUnableToScan(blockaidData, blockaidOverrideState, networkDetails)`
- `getSiteSecurityStates(scanData, blockaidOverrideState, networkDetails: NetworkDetails | null)`
  — accept `NetworkDetails | null`. When `networkDetails === null`
  *or* `!isBlockaidEnabled(networkDetails)`, return the same
  no-warning shape the current function returns on the in-flight
  `scanData === undefined` path (`blockaid.ts:489-497`):
  `{ isMalicious: false, isSuspicious: false, isUnableToScan: false }`.
  Explicitly **not** `isUnableToScan: true`.

Each helper preserves its existing override-first branch
(`getSiteSecurityStates` already has `if (isDev && blockaidOverrideState)`
at line 478; the two `shouldTreat*` helpers have analogous
`if (isDev && blockaidOverrideState === SecurityLevel.UNABLE_TO_SCAN)`
short-circuits at lines 387 and 400). After the override branch and
before falling through to the scan-data branch, insert the network
gate: `if (!isBlockaidEnabled(networkDetails)) return <not-applicable shape>`.

#### Hook variants

`useShouldTreatTxAsUnableToScan` and `useShouldTreatAssetAsUnableToScan`
add a second `useSelector(settingsNetworkDetailsSelector)` (they
already use `useSelector` for the override). They forward
`networkDetails` to the function variant. **Hook consumers do not
change** (this includes `BlockAidScanExpanded` in
`WarningMessages/index.tsx:1158-1170`, which uses the hook variants).

#### Function-variant callsite inventory (verified)

- `shouldTreatTxAsUnableToScan` (function): direct callers are the
  unit tests in `popup/helpers/__tests__/blockaid.test.tsx:72-122,327`.
  No production direct callers — production goes through the hook.
  Update the unit-test calls to pass `networkDetails` (mainnet
  fixture for existing assertions; new testnet cases assert
  `false`).
- `shouldTreatAssetAsUnableToScan` (function): production callers:
  - `useChangeTrustData.tsx:103` — `networkDetails` already in
    scope (resolved at lines 35-50).
  - `AddToken/index.tsx:161` — `networkDetails` in scope at
    line 148.
- `getSiteSecurityStates`: exactly three production callers; all
  three reach this only on the `AppDataType.RESOLVED` branch of
  the surrounding state, so `state.data.networkDetails` is
  guaranteed present at the call point:
  - `GrantAccess/index.tsx:117` — `state.data.networkDetails`.
  - `SignMessage/index.tsx:195` — extract via the existing
    `signMessageState.data?.type === AppDataType.RESOLVED ? signMessageState.data.networkDetails : null`
    discriminant the file already uses for `scanData` and
    `blockaidOverrideState` (lines 185-192). Verified that
    `ResolvedData` includes `networkDetails`
    (`useGetSignMessageData.tsx:19-31`).
  - `SignTransaction/index.tsx:162` — same pattern;
    `useGetSignTxData.tsx:37-52` `ResolvedData` includes
    `networkDetails`.

#### Cleanup

After Layer 2 lands, remove the now-redundant
`isUnableToScanOnMainnet` local in
`ChangeTrustInternal/index.tsx:168-173` —
`state.data.isAssetUnableToScan` (produced by
`shouldTreatAssetAsUnableToScan` in `useChangeTrustData.tsx:103`)
is mainnet-aware on its own.

### 4. Layer 3 — Hide "Feedback?" off mainnet

In `WarningMessages/index.tsx:456`, change

```ts
{isMainnet(networkDetails) || isTestnet(networkDetails) ? (
```

to

```ts
{isBlockaidEnabled(networkDetails) ? (
```

### 5. Public-export safety

Verified: `popup/helpers/blockaid` is only imported from inside the
`freighter` submodule. No `@shared` / `@stellar/freighter-api`
contract is broken.

`isAssetSuspicious` / `isAssetMalicious` / `isTxSuspicious` are
**not** gated by this proposal. After Layer 1, the only way for
non-null `blockaidData` to reach these on a non-mainnet network is
via the dev override path (already gated on `isDev`), matching the
precedence rule above. This is intentional: dev/QA override
workflows continue to function on testnet.

### 6. Tests

#### Helper-level (`popup/helpers/__tests__/blockaid.test.tsx`)

Constraint: `makeDummyStore` (`popup/__testHelpers__/index.tsx:37-42`)
**does not deep-merge nested slices**. Existing fixtures that set
only `settings.overriddenBlockaidResponse` (e.g. lines 255-259,
301-305) must be updated to include `settings.networkDetails` in
the **same `settings` object** as the override; setting them in
two separate calls would drop the earlier field.

- `isBlockaidEnabled`: mainnet → `true`; testnet, futurenet, custom
  → `false`; testnet with `(window as any).IS_PLAYWRIGHT === "true"`
  → `true`.
- `shouldTreatTxAsUnableToScan` / `shouldTreatAssetAsUnableToScan`:
  add `networkDetails` to the existing direct-call test cases at
  `:72-122,327`. Add new precedence cases:
  - `isDev` override on testnet → override wins.
  - missing data on testnet (no override) → `false`.
  - missing data on mainnet (no override) → `true` (existing
    behavior preserved).
- `getSiteSecurityStates`: testnet → all-false regardless of
  `scanData`; testnet + override → override wins.
- Network-call early-exit: `scanTx`, `scanAssetBulk`,
  `reportAssetWarning`, `reportTransactionWarning`,
  `useScanSite.scanSite` — assert each returns `null` / empty and
  does not call `fetch` / `fetchJson` when `networkDetails` is
  testnet and `IS_PLAYWRIGHT` is unset.

#### View / hook (active suites only)

`SendPayment.test.tsx`, `Swap.test.tsx`, and `ManageAssets.test.tsx`
are `describe.skip` and are not used.

- `popup/views/__tests__/SignTransaction.test.tsx` — testnet
  variant: no Blockaid `fetch`, no `BlockaidWarning` banner.
- `popup/views/__tests__/Account.test.tsx` — testnet variant: no
  `/scan-asset-bulk` call from `makeDisplayableBalances`.
- `popup/views/__tests__/GrantAccess.test.tsx` — testnet variant:
  no `/scan-dapp`, no "unable to scan" banner.
- `popup/views/SignTransaction/hooks/__tests__/useGetSignTxData.test.tsx`
  — testnet: `scanResult === null`, no `/scan-tx` fetch.
- `popup/components/send/SendAmount/hooks/__tests__/useSimulateTxData.test.ts`
  — testnet: no `/scan-tx` fetch.
- `popup/components/__tests__/SearchAsset.test.tsx` — testnet:
  no `/scan-asset-bulk` (validates the
  `SearchAsset/index.tsx:91` change picks up the Playwright-aware
  helper while still gating off testnet without the env var).

#### E2E

Existing `extension/e2e-tests/blockaidScan.*.test.ts` runs with
`IS_PLAYWRIGHT=true`; the carve-out keeps them green. No e2e
changes required.

### 7. Out of scope (deferred)

- **Server-side gating in `freighter-backend`** (`/scan-tx`,
  `/scan-dapp`, `/scan-asset`, `/scan-asset-bulk`, `/report-*`).
  Defense-in-depth at that layer; separate submodule. **Will file
  follow-up issue on `stellar/freighter-backend`.**
- **`freighter-mobile` Blockaid integration.** Same gap may exist;
  out of scope. **Will file follow-up issue on
  `stellar/freighter-mobile`.**

## Why this shape

- **One policy helper, threaded through three layers** — no
  consumer re-derives the rule, and a future contributor adding a
  new Blockaid endpoint or warning-rendering site has a single
  function name (`isBlockaidEnabled`) to grep for.
- **Pushing the gate into `shouldTreat*AsUnableToScan` /
  `getSiteSecurityStates`** matches the existing
  `ChangeTrustInternal` precedent and avoids duplicating the check
  in every consumer.
- **Explicit `networkDetails` parameter, not hidden `useSelector`,**
  keeps the function variants pure and avoids stale-network races.
  The hook variants do read the selector — but only as a
  convenience, mirroring how they already read the override state.
- **Explicit precedence (override > network gate > scan data)**
  preserves the dev/QA override workflow on testnet.
- **No new sentinel state.** "Blockaid not applicable" collapses
  into "no scan ran, no warning to show," matching the UX of a
  pre-Blockaid extension build.

## Files touched

- `extension/src/popup/helpers/blockaid.ts` — new helper, six
  scan/report functions updated, three central UI helpers and two
  hooks updated.
- `extension/src/popup/components/WarningMessages/index.tsx` —
  pass `networkDetails` to `reportTransactionWarning`; switch
  `BlockaidByLine` gate.
- `extension/src/popup/components/manageAssets/ManageAssetRows/ChangeTrustInternal/index.tsx`
  — drop redundant local gate.
- `extension/src/popup/components/manageAssets/SearchAsset/index.tsx`
  — switch line 91 to the new helper.
- `extension/src/popup/views/{GrantAccess,SignMessage,SignTransaction}/index.tsx`
  — extract `networkDetails` and pass to `getSiteSecurityStates`.
- `extension/src/popup/views/{GrantAccess,SignMessage,SignTransaction,SignAuthEntry}/hooks/use*Data.{ts,tsx}`
  — pass `appData.settings.networkDetails` to the new
  `scanSite(payload, networkDetails)` call.
- `extension/src/popup/views/AddToken/index.tsx`,
  `extension/src/popup/components/manageAssets/ManageAssetRows/ChangeTrustInternal/hooks/useChangeTrustData.tsx`
  — pass `networkDetails` to function-variant `shouldTreat*` calls.
- Tests as listed.

No changes to public APIs (`@stellar/freighter-api`), Redux state
shape, or background/popup message types.


---

Closes #2737
