### PR TITLE
Truncate long memos in transaction display rows

### DIFF
--- a/extension/src/popup/components/InternalTransaction/ReviewTransaction/index.tsx
+++ b/extension/src/popup/components/InternalTransaction/ReviewTransaction/index.tsx
@@ -347,7 +347,7 @@ export const ReviewTx = ({
       <div className="ReviewTx__Details">
         {/* Hide memo row when memo is disabled (e.g., for all M addresses) */}
         {!isMemoDisabled && (
-          <div className="ReviewTx__Details__Row">
+          <div className="ReviewTx__Details__Row ReviewTx__Details__Row--memo">
             <div className="ReviewTx__Details__Row__Title">
               <Icon.File02 />
               {t("Memo")}
@@ -356,7 +356,12 @@ export const ReviewTx = ({
               className="ReviewTx__Details__Row__Value"
               data-testid="review-tx-memo"
             >
-              {memo || t("None")}
+              <div
+                className="ReviewTx__Memo"
+                title={memo && memo.trim() ? memo : undefined}
+              >
+                {memo || t("None")}
+              </div>
             </div>
           </div>
         )}

--- a/extension/src/popup/components/InternalTransaction/ReviewTransaction/index.tsx
+++ b/extension/src/popup/components/InternalTransaction/ReviewTransaction/index.tsx
@@ -38,6 +38,7 @@ import {
   MemoRequiredLabel,
 } from "popup/components/WarningMessages";
 import { CopyValue } from "popup/components/CopyValue";
+import { TruncatedMemo } from "popup/components/TruncatedMemo";
 import { ActionButtons } from "./components/ActionButtons";
 import { SendAsset, SendDestination } from "./components";
 
@@ -356,12 +357,7 @@ export const ReviewTx = ({
               className="ReviewTx__Details__Row__Value"
               data-testid="review-tx-memo"
             >
-              <div
-                className="ReviewTx__Memo"
-                title={memo && memo.trim() ? memo : undefined}
-              >
-                {memo || t("None")}
-              </div>
+              <TruncatedMemo memo={memo} className="ReviewTx__Memo" />
             </div>
           </div>
         )}

--- a/extension/src/popup/components/InternalTransaction/ReviewTransaction/styles.scss
+++ b/extension/src/popup/components/InternalTransaction/ReviewTransaction/styles.scss
@@ -48,6 +48,10 @@
     &__Row {
       display: flex;
 
+      &--memo > * {
+        min-width: 0;
+      }
+
       &:not(:last-child) {
         margin-bottom: pxToRem(12px);
         padding-bottom: pxToRem(12px);
@@ -82,6 +86,16 @@
         }
       }
     }
+  }
+
+  &__Memo {
+    display: block;
+    align-self: stretch;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: right;
   }
 
   &__Actions {

--- a/extension/src/popup/components/InternalTransaction/ReviewTransaction/styles.scss
+++ b/extension/src/popup/components/InternalTransaction/ReviewTransaction/styles.scss
@@ -89,12 +89,7 @@
   }
 
   &__Memo {
-    display: block;
     align-self: stretch;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     text-align: right;
   }
 

--- a/extension/src/popup/components/TruncatedMemo/__tests__/index.test.tsx
+++ b/extension/src/popup/components/TruncatedMemo/__tests__/index.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { TruncatedMemo } from "../index";
+
+describe("TruncatedMemo", () => {
+  it("renders the memo and sets title when memo is present", () => {
+    const memo = "important memo";
+    render(<TruncatedMemo memo={memo} data-testid="memo" />);
+    const el = screen.getByTestId("memo");
+    expect(el).toHaveTextContent(memo);
+    expect(el).toHaveAttribute("title", memo);
+  });
+
+  it("renders the default fallback and omits title when memo is empty", () => {
+    render(<TruncatedMemo memo="" data-testid="memo" />);
+    const el = screen.getByTestId("memo");
+    expect(el).toHaveTextContent("None");
+    expect(el).not.toHaveAttribute("title");
+  });
+
+  it("renders a custom fallback when provided", () => {
+    render(
+      <TruncatedMemo
+        memo={undefined}
+        fallback="—"
+        data-testid="memo"
+      />,
+    );
+    const el = screen.getByTestId("memo");
+    expect(el).toHaveTextContent("—");
+    expect(el).not.toHaveAttribute("title");
+  });
+
+  it("preserves whitespace memos verbatim (does not trim user input)", () => {
+    const memo = "  spaced  ";
+    render(<TruncatedMemo memo={memo} data-testid="memo" />);
+    const el = screen.getByTestId("memo");
+    expect(el).toHaveAttribute("title", memo);
+    expect(el).toHaveTextContent("spaced");
+  });
+
+  it("renders as a div by default and as a span when inline", () => {
+    const { rerender } = render(
+      <TruncatedMemo memo="x" data-testid="memo" />,
+    );
+    expect(screen.getByTestId("memo").tagName).toBe("DIV");
+
+    rerender(<TruncatedMemo memo="x" inline data-testid="memo" />);
+    expect(screen.getByTestId("memo").tagName).toBe("SPAN");
+    expect(screen.getByTestId("memo")).toHaveClass("TruncatedMemo--inline");
+  });
+});

--- a/extension/src/popup/components/TruncatedMemo/index.tsx
+++ b/extension/src/popup/components/TruncatedMemo/index.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import "./styles.scss";
+
+interface TruncatedMemoProps {
+  memo?: string | null;
+  fallback?: string;
+  inline?: boolean;
+  className?: string;
+  "data-testid"?: string;
+}
+
+export const TruncatedMemo = ({
+  memo,
+  fallback,
+  inline = false,
+  className,
+  "data-testid": testId,
+}: TruncatedMemoProps) => {
+  const { t } = useTranslation();
+  const hasMemo = !!memo;
+  const display = hasMemo ? memo : fallback ?? t("None");
+  const title = hasMemo ? (memo as string) : undefined;
+  const classes = [
+    "TruncatedMemo",
+    inline ? "TruncatedMemo--inline" : null,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  if (inline) {
+    return (
+      <span className={classes} title={title} data-testid={testId}>
+        {display}
+      </span>
+    );
+  }
+
+  return (
+    <div className={classes} title={title} data-testid={testId}>
+      {display}
+    </div>
+  );
+};

--- a/extension/src/popup/components/TruncatedMemo/styles.scss
+++ b/extension/src/popup/components/TruncatedMemo/styles.scss
@@ -1,0 +1,13 @@
+.TruncatedMemo {
+  display: block;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &--inline {
+    display: inline-block;
+    vertical-align: bottom;
+  }
+}

--- a/extension/src/popup/components/accountHistory/TransactionDetail/index.tsx
+++ b/extension/src/popup/components/accountHistory/TransactionDetail/index.tsx
@@ -9,6 +9,7 @@ import { emitMetric } from "helpers/metrics";
 import { openTab } from "popup/helpers/navigate";
 import { stroopToXlm } from "helpers/stellar";
 import { KeyIdenticon } from "popup/components/identicons/KeyIdenticon";
+import { TruncatedMemo } from "popup/components/TruncatedMemo";
 
 import { METRIC_NAMES } from "popup/constants/metricsNames";
 
@@ -383,12 +384,10 @@ export const TransactionDetail = ({
               <Icon.File02 />
               {t("Memo")}
             </div>
-            <div
+            <TruncatedMemo
+              memo={memo}
               className="Metadata__value Metadata__memo"
-              title={memo && memo.trim() ? memo : undefined}
-            >
-              {memo || t("None")}
-            </div>
+            />
           </div>
         )}
       </div>

--- a/extension/src/popup/components/accountHistory/TransactionDetail/index.tsx
+++ b/extension/src/popup/components/accountHistory/TransactionDetail/index.tsx
@@ -378,12 +378,17 @@ export const TransactionDetail = ({
         </div>
         {/* Hide memo row when memo is disabled (e.g., for all M addresses) */}
         {!isMemoDisabled && (
-          <div className="Metadata">
+          <div className="Metadata Metadata--memo">
             <div className="Metadata__label">
               <Icon.File02 />
               {t("Memo")}
             </div>
-            <div className="Metadata__value">{memo || t("None")}</div>
+            <div
+              className="Metadata__value Metadata__memo"
+              title={memo && memo.trim() ? memo : undefined}
+            >
+              {memo || t("None")}
+            </div>
           </div>
         )}
       </div>

--- a/extension/src/popup/components/accountHistory/TransactionDetail/styles.scss
+++ b/extension/src/popup/components/accountHistory/TransactionDetail/styles.scss
@@ -311,11 +311,6 @@
       }
 
       &__memo {
-        display: block;
-        max-width: 100%;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
         text-align: right;
       }
     }

--- a/extension/src/popup/components/accountHistory/TransactionDetail/styles.scss
+++ b/extension/src/popup/components/accountHistory/TransactionDetail/styles.scss
@@ -305,6 +305,19 @@
           margin-right: pxToRem(6px);
         }
       }
+
+      &--memo > * {
+        min-width: 0;
+      }
+
+      &__memo {
+        display: block;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        text-align: right;
+      }
     }
   }
 

--- a/extension/src/popup/views/SignTransaction/Preview/Summary/__tests__/index.test.tsx
+++ b/extension/src/popup/views/SignTransaction/Preview/Summary/__tests__/index.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { Summary } from "popup/views/SignTransaction/Preview/Summary";
+
+describe("SignTransaction/Preview/Summary memo display", () => {
+  const baseProps = {
+    operationNames: ["payment"],
+    fee: "1000",
+    sequenceNumber: "1",
+    xdr: "AAAA",
+  };
+
+  it("renders the memo value with a truncating wrapper inside MemoBlock", () => {
+    const longMemo = "a".repeat(80);
+    render(
+      <Summary {...baseProps} memo={{ value: longMemo, type: "text" }} />,
+    );
+
+    const memoBlock = screen.getByTestId("MemoBlock");
+    expect(memoBlock).toBeInTheDocument();
+    expect(memoBlock.textContent).toContain(longMemo);
+    expect(memoBlock.textContent).toContain("MEMO_TEXT");
+
+    const wrapper = memoBlock.querySelector(".TxInfoBlock__memo");
+    expect(wrapper).not.toBeNull();
+    expect(wrapper).toHaveTextContent(longMemo);
+  });
+
+  it("sets the title attribute to the memo value when present", () => {
+    const memoValue = "important payment reference";
+    render(
+      <Summary {...baseProps} memo={{ value: memoValue, type: "text" }} />,
+    );
+
+    const wrapper = screen
+      .getByTestId("MemoBlock")
+      .querySelector(".TxInfoBlock__memo");
+    expect(wrapper).toHaveAttribute("title", memoValue);
+  });
+
+  it("omits the title attribute when memo is missing", () => {
+    render(<Summary {...baseProps} />);
+
+    const memoBlock = screen.getByTestId("MemoBlock");
+    expect(memoBlock.textContent).toContain("None");
+
+    const wrapper = memoBlock.querySelector(".TxInfoBlock__memo");
+    expect(wrapper).not.toBeNull();
+    expect(wrapper).not.toHaveAttribute("title");
+  });
+
+  it("omits the title attribute when memo is whitespace-only", () => {
+    render(
+      <Summary {...baseProps} memo={{ value: "   ", type: "text" }} />,
+    );
+
+    const wrapper = screen
+      .getByTestId("MemoBlock")
+      .querySelector(".TxInfoBlock__memo");
+    expect(wrapper).not.toBeNull();
+    expect(wrapper).not.toHaveAttribute("title");
+  });
+});

--- a/extension/src/popup/views/SignTransaction/Preview/Summary/__tests__/index.test.tsx
+++ b/extension/src/popup/views/SignTransaction/Preview/Summary/__tests__/index.test.tsx
@@ -50,7 +50,7 @@ describe("SignTransaction/Preview/Summary memo display", () => {
     expect(wrapper).not.toHaveAttribute("title");
   });
 
-  it("omits the title attribute when memo is whitespace-only", () => {
+  it("includes the title attribute even when memo is whitespace-only (preserves user input)", () => {
     render(
       <Summary {...baseProps} memo={{ value: "   ", type: "text" }} />,
     );
@@ -59,6 +59,31 @@ describe("SignTransaction/Preview/Summary memo display", () => {
       .getByTestId("MemoBlock")
       .querySelector(".TxInfoBlock__memo");
     expect(wrapper).not.toBeNull();
-    expect(wrapper).not.toHaveAttribute("title");
+    expect(wrapper).toHaveAttribute("title", "   ");
+  });
+
+  it("renders MEMO_NONE label when memo value is empty even if type is set", () => {
+    render(
+      <Summary {...baseProps} memo={{ value: "", type: "text" }} />,
+    );
+
+    const memoBlock = screen.getByTestId("MemoBlock");
+    expect(memoBlock.textContent).toContain("None");
+    expect(memoBlock.textContent).toContain("MEMO_NONE");
+    expect(memoBlock.textContent).not.toContain("MEMO_TEXT");
+  });
+
+  it("renders the type-label suffix in a non-shrinking sibling element", () => {
+    render(
+      <Summary
+        {...baseProps}
+        memo={{ value: "a".repeat(120), type: "text" }}
+      />,
+    );
+
+    const memoBlock = screen.getByTestId("MemoBlock");
+    const memoType = memoBlock.querySelector(".TxInfoBlock__memoType");
+    expect(memoType).not.toBeNull();
+    expect(memoType).toHaveTextContent("MEMO_TEXT");
   });
 });

--- a/extension/src/popup/views/SignTransaction/Preview/Summary/index.tsx
+++ b/extension/src/popup/views/SignTransaction/Preview/Summary/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import { stroopToXlm } from "helpers/stellar";
 import { CopyValue } from "popup/components/CopyValue";
+import { TruncatedMemo } from "popup/components/TruncatedMemo";
 
 import "./styles.scss";
 
@@ -55,19 +56,16 @@ export const Summary = (props: SummaryProps) => {
           <p>{t("Memo")}</p>
         </div>
         <span className="TxInfoBlock__value TxInfoBlock__value--memo">
-          <span
+          <TruncatedMemo
+            inline
+            memo={props.memo ? props.memo.value : undefined}
             className="TxInfoBlock__memo"
-            title={
-              props.memo && props.memo.value && props.memo.value.trim()
-                ? props.memo.value
-                : undefined
-            }
-          >
-            {props.memo && props.memo.value
-              ? props.memo.value
-              : t("None")}
+          />
+          <span className="TxInfoBlock__memoType">
+            {` (${getMemoLabel(
+              props.memo && props.memo.value ? props.memo.type : "none",
+            )})`}
           </span>
-          {` (${getMemoLabel(props.memo ? props.memo.type : "none")})`}
         </span>
       </div>
       <div className="TxInfoBlock">

--- a/extension/src/popup/views/SignTransaction/Preview/Summary/index.tsx
+++ b/extension/src/popup/views/SignTransaction/Preview/Summary/index.tsx
@@ -54,11 +54,21 @@ export const Summary = (props: SummaryProps) => {
         <div className="TxInfoBlock__title">
           <p>{t("Memo")}</p>
         </div>
-        <p className="TxInfoBlock__value">
-          {props.memo && props.memo.value
-            ? `${props.memo.value} (${getMemoLabel(props.memo.type)})`
-            : `${t("None")} (${getMemoLabel("none")})`}
-        </p>
+        <span className="TxInfoBlock__value TxInfoBlock__value--memo">
+          <span
+            className="TxInfoBlock__memo"
+            title={
+              props.memo && props.memo.value && props.memo.value.trim()
+                ? props.memo.value
+                : undefined
+            }
+          >
+            {props.memo && props.memo.value
+              ? props.memo.value
+              : t("None")}
+          </span>
+          {` (${getMemoLabel(props.memo ? props.memo.type : "none")})`}
+        </span>
       </div>
       <div className="TxInfoBlock">
         <div className="TxInfoBlock__title">

--- a/extension/src/popup/views/SignTransaction/Preview/Summary/styles.scss
+++ b/extension/src/popup/views/SignTransaction/Preview/Summary/styles.scss
@@ -27,6 +27,15 @@
         --sds-clr-gray-12
       ) !important; //sds rule does not allwo changing colors on p tags
 
+      &--memo {
+        min-width: 0;
+        display: inline-flex;
+        align-items: baseline;
+        gap: pxToRem(4px);
+        max-width: 100%;
+        overflow: hidden;
+      }
+
       .CopyValue {
         max-width: pxToRem(120px);
 
@@ -41,6 +50,14 @@
           color: var(--sds-clr-gray-09);
         }
       }
+    }
+    &__memo {
+      display: inline-block;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      vertical-align: bottom;
     }
   }
 }

--- a/extension/src/popup/views/SignTransaction/Preview/Summary/styles.scss
+++ b/extension/src/popup/views/SignTransaction/Preview/Summary/styles.scss
@@ -52,12 +52,12 @@
       }
     }
     &__memo {
-      display: inline-block;
-      max-width: 100%;
-      overflow: hidden;
-      text-overflow: ellipsis;
+      flex: 0 1 auto;
+      min-width: 0;
+    }
+    &__memoType {
+      flex: 0 0 auto;
       white-space: nowrap;
-      vertical-align: bottom;
     }
   }
 }

--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -79,6 +79,7 @@ import { KeyIdenticon } from "popup/components/identicons/KeyIdenticon";
 import { MultiPaneSlider } from "popup/components/SlidingPaneSwitcher";
 
 import { AuthEntries } from "popup/components/AuthEntry";
+import { TruncatedMemo } from "popup/components/TruncatedMemo";
 import { Summary } from "./Preview/Summary";
 import { Details } from "./Preview/Details";
 
@@ -492,20 +493,10 @@ export const SignTransaction = () => {
                       <span>{t("Memo")}</span>
                     </div>
                     <div className="SignTransaction__Metadata__Value">
-                      <div
+                      <TruncatedMemo
+                        memo={decodedMemo ? decodedMemo.value : undefined}
                         className="SignTransaction__Metadata__Memo"
-                        title={
-                          decodedMemo &&
-                          decodedMemo.value &&
-                          decodedMemo.value.trim()
-                            ? decodedMemo.value
-                            : undefined
-                        }
-                      >
-                        {decodedMemo && decodedMemo.value
-                          ? decodedMemo.value
-                          : t("None")}
-                      </div>
+                      />
                     </div>
                   </div>
                 </div>

--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -486,17 +486,26 @@ export const SignTransaction = () => {
                       </span>
                     </div>
                   </div>
-                  <div className="SignTransaction__Metadata__Row">
+                  <div className="SignTransaction__Metadata__Row SignTransaction__Metadata__Row--memo">
                     <div className="SignTransaction__Metadata__Label">
                       <Icon.File02 />
                       <span>{t("Memo")}</span>
                     </div>
                     <div className="SignTransaction__Metadata__Value">
-                      <span>
+                      <div
+                        className="SignTransaction__Metadata__Memo"
+                        title={
+                          decodedMemo &&
+                          decodedMemo.value &&
+                          decodedMemo.value.trim()
+                            ? decodedMemo.value
+                            : undefined
+                        }
+                      >
                         {decodedMemo && decodedMemo.value
                           ? decodedMemo.value
                           : t("None")}
-                      </span>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/extension/src/popup/views/SignTransaction/styles.scss
+++ b/extension/src/popup/views/SignTransaction/styles.scss
@@ -243,6 +243,10 @@
       align-items: center;
       width: 100%;
 
+      &--memo > * {
+        min-width: 0;
+      }
+
       &:not(:last-child) {
         margin-bottom: pxToRem(12px);
         padding-bottom: pxToRem(12px);
@@ -275,6 +279,15 @@
           color: var(--sds-clr-gray-09);
         }
       }
+    }
+
+    &__Memo {
+      display: block;
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      text-align: right;
     }
   }
 

--- a/extension/src/popup/views/SignTransaction/styles.scss
+++ b/extension/src/popup/views/SignTransaction/styles.scss
@@ -282,11 +282,6 @@
     }
 
     &__Memo {
-      display: block;
-      max-width: 100%;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
       text-align: right;
     }
   }


### PR DESCRIPTION
# Proposal v4 — Fix memo display for long memos (issue #2615)

## Problem

A long memo entered in the Send flow visually overflows its row in the
Review Transaction sheet and crashes into the "Memo" label. The same
"label / plain-text value in a flex row with `space-between` (or two
`flex: 2` columns) and no truncation" pattern is used to display memos
in three other views and exhibits the same defect in each.

## Confirmed facts

- `transactionData.memo` is `string | undefined`
  (`extension/src/popup/ducks/transactionSubmission.ts:427`).
- `freighter/extension/package.json` has no `lint` or unit-test script.
  Tests run via `yarn test:ci` (`jest --ci`) from `freighter/`. Lint is
  invoked through `lint-staged`/`eslint --max-warnings 0` on commit.
- A grep across `extension/src` for memo display sites confirms exactly
  four affected views; ChangeTrustInternal / signTransaction Operations
  use memo only for editing or for the memo-required warning, not as a
  display value.
- Existing Jest tests do not assert on the inner text node of any of
  the affected memo containers (no consumers of `review-tx-memo`,
  `MemoBlock`, etc. in `__tests__`). Wrapping the memo text in an
  additional element will not break tests.

## Out-of-scope

- No global row-layout rewrite. No CopyValue swap. No baked-in
  truncation in `CopyValue`. No changes to `EditMemo`, send validation,
  or memo type handling.

## Affected sites and per-site change plan

For every site, the change is:
- Replace the bare `{memo || t("None")}` text node so it renders
  truncatable content.
- Add a `title={memo}` attribute **only when** `memo && memo.trim()` —
  i.e., when there's a non-whitespace memo to surface on hover. This
  prevents blank tooltips on whitespace-only memos.
- Add a small site-specific CSS modifier class scoped under the
  view's existing root selector. No global selectors. Other rows are
  untouched.

The exact form differs per site to fit existing markup (in particular
to avoid nesting a `<div>` inside a `<p>`).

### Site 1 — `ReviewTransaction` (the issue's screenshot)

`extension/src/popup/components/InternalTransaction/ReviewTransaction/index.tsx`
(memo row at lines ~349–362):

```tsx
const memoTitle = memo && memo.trim() ? memo : undefined;
// ...
<div className="ReviewTx__Details__Row ReviewTx__Details__Row--memo">
  <div className="ReviewTx__Details__Row__Title">
    <Icon.File02 />
    {t("Memo")}
  </div>
  <div
    className="ReviewTx__Details__Row__Value"
    data-testid="review-tx-memo"
  >
    <div className="ReviewTx__Memo" title={memoTitle}>
      {memo || t("None")}
    </div>
  </div>
</div>
```

`styles.scss` additions (scoped under `.ReviewTx`):

```scss
.ReviewTx__Details__Row--memo > * {
  min-width: 0;            // allow flex children to shrink below content width
}

.ReviewTx__Memo {
  display: block;
  align-self: stretch;     // span the column-flex Value's available width
  max-width: 100%;
  overflow: hidden;
  text-overflow: ellipsis;
  white-space: nowrap;
  text-align: right;       // preserve the existing `align-items: end` look
}
```

(`align-self: stretch` is needed because `__Value` is `display: flex;
flex-direction: column; align-items: end`. The cross-axis stretch makes
the memo wrapper take the full available width so ellipsis triggers.)

### Site 2 — `SignTransaction` Preview Summary (uses `<p>` host)

`extension/src/popup/views/SignTransaction/Preview/Summary/index.tsx`
(memo block at lines 53–61): change the existing `<p
className="TxInfoBlock__value">` for the memo block into a `<span>`
host so a block-level inner element is HTML-valid, then wrap the memo:

```tsx
const memoValue = props.memo && props.memo.value ? props.memo.value : t("None");
const memoTitle =
  props.memo && props.memo.value && props.memo.value.trim()
    ? props.memo.value
    : undefined;
// ...
<div className="TxInfoBlock" data-testid="MemoBlock">
  <div className="TxInfoBlock__title">
    <p>{t("Memo")}</p>
  </div>
  <span className="TxInfoBlock__value TxInfoBlock__value--memo">
    <span className="TxInfoBlock__memo" title={memoTitle}>
      {memoValue}
    </span>
    {` (${getMemoLabel(props.memo?.type ?? "none")})`}
  </span>
</div>
```

(The `(MEMO_TEXT)` label suffix stays outside the truncated span so
only the user-supplied memo value is ellipsised; the type label is
always short and visible.)

`styles.scss` additions (scoped under `.TxInfo`):

```scss
.TxInfo .TxInfoBlock--memo,
.TxInfo .TxInfoBlock:has(.TxInfoBlock__memo) {
  // no-op placeholder if BEM modifier is preferred — see below
}

.TxInfo .TxInfoBlock__value--memo {
  min-width: 0;
  display: inline-flex;
  align-items: baseline;
  gap: pxToRem(4px);
  max-width: 100%;
  overflow: hidden;
}

.TxInfo .TxInfoBlock__memo {
  display: inline-block;
  max-width: 100%;
  overflow: hidden;
  text-overflow: ellipsis;
  white-space: nowrap;
  vertical-align: bottom;
}
```

`min-width: 0` goes on the value host directly because in this view the
row's value side is the immediate flex child — the `space-between` row
needs that single child to drop its `min-width: auto`. No global
`__value` rule is added; the modifier class scopes the change.

(If the team prefers not to switch the host element from `<p>` to
`<span>`, an alternative is to apply the truncation styles directly on
the `<p className="TxInfoBlock__value TxInfoBlock__value--memo">` and
keep the memo text + label as plain children — but that gives up the
"truncate the value, keep the label visible" property. The implementor
should pick whichever yields the smaller diff while preserving the
"memo ellipsises, label remains" behavior, and document the choice in
the PR description.)

### Site 3 — `accountHistory/TransactionDetail`

`extension/src/popup/components/accountHistory/TransactionDetail/index.tsx`
(memo row at lines 381–387):

```tsx
const memoTitle = memo && memo.trim() ? memo : undefined;
// ...
<div className="Metadata Metadata--memo">
  <div className="Metadata__label">
    <Icon.File02 />
    {t("Memo")}
  </div>
  <div className="Metadata__value Metadata__memo" title={memoTitle}>
    {memo || t("None")}
  </div>
</div>
```

`styles.scss` additions inside the existing `&__metadata { .Metadata { … } }`
block (around lines 274–308). The `Metadata` selector is nested under
the page's `&__metadata` ancestor, so the new rules use the same
nesting:

```scss
&__metadata {
  // ... existing rules ...
  .Metadata {
    // ... existing rules ...

    &--memo > * {
      min-width: 0;
    }

    &__memo {
      display: block;
      max-width: 100%;
      overflow: hidden;
      text-overflow: ellipsis;
      white-space: nowrap;
      text-align: right;
    }
  }
}
```

These compile to selectors of the form
`.TransactionDetailModal__metadata .Metadata--memo > *` and
`.TransactionDetailModal__metadata .Metadata__memo`, matching the
existing structure.

### Site 4 — `SignTransaction` main metadata

`extension/src/popup/views/SignTransaction/index.tsx`
(memo row at lines 489–500): replace the existing unstyled `<span>` (lines
494–499) with the truncating wrapper rather than nesting under it.

```tsx
const memoText =
  decodedMemo && decodedMemo.value ? decodedMemo.value : t("None");
const memoTitle =
  decodedMemo && decodedMemo.value && decodedMemo.value.trim()
    ? decodedMemo.value
    : undefined;
// ...
<div className="SignTransaction__Metadata__Row SignTransaction__Metadata__Row--memo">
  <div className="SignTransaction__Metadata__Label">
    <Icon.File02 />
    <span>{t("Memo")}</span>
  </div>
  <div className="SignTransaction__Metadata__Value">
    <div className="SignTransaction__Metadata__Memo" title={memoTitle}>
      {memoText}
    </div>
  </div>
</div>
```

`styles.scss` additions inside the existing `&__Metadata { … }` block
(scope from line 231):

```scss
&__Metadata {
  // ... existing rules ...
  &__Row--memo > * {
    min-width: 0;
  }
  &__Memo {
    display: block;
    max-width: 100%;
    overflow: hidden;
    text-overflow: ellipsis;
    white-space: nowrap;
    text-align: right;
  }
}
```

## Verification

Run from `freighter/`:

- `yarn test:ci`
- `yarn workspace extension build`
- `npx eslint --max-warnings 0` on each changed `.tsx`
- Manual: load the unpacked extension, send-flow with a 28-char memo,
  confirm Review sheet truncates with ellipsis and full memo appears on
  hover. Repeat the visual check on Sign Transaction (main + Preview
  panes) and on a long-memo entry in Account History.

## Files touched

- `extension/src/popup/components/InternalTransaction/ReviewTransaction/index.tsx`
- `extension/src/popup/components/InternalTransaction/ReviewTransaction/styles.scss`
- `extension/src/popup/views/SignTransaction/Preview/Summary/index.tsx`
- `extension/src/popup/views/SignTransaction/Preview/Summary/styles.scss`
- `extension/src/popup/components/accountHistory/TransactionDetail/index.tsx`
- `extension/src/popup/components/accountHistory/TransactionDetail/styles.scss`
- `extension/src/popup/views/SignTransaction/index.tsx`
- `extension/src/popup/views/SignTransaction/styles.scss`

## Risks

Very low. Each change is a localized markup tweak plus a scoped CSS
modifier rule. No primitive is altered; other rows in each container
are pixel-identical.

## Deferred follow-up

A shared `<DetailsRow title value />` and/or `<TruncatedText value />`
primitive that bakes in the `min-width: 0` flex-shrink fix and ellipsis
behavior would replace these four near-identical CSS snippets and
prevent the class of bug from recurring in the next detail view added.
Out of scope for this fix; will be filed as a follow-up issue at
completion.


---

Closes #2615
