### PR TITLE
fix: prevent SVG NFTs from collapsing to 0x0

### DIFF
--- a/extension/src/popup/components/account/CollectibleInfo/styles.scss
+++ b/extension/src/popup/components/account/CollectibleInfo/styles.scss
@@ -5,6 +5,8 @@
     border-radius: pxToRem(24px);
     margin-bottom: pxToRem(12px);
     overflow: hidden;
+    width: 100%;
+    aspect-ratio: 1 / 1;
 
     img {
       width: 100%;

--- a/extension/src/popup/components/account/CollectibleInfo/styles.scss
+++ b/extension/src/popup/components/account/CollectibleInfo/styles.scss
@@ -11,7 +11,7 @@
     img {
       width: 100%;
       height: 100%;
-      object-fit: cover;
+      object-fit: contain;
     }
 
     &--small {


### PR DESCRIPTION
## Description
Fixes an issue where valid SVG NFTs (e.g. SEP-50 standard tokens) with `width='100%'` and `height='100%'` collapse to a 0x0 height inside the `CollectibleInfo__image` container. By adding an explicit `aspect-ratio: 1 / 1;`, it ensures that the container maintains correct square proportions and standard SVGs render visibly.

## Changes
- Added `aspect-ratio: 1 / 1` and `width: 100%` to `.CollectibleInfo__image` in `styles.scss`.