### PR TITLE
Order Account view balances by USD value

### DIFF
--- a/extension/src/popup/helpers/__tests__/balance.test.js
+++ b/extension/src/popup/helpers/__tests__/balance.test.js
@@ -3,7 +3,7 @@ import BigNumber from "bignumber.js";
 import { TESTNET_NETWORK_DETAILS } from "@shared/constants/stellar";
 import { defaultBlockaidScanAssetResult } from "@shared/helpers/stellar";
 
-import { getBalanceByKey, findAssetBalance } from "../balance";
+import { getBalanceByKey, findAssetBalance, sortBalancesByValue } from "../balance";
 
 const CONTRACT_ID = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
 const TOKEN_BALANCE_KEY = `DT:${CONTRACT_ID}`;
@@ -98,5 +98,110 @@ describe("findAssetBalance", () => {
       issuer: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
     });
     expect(result).toBeUndefined();
+  });
+});
+
+describe("sortBalancesByValue", () => {
+  const NATIVE = {
+    token: { type: "native", code: "XLM" },
+    total: new BigNumber("50"),
+    available: new BigNumber("50"),
+  };
+  const USDC_ISSUER = "GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM";
+  const USDC = {
+    token: { code: "USDC", issuer: { key: USDC_ISSUER } },
+    total: new BigNumber("100"),
+    available: new BigNumber("100"),
+  };
+  const ARS_ISSUER = "GCYE7C77EB5AWAA25R5XMWNI2EDOKTTFTTPZKM2SR5DI4B4WFD52DARS";
+  const ARS = {
+    token: { code: "ARS", issuer: { key: ARS_ISSUER } },
+    total: new BigNumber("100000"),
+    available: new BigNumber("100000"),
+  };
+  const LP = {
+    liquidityPoolId:
+      "a468d41d8e9b8f3c7209651608b74b7db7ac9952dcae0cdf24871d1d9c7b0088",
+    total: new BigNumber("10"),
+    limit: new BigNumber("100"),
+  };
+
+  const fullPrices = {
+    native: { currentPrice: "0.276" },
+    [`USDC:${USDC_ISSUER}`]: { currentPrice: "1" },
+    [`ARS:${ARS_ISSUER}`]: { currentPrice: "0.001" },
+  };
+
+  it("returns input unchanged when prices is null", () => {
+    const input = [NATIVE, USDC, LP];
+    expect(sortBalancesByValue(input, null)).toEqual(input);
+  });
+
+  it("returns input unchanged when prices is undefined", () => {
+    const input = [NATIVE, USDC, LP];
+    expect(sortBalancesByValue(input, undefined)).toEqual(input);
+  });
+
+  it("returns input unchanged when prices is empty", () => {
+    const input = [NATIVE, USDC, LP];
+    expect(sortBalancesByValue(input, {})).toEqual(input);
+  });
+
+  it("orders all priced assets descending by USD value", () => {
+    // USD values: USDC = 100 * 1 = 100; XLM = 50 * 0.276 = 13.8; ARS = 100000 * 0.001 = 100
+    // ARS and USDC tie at 100 → original order (USDC first) preserved.
+    const input = [NATIVE, USDC, ARS];
+    const result = sortBalancesByValue(input, fullPrices);
+    expect(result).toEqual([USDC, ARS, NATIVE]);
+  });
+
+  it("places priced assets before unpriced; unpriced keep original order", () => {
+    // USDC and ARS unpriced (no entry); XLM priced.
+    const partialPrices = { native: { currentPrice: "0.276" } };
+    const input = [USDC, NATIVE, ARS];
+    const result = sortBalancesByValue(input, partialPrices);
+    expect(result).toEqual([NATIVE, USDC, ARS]);
+  });
+
+  it("treats LP shares as unpriced and keeps them after priced assets", () => {
+    const input = [NATIVE, LP, USDC];
+    const result = sortBalancesByValue(input, fullPrices);
+    // USDC=100, XLM=13.8 → USDC, XLM, LP (LP unpriced; appears after priced).
+    expect(result).toEqual([USDC, NATIVE, LP]);
+  });
+
+  it("keeps a zero currentPrice in the priced group", () => {
+    const prices = {
+      native: { currentPrice: "0" },
+      [`USDC:${USDC_ISSUER}`]: { currentPrice: "1" },
+    };
+    // ARS unpriced → after priced. NATIVE has zero priced value, USDC has 100.
+    const input = [NATIVE, ARS, USDC];
+    const result = sortBalancesByValue(input, prices);
+    expect(result).toEqual([USDC, NATIVE, ARS]);
+  });
+
+  it("treats a malformed currentPrice as unpriced", () => {
+    const prices = {
+      native: { currentPrice: "not-a-number" },
+      [`USDC:${USDC_ISSUER}`]: { currentPrice: "1" },
+    };
+    const input = [NATIVE, USDC];
+    const result = sortBalancesByValue(input, prices);
+    expect(result).toEqual([USDC, NATIVE]);
+  });
+
+  it("preserves original order when two priced assets have identical USD value", () => {
+    // USDC = 100; ARS = 100. Original order: ARS, USDC → ARS stays first.
+    const input = [ARS, USDC];
+    const result = sortBalancesByValue(input, fullPrices);
+    expect(result).toEqual([ARS, USDC]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [NATIVE, USDC, LP];
+    const snapshot = [...input];
+    sortBalancesByValue(input, fullPrices);
+    expect(input).toEqual(snapshot);
   });
 });

--- a/extension/src/popup/helpers/__tests__/balance.test.js
+++ b/extension/src/popup/helpers/__tests__/balance.test.js
@@ -3,7 +3,7 @@ import BigNumber from "bignumber.js";
 import { TESTNET_NETWORK_DETAILS } from "@shared/constants/stellar";
 import { defaultBlockaidScanAssetResult } from "@shared/helpers/stellar";
 
-import { getBalanceByKey, findAssetBalance, sortBalancesByValue } from "../balance";
+import { getBalanceByKey, findAssetBalance, sortBalancesByValue, getBalanceCanonicalKey } from "../balance";
 
 const CONTRACT_ID = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
 const TOKEN_BALANCE_KEY = `DT:${CONTRACT_ID}`;
@@ -203,5 +203,56 @@ describe("sortBalancesByValue", () => {
     const snapshot = [...input];
     sortBalancesByValue(input, fullPrices);
     expect(input).toEqual(snapshot);
+  });
+});
+
+describe("getBalanceCanonicalKey", () => {
+  const NATIVE = {
+    token: { type: "native", code: "XLM" },
+    total: new BigNumber("50"),
+  };
+  const CLASSIC_USDC = {
+    token: {
+      code: "USDC",
+      issuer: { key: "GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM" },
+    },
+    total: new BigNumber("100"),
+  };
+  const SOROBAN = {
+    contractId: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+    total: new BigNumber("1"),
+  };
+  const LP = {
+    liquidityPoolId:
+      "a468d41d8e9b8f3c7209651608b74b7db7ac9952dcae0cdf24871d1d9c7b0088",
+    total: new BigNumber(10),
+  };
+
+  it("returns the canonical CODE:ISSUER form for classic balances", () => {
+    expect(getBalanceCanonicalKey(CLASSIC_USDC)).toBe(
+      "USDC:GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM",
+    );
+  });
+
+  it("returns 'native' for the native XLM balance", () => {
+    expect(getBalanceCanonicalKey(NATIVE)).toBe("native");
+  });
+
+  it("namespaces Soroban contract IDs with a 'soroban:' prefix", () => {
+    expect(getBalanceCanonicalKey(SOROBAN)).toBe(
+      "soroban:CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+    );
+  });
+
+  it("namespaces liquidity pool ids with an 'lp:' prefix", () => {
+    expect(getBalanceCanonicalKey(LP)).toBe(
+      "lp:a468d41d8e9b8f3c7209651608b74b7db7ac9952dcae0cdf24871d1d9c7b0088",
+    );
+  });
+
+  it("returns distinct keys for classic and Soroban balances of the same code", () => {
+    expect(getBalanceCanonicalKey(CLASSIC_USDC)).not.toBe(
+      getBalanceCanonicalKey(SOROBAN),
+    );
   });
 });

--- a/extension/src/popup/helpers/__tests__/balance.test.js
+++ b/extension/src/popup/helpers/__tests__/balance.test.js
@@ -219,6 +219,10 @@ describe("getBalanceCanonicalKey", () => {
     total: new BigNumber("100"),
   };
   const SOROBAN = {
+    token: {
+      code: "DT",
+      issuer: { key: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC" },
+    },
     contractId: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
     total: new BigNumber("1"),
   };
@@ -238,21 +242,31 @@ describe("getBalanceCanonicalKey", () => {
     expect(getBalanceCanonicalKey(NATIVE)).toBe("native");
   });
 
-  it("namespaces Soroban contract IDs with a 'soroban:' prefix", () => {
+  it("returns CODE:CONTRACT_ID for Soroban balances (consistent with getCanonicalFromAsset)", () => {
     expect(getBalanceCanonicalKey(SOROBAN)).toBe(
-      "soroban:CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+      "DT:CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
     );
   });
 
-  it("namespaces liquidity pool ids with an 'lp:' prefix", () => {
+  it("uses the LP_IDENTIFIER ':lp' suffix for liquidity pool shares", () => {
     expect(getBalanceCanonicalKey(LP)).toBe(
-      "lp:a468d41d8e9b8f3c7209651608b74b7db7ac9952dcae0cdf24871d1d9c7b0088",
+      "a468d41d8e9b8f3c7209651608b74b7db7ac9952dcae0cdf24871d1d9c7b0088:lp",
     );
   });
 
-  it("returns distinct keys for classic and Soroban balances of the same code", () => {
+  it("returns distinct keys for classic and Soroban balances even when the code matches", () => {
+    const SOROBAN_USDC = {
+      token: {
+        code: "USDC",
+        issuer: {
+          key: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+        },
+      },
+      contractId: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+      total: new BigNumber("1"),
+    };
     expect(getBalanceCanonicalKey(CLASSIC_USDC)).not.toBe(
-      getBalanceCanonicalKey(SOROBAN),
+      getBalanceCanonicalKey(SOROBAN_USDC),
     );
   });
 });

--- a/extension/src/popup/helpers/balance.ts
+++ b/extension/src/popup/helpers/balance.ts
@@ -195,6 +195,50 @@ export const getPriceDeltaColor = (delta: BigNumber) => {
   return "";
 };
 
+/**
+ * Re-orders balances for display by descending USD value.
+ *
+ * Only native + classic G-issuer assets receive prices from the indexer
+ * (Soroban, custom tokens, and LP shares are filtered out upstream — see
+ * `getTokenPrices` in `@shared/api/internal.ts`). Unpriced balances keep
+ * the relative order produced by `sortBalances` and sort below all
+ * priced balances. A `currentPrice` of `"0"` is a valid USD value and
+ * keeps the asset in the priced group; a malformed `currentPrice` is
+ * treated as unpriced.
+ */
+export const sortBalancesByValue = (
+  balances: AssetType[],
+  prices: ApiTokenPrices | null | undefined,
+): AssetType[] => {
+  if (!prices || Object.keys(prices).length === 0) {
+    return balances;
+  }
+
+  const usdValueOf = (b: AssetType): BigNumber | null => {
+    if (!("token" in b)) return null;
+    const canonical = getCanonicalFromAsset(
+      b.token.code,
+      "issuer" in b.token ? b.token.issuer.key : undefined,
+    );
+    const priceStr = prices[canonical]?.currentPrice;
+    if (priceStr === undefined || priceStr === null || priceStr === "") {
+      return null;
+    }
+    const value = new BigNumber(priceStr).multipliedBy(b.total);
+    return value.isFinite() ? value : null;
+  };
+
+  return balances
+    .map((b, i) => ({ b, i, v: usdValueOf(b) }))
+    .sort((a, z) => {
+      if (a.v && z.v) return z.v.comparedTo(a.v) || a.i - z.i;
+      if (a.v) return -1;
+      if (z.v) return 1;
+      return a.i - z.i;
+    })
+    .map((x) => x.b);
+};
+
 export const getTotalUsd = (prices: ApiTokenPrices, balances: AssetType[]) => {
   return Object.keys(prices).reduce((prev, curr) => {
     const asset = getAssetFromCanonical(curr);

--- a/extension/src/popup/helpers/balance.ts
+++ b/extension/src/popup/helpers/balance.ts
@@ -196,6 +196,27 @@ export const getPriceDeltaColor = (delta: BigNumber) => {
 };
 
 /**
+ * Returns a stable identity key for a balance. Two balances refer to the
+ * same on-chain asset iff they share this key. Used by display logic
+ * that needs to track balance identity across re-fetches (e.g.
+ * `useStableSortedBalances`).
+ *
+ * Classic / native balances key off the canonical `CODE:ISSUER` form;
+ * Soroban tokens key off their contract ID; LP shares key off the LP id.
+ */
+export const getBalanceCanonicalKey = (b: AssetType): string => {
+  if ("contractId" in b) return `soroban:${b.contractId}`;
+  if ("liquidityPoolId" in b) return `lp:${b.liquidityPoolId}`;
+  if ("token" in b) {
+    return getCanonicalFromAsset(
+      b.token.code,
+      "issuer" in b.token ? b.token.issuer.key : undefined,
+    );
+  }
+  return "";
+};
+
+/**
  * Re-orders balances for display by descending USD value.
  *
  * Only native + classic G-issuer assets receive prices from the indexer
@@ -216,10 +237,7 @@ export const sortBalancesByValue = (
 
   const usdValueOf = (b: AssetType): BigNumber | null => {
     if (!("token" in b)) return null;
-    const canonical = getCanonicalFromAsset(
-      b.token.code,
-      "issuer" in b.token ? b.token.issuer.key : undefined,
-    );
+    const canonical = getBalanceCanonicalKey(b);
     const priceStr = prices[canonical]?.currentPrice;
     if (priceStr === undefined || priceStr === null || priceStr === "") {
       return null;

--- a/extension/src/popup/helpers/balance.ts
+++ b/extension/src/popup/helpers/balance.ts
@@ -17,6 +17,7 @@ import {
 } from "@shared/api/types/account-balance";
 import { NetworkDetails } from "@shared/constants/stellar";
 import { getAssetSacAddress } from "@shared/helpers/soroban/token";
+import { LP_IDENTIFIER } from "./account";
 import { isContractId } from "./soroban";
 
 export const isClassicBalance = (balance: AssetType): balance is ClassicAsset =>
@@ -201,12 +202,16 @@ export const getPriceDeltaColor = (delta: BigNumber) => {
  * that needs to track balance identity across re-fetches (e.g.
  * `useStableSortedBalances`).
  *
- * Classic / native balances key off the canonical `CODE:ISSUER` form;
- * Soroban tokens key off their contract ID; LP shares key off the LP id.
+ * Uses the same conventions as the rest of the codebase:
+ * - LP shares: `<poolId>:lp` (the established `LP_IDENTIFIER` suffix).
+ * - Native, classic, and Soroban tokens: `getCanonicalFromAsset(code,
+ *   issuer.key)`. For Soroban balances, `issuer.key` is the contract ID,
+ *   so this produces `CODE:CONTRACT_ID` consistent with what the price
+ *   map, `getAssetFromCanonical`, and the swap/send `prices[asset]`
+ *   lookups all use.
  */
 export const getBalanceCanonicalKey = (b: AssetType): string => {
-  if ("contractId" in b) return `soroban:${b.contractId}`;
-  if ("liquidityPoolId" in b) return `lp:${b.liquidityPoolId}`;
+  if ("liquidityPoolId" in b) return `${b.liquidityPoolId}${LP_IDENTIFIER}`;
   if ("token" in b) {
     return getCanonicalFromAsset(
       b.token.code,

--- a/extension/src/popup/views/Account/hooks/__tests__/useStableSortedBalances.test.ts
+++ b/extension/src/popup/views/Account/hooks/__tests__/useStableSortedBalances.test.ts
@@ -1,0 +1,155 @@
+import { renderHook } from "@testing-library/react";
+import BigNumber from "bignumber.js";
+
+import { AssetType } from "@shared/api/types/account-balance";
+import { ApiTokenPrices } from "@shared/api/types";
+
+import { useStableSortedBalances } from "../useStableSortedBalances";
+
+const USDC_KEY =
+  "USDC:GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM";
+const BTC_KEY =
+  "BTC:GBSTRH4QOTWNSVA6E4HFERETX4ZLSR3CIUBLK7AXYII277PFJC4BBYOG";
+
+const usdc: AssetType = {
+  token: { code: "USDC", issuer: { key: USDC_KEY.split(":")[1] } },
+  total: new BigNumber("100"),
+  available: new BigNumber("100"),
+} as unknown as AssetType;
+
+const btc: AssetType = {
+  token: { code: "BTC", issuer: { key: BTC_KEY.split(":")[1] } },
+  total: new BigNumber("1"),
+  available: new BigNumber("1"),
+} as unknown as AssetType;
+
+const xlm: AssetType = {
+  token: { type: "native", code: "XLM" },
+  total: new BigNumber("50"),
+  available: new BigNumber("50"),
+} as unknown as AssetType;
+
+const balances: AssetType[] = [usdc, btc, xlm];
+
+const initialPrices: ApiTokenPrices = {
+  [USDC_KEY]: { currentPrice: "1", percentagePriceChange24h: "0" } as any,
+  [BTC_KEY]: {
+    currentPrice: "100000",
+    percentagePriceChange24h: "0",
+  } as any,
+  native: {
+    currentPrice: "0.27633884304166495",
+    percentagePriceChange24h: "0",
+  } as any,
+};
+
+// Prices that, if applied freshly, would re-order the list.
+const flippedPrices: ApiTokenPrices = {
+  [USDC_KEY]: {
+    currentPrice: "10000",
+    percentagePriceChange24h: "0",
+  } as any,
+  [BTC_KEY]: { currentPrice: "1", percentagePriceChange24h: "0" } as any,
+  native: { currentPrice: "20", percentagePriceChange24h: "0" } as any,
+};
+
+const codesOf = (list: AssetType[]) =>
+  list.map((b) => ("token" in b ? (b as any).token.code : "?"));
+
+describe("useStableSortedBalances", () => {
+  it("returns balances sorted by descending USD value on first render", () => {
+    const { result } = renderHook(() =>
+      useStableSortedBalances(balances, initialPrices),
+    );
+    // BTC: $100,000; USDC: $100; XLM: ~$13.81
+    expect(codesOf(result.current)).toEqual(["BTC", "USDC", "XLM"]);
+  });
+
+  it("preserves the initial order when prices change but the asset set does not", () => {
+    const { result, rerender } = renderHook(
+      ({ p }: { p: ApiTokenPrices }) =>
+        useStableSortedBalances(balances, p),
+      { initialProps: { p: initialPrices } },
+    );
+    expect(codesOf(result.current)).toEqual(["BTC", "USDC", "XLM"]);
+
+    // Prices update mid-view (e.g. polling refresh). The hook MUST keep
+    // the captured display order so rows do not jump around.
+    rerender({ p: flippedPrices });
+    expect(codesOf(result.current)).toEqual(["BTC", "USDC", "XLM"]);
+  });
+
+  it("re-sorts when the set of held assets changes (asset added)", () => {
+    const { result, rerender } = renderHook(
+      ({ b, p }: { b: AssetType[]; p: ApiTokenPrices }) =>
+        useStableSortedBalances(b, p),
+      { initialProps: { b: [usdc, xlm], p: initialPrices } },
+    );
+    // USDC ($100) > XLM ($13.81)
+    expect(codesOf(result.current)).toEqual(["USDC", "XLM"]);
+
+    // User adds BTC. The asset set changed, so a fresh sort is computed —
+    // BTC ($100,000) jumps to the top.
+    rerender({ b: [usdc, xlm, btc], p: initialPrices });
+    expect(codesOf(result.current)).toEqual(["BTC", "USDC", "XLM"]);
+  });
+
+  it("re-sorts when an asset is removed", () => {
+    const { result, rerender } = renderHook(
+      ({ b, p }: { b: AssetType[]; p: ApiTokenPrices }) =>
+        useStableSortedBalances(b, p),
+      { initialProps: { b: balances, p: initialPrices } },
+    );
+    expect(codesOf(result.current)).toEqual(["BTC", "USDC", "XLM"]);
+
+    rerender({ b: [usdc, xlm], p: initialPrices });
+    expect(codesOf(result.current)).toEqual(["USDC", "XLM"]);
+  });
+
+  it("flows updated `total` values through while preserving order", () => {
+    const { result, rerender } = renderHook(
+      ({ b, p }: { b: AssetType[]; p: ApiTokenPrices }) =>
+        useStableSortedBalances(b, p),
+      { initialProps: { b: balances, p: initialPrices } },
+    );
+    expect(codesOf(result.current)).toEqual(["BTC", "USDC", "XLM"]);
+
+    // Same asset set, but USDC's `total` has changed (a new payment).
+    const updatedUsdc = {
+      ...(usdc as any),
+      total: new BigNumber("999"),
+      available: new BigNumber("999"),
+    } as AssetType;
+    rerender({ b: [updatedUsdc, btc, xlm], p: initialPrices });
+
+    expect(codesOf(result.current)).toEqual(["BTC", "USDC", "XLM"]);
+    const usdcEntry = result.current.find(
+      (b) => "token" in b && (b as any).token.code === "USDC",
+    ) as any;
+    expect(usdcEntry.total.toString()).toBe("999");
+  });
+
+  it("returns an empty list and resets the snapshot when balances are empty", () => {
+    const { result, rerender } = renderHook(
+      ({ b }: { b: AssetType[] }) =>
+        useStableSortedBalances(b, initialPrices),
+      { initialProps: { b: balances } },
+    );
+    expect(result.current).toHaveLength(3);
+
+    rerender({ b: [] });
+    expect(result.current).toEqual([]);
+
+    // Re-introducing balances must compute a fresh sort, not reuse the
+    // stale snapshot.
+    rerender({ b: [usdc, xlm] });
+    expect(codesOf(result.current)).toEqual(["USDC", "XLM"]);
+  });
+
+  it("returns the input order untouched when no prices are available", () => {
+    const { result } = renderHook(() =>
+      useStableSortedBalances(balances, undefined),
+    );
+    expect(codesOf(result.current)).toEqual(["USDC", "BTC", "XLM"]);
+  });
+});

--- a/extension/src/popup/views/Account/hooks/useStableSortedBalances.ts
+++ b/extension/src/popup/views/Account/hooks/useStableSortedBalances.ts
@@ -1,0 +1,66 @@
+import { useRef } from "react";
+
+import { ApiTokenPrices } from "@shared/api/types";
+import { AssetType } from "@shared/api/types/account-balance";
+
+import {
+  getBalanceCanonicalKey,
+  sortBalancesByValue,
+} from "popup/helpers/balance";
+
+/**
+ * Returns the user's balances sorted by descending USD value, with the
+ * order **frozen for the lifetime of the calling component** unless the
+ * set of held assets changes.
+ *
+ * Token prices on the Account view refresh periodically (and again when
+ * `useGetAccountData` re-fetches). Re-sorting on every refresh would
+ * shuffle rows mid-view, which is jarring — especially in sidebar mode
+ * where Freighter can stay open indefinitely. Instead, this hook captures
+ * the sort order on first arrival of priced data and re-uses it on
+ * subsequent renders. The order is recomputed only when:
+ *
+ * - the set of asset identities changes (an asset was added, removed, or
+ *   trustline-deauthorized), or
+ * - the consumer component remounts (popup is reopened, or the user
+ *   navigates back to the Account view from another route).
+ *
+ * Updated `total` / `available` values flow through to the UI even when
+ * the order is preserved, because the hook re-keys the snapshot against
+ * the latest balance objects on every render.
+ */
+export const useStableSortedBalances = (
+  balances: AssetType[],
+  prices: ApiTokenPrices | null | undefined,
+): AssetType[] => {
+  const snapshotRef = useRef<{
+    signature: string;
+    orderKeys: string[];
+  } | null>(null);
+
+  if (balances.length === 0) {
+    snapshotRef.current = null;
+    return [];
+  }
+
+  const signature = balances
+    .map(getBalanceCanonicalKey)
+    .slice()
+    .sort()
+    .join("|");
+
+  const snap = snapshotRef.current;
+  if (!snap || snap.signature !== signature) {
+    const sorted = sortBalancesByValue(balances, prices);
+    snapshotRef.current = {
+      signature,
+      orderKeys: sorted.map(getBalanceCanonicalKey),
+    };
+    return sorted;
+  }
+
+  const byKey = new Map(balances.map((b) => [getBalanceCanonicalKey(b), b]));
+  return snap.orderKeys
+    .map((k) => byKey.get(k))
+    .filter((b): b is AssetType => b !== undefined);
+};

--- a/extension/src/popup/views/Account/index.tsx
+++ b/extension/src/popup/views/Account/index.tsx
@@ -25,7 +25,7 @@ import { NotFundedMessage } from "popup/components/account/NotFundedMessage";
 import { formatAmount, roundUsdValue } from "popup/helpers/formatters";
 
 import { newTabHref } from "helpers/urls";
-import { getTotalUsd } from "popup/helpers/balance";
+import { getTotalUsd, sortBalancesByValue } from "popup/helpers/balance";
 import { NetworkDetails } from "@shared/constants/stellar";
 import { reRouteOnboarding } from "popup/helpers/route";
 import { AppDataType } from "helpers/hooks/useGetAppData";
@@ -180,6 +180,10 @@ export const Account = () => {
   const tokenPrices = resolvedData?.tokenPrices || {};
   const balances = resolvedData?.balances.balances!;
   const totalBalanceUsd = getTotalUsd(tokenPrices, balances);
+  const sortedBalances = sortBalancesByValue(
+    balances,
+    resolvedData?.tokenPrices,
+  );
   const roundedTotalBalanceUsd =
     !hasError &&
     isMainnet(resolvedData!.networkDetails) &&
@@ -276,7 +280,10 @@ export const Account = () => {
                   data-testid="account-assets"
                 >
                   <AccountAssets
-                    balances={resolvedData.balances}
+                    balances={{
+                      ...resolvedData.balances,
+                      balances: sortedBalances,
+                    }}
                     historyData={historyData.data}
                     assetPrices={tokenPrices}
                     assetIcons={resolvedIcons}

--- a/extension/src/popup/views/Account/index.tsx
+++ b/extension/src/popup/views/Account/index.tsx
@@ -25,7 +25,7 @@ import { NotFundedMessage } from "popup/components/account/NotFundedMessage";
 import { formatAmount, roundUsdValue } from "popup/helpers/formatters";
 
 import { newTabHref } from "helpers/urls";
-import { getTotalUsd, sortBalancesByValue } from "popup/helpers/balance";
+import { getTotalUsd } from "popup/helpers/balance";
 import { NetworkDetails } from "@shared/constants/stellar";
 import { reRouteOnboarding } from "popup/helpers/route";
 import { AppDataType } from "helpers/hooks/useGetAppData";
@@ -38,6 +38,7 @@ import {
   useGetIcons,
   RequestState as IconsRequestState,
 } from "./hooks/useGetIcons";
+import { useStableSortedBalances } from "./hooks/useStableSortedBalances";
 import { AccountTabsContext, TabsList } from "./contexts/activeTabContext";
 
 import {
@@ -112,6 +113,20 @@ export const Account = () => {
       ? accountData.data?.isScanAppended
       : false;
 
+  // Derive `balances` and `tokenPrices` *before* the early returns below
+  // so that `useStableSortedBalances` is called unconditionally on every
+  // render (Rules of Hooks). When `accountData` is in `RequestState.ERROR`
+  // its reducer sets `data: null`, so `accountBalances` is null and we
+  // pass an empty list — the helpers below stay safe and the error UI
+  // farther down can still render.
+  const balances = accountBalances?.balances ?? [];
+  const tokenPrices =
+    accountData.state === RequestState.SUCCESS &&
+    accountData.data.type === AppDataType.RESOLVED
+      ? accountData.data?.tokenPrices
+      : undefined;
+  const sortedBalances = useStableSortedBalances(balances, tokenPrices);
+
   useEffect(() => {
     const getData = async () => {
       if (accountBalances && !isScanAppended) {
@@ -177,13 +192,7 @@ export const Account = () => {
       ? iconsData?.data?.icons
       : {};
 
-  const tokenPrices = resolvedData?.tokenPrices || {};
-  const balances = resolvedData?.balances.balances!;
-  const totalBalanceUsd = getTotalUsd(tokenPrices, balances);
-  const sortedBalances = sortBalancesByValue(
-    balances,
-    resolvedData?.tokenPrices,
-  );
+  const totalBalanceUsd = getTotalUsd(tokenPrices ?? {}, balances);
   const roundedTotalBalanceUsd =
     !hasError &&
     isMainnet(resolvedData!.networkDetails) &&
@@ -285,7 +294,7 @@ export const Account = () => {
                       balances: sortedBalances,
                     }}
                     historyData={historyData.data}
-                    assetPrices={tokenPrices}
+                    assetPrices={tokenPrices ?? {}}
                     assetIcons={resolvedIcons}
                   />
                 </div>

--- a/extension/src/popup/views/__tests__/Account.test.tsx
+++ b/extension/src/popup/views/__tests__/Account.test.tsx
@@ -1061,6 +1061,135 @@ describe("Account view", () => {
     });
   });
 
+  it("orders balances by USD value descending when prices are available", async () => {
+    jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+      Promise.resolve({
+        networkDetails: MAINNET_NETWORK_DETAILS,
+        networksList: DEFAULT_NETWORKS,
+        hiddenAssets: {},
+        allowList: ApiInternal.DEFAULT_ALLOW_LIST,
+        error: "",
+        isDataSharingAllowed: false,
+        isMemoValidationEnabled: false,
+        isHideDustEnabled: true,
+        isOpenSidebarByDefault: false,
+        settingsState: SettingsState.SUCCESS,
+        isSorobanPublicEnabled: false,
+        isRpcHealthy: true,
+        userNotification: {
+          enabled: false,
+          message: "",
+        },
+        isExperimentalModeEnabled: false,
+        isHashSigningEnabled: false,
+        isNonSSLEnabled: false,
+        experimentalFeaturesState: SettingsState.SUCCESS,
+        assetsLists: DEFAULT_ASSETS_LISTS,
+      }),
+    );
+    jest
+      .spyOn(ApiInternal, "getAccountBalances")
+      .mockImplementation(() => Promise.resolve(mockBalances));
+    jest
+      .spyOn(ApiInternal, "getTokenPrices")
+      .mockImplementation(() => Promise.resolve(mockPrices));
+
+    render(
+      <Wrapper
+        routes={[ROUTES.account]}
+        state={{
+          auth: {
+            error: null,
+            applicationState: ApplicationState.MNEMONIC_PHRASE_CONFIRMED,
+            publicKey: "G1",
+            allAccounts: mockAccounts,
+          },
+          settings: {
+            networkDetails: MAINNET_NETWORK_DETAILS,
+            networksList: DEFAULT_NETWORKS,
+          },
+        }}
+      >
+        <Account />
+      </Wrapper>,
+    );
+
+    // mockBalances: DT (Soroban-style canonical, total 1e9, price ~0.000834
+    // → ~$834,463), USDC (total 100, no price entry), native XLM (total 50,
+    // price ~0.276 → ~$13.81). Expected order: DT, XLM, USDC (unpriced last).
+    await waitFor(() => {
+      const assetNodes = screen.getAllByTestId("account-assets-item");
+      expect(assetNodes.length).toEqual(3);
+      expect(assetNodes[0]).toHaveTextContent("DT");
+      expect(assetNodes[1]).toHaveTextContent("XLM");
+      expect(assetNodes[2]).toHaveTextContent("USDC");
+    });
+  });
+
+  it("preserves the default balance order when token prices fail to load", async () => {
+    jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>
+      Promise.resolve({
+        networkDetails: MAINNET_NETWORK_DETAILS,
+        networksList: DEFAULT_NETWORKS,
+        hiddenAssets: {},
+        allowList: ApiInternal.DEFAULT_ALLOW_LIST,
+        error: "",
+        isDataSharingAllowed: false,
+        isMemoValidationEnabled: false,
+        isHideDustEnabled: true,
+        isOpenSidebarByDefault: false,
+        settingsState: SettingsState.SUCCESS,
+        isSorobanPublicEnabled: false,
+        isRpcHealthy: true,
+        userNotification: {
+          enabled: false,
+          message: "",
+        },
+        isExperimentalModeEnabled: false,
+        isHashSigningEnabled: false,
+        isNonSSLEnabled: false,
+        experimentalFeaturesState: SettingsState.SUCCESS,
+        assetsLists: DEFAULT_ASSETS_LISTS,
+      }),
+    );
+    jest
+      .spyOn(ApiInternal, "getAccountBalances")
+      .mockImplementation(() => Promise.resolve(mockBalances));
+    jest.spyOn(ApiInternal, "getTokenPrices").mockImplementation(() => {
+      throw new Error("Failed to fetch prices");
+    });
+
+    render(
+      <Wrapper
+        routes={[ROUTES.account]}
+        state={{
+          auth: {
+            error: null,
+            applicationState: ApplicationState.MNEMONIC_PHRASE_CONFIRMED,
+            publicKey: "G1",
+            allAccounts: mockAccounts,
+          },
+          settings: {
+            networkDetails: MAINNET_NETWORK_DETAILS,
+            networksList: DEFAULT_NETWORKS,
+          },
+        }}
+      >
+        <Account />
+      </Wrapper>,
+    );
+
+    // With no prices, sortBalancesByValue is a no-op; the existing
+    // sortBalances output is XLM (native unshifted to top), then DT, USDC.
+    await waitFor(() => {
+      const assetNodes = screen.getAllByTestId("account-assets-item");
+      expect(assetNodes.length).toEqual(3);
+      expect(assetNodes[0]).toHaveTextContent("XLM");
+      expect(assetNodes[1]).toHaveTextContent("DT");
+      expect(assetNodes[2]).toHaveTextContent("USDC");
+    });
+  });
+
   it("polls for account balances", async () => {
     jest.useFakeTimers();
     jest.spyOn(ApiInternal, "loadSettings").mockImplementation(() =>

--- a/extension/src/popup/views/__tests__/Account.test.tsx
+++ b/extension/src/popup/views/__tests__/Account.test.tsx
@@ -1019,9 +1019,9 @@ describe("Account view", () => {
       .spyOn(ApiInternal, "getAccountBalances")
       .mockImplementation(() => Promise.resolve(mockBalances));
 
-    jest.spyOn(ApiInternal, "getTokenPrices").mockImplementation(() => {
-      throw new Error("Failed to fetch prices");
-    });
+    jest
+      .spyOn(ApiInternal, "getTokenPrices")
+      .mockRejectedValueOnce(new Error("Failed to fetch prices"));
 
     render(
       <Wrapper
@@ -1090,9 +1090,25 @@ describe("Account view", () => {
     jest
       .spyOn(ApiInternal, "getAccountBalances")
       .mockImplementation(() => Promise.resolve(mockBalances));
+    // The production indexer (`getTokenPrices` in `@shared/api/internal.ts`)
+    // filters out contract-ID issuers via `isContractId(asset.issuer)`, so
+    // `DT` (which has a `C…` issuer in `mockBalances`) cannot be priced in
+    // real usage. Price the classic G-issuer assets instead — `USDC`
+    // (large value) and native `XLM` — so the ordering scenario under test
+    // matches what users actually see.
+    const realisticPrices = {
+      ["USDC:GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM"]: {
+        currentPrice: "1.00",
+        percentagePriceChange24h: "0",
+      },
+      native: {
+        currentPrice: "0.27633884304166495",
+        percentagePriceChange24h: "1.09899728516430811",
+      },
+    };
     jest
       .spyOn(ApiInternal, "getTokenPrices")
-      .mockImplementation(() => Promise.resolve(mockPrices));
+      .mockImplementation(() => Promise.resolve(realisticPrices));
 
     render(
       <Wrapper
@@ -1114,15 +1130,16 @@ describe("Account view", () => {
       </Wrapper>,
     );
 
-    // mockBalances: DT (Soroban-style canonical, total 1e9, price ~0.000834
-    // → ~$834,463), USDC (total 100, no price entry), native XLM (total 50,
-    // price ~0.276 → ~$13.81). Expected order: DT, XLM, USDC (unpriced last).
+    // mockBalances + realisticPrices: USDC (100 * $1 = $100), XLM
+    // (50 * ~$0.276 = ~$13.81), DT (unpriced — contract-ID issuer is
+    // filtered out by the production pricing API). Expected order:
+    // USDC, XLM, DT (unpriced last).
     await waitFor(() => {
       const assetNodes = screen.getAllByTestId("account-assets-item");
       expect(assetNodes.length).toEqual(3);
-      expect(assetNodes[0]).toHaveTextContent("DT");
+      expect(assetNodes[0]).toHaveTextContent("USDC");
       expect(assetNodes[1]).toHaveTextContent("XLM");
-      expect(assetNodes[2]).toHaveTextContent("USDC");
+      expect(assetNodes[2]).toHaveTextContent("DT");
     });
   });
 
@@ -1155,9 +1172,9 @@ describe("Account view", () => {
     jest
       .spyOn(ApiInternal, "getAccountBalances")
       .mockImplementation(() => Promise.resolve(mockBalances));
-    jest.spyOn(ApiInternal, "getTokenPrices").mockImplementation(() => {
-      throw new Error("Failed to fetch prices");
-    });
+    jest
+      .spyOn(ApiInternal, "getTokenPrices")
+      .mockRejectedValueOnce(new Error("Failed to fetch prices"));
 
     render(
       <Wrapper

--- a/extension/src/popup/views/__tests__/Account.test.tsx
+++ b/extension/src/popup/views/__tests__/Account.test.tsx
@@ -1273,6 +1273,48 @@ describe("Account view", () => {
     expect(getAccountBalancesSpy).toHaveBeenCalledTimes(3);
   });
 
+  it("renders the error notification without crashing when account data is in ERROR state", async () => {
+    const accountDataSpy = jest
+      .spyOn(AccountDataHooks, "useGetAccountData")
+      .mockReturnValue({
+        state: {
+          state: RequestState.ERROR,
+          data: null,
+          error: new Error("boom"),
+        },
+        fetchData: jest.fn(),
+        refreshAppData: jest.fn(),
+      });
+
+    render(
+      <Wrapper
+        routes={[ROUTES.account]}
+        state={{
+          auth: {
+            error: null,
+            applicationState: ApplicationState.MNEMONIC_PHRASE_CONFIRMED,
+            publicKey: TEST_PUBLIC_KEY,
+            allAccounts: mockAccounts,
+          },
+          settings: {
+            networkDetails: MAINNET_NETWORK_DETAILS,
+            networksList: DEFAULT_NETWORKS,
+          },
+        }}
+      >
+        <Account />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to fetch your account balances."),
+      ).toBeInTheDocument();
+    });
+
+    accountDataSpy.mockRestore();
+  });
+
   it("handles abandoned onboarding in password created step", async () => {
     jest.spyOn(ApiInternal, "loadAccount").mockImplementation(() =>
       Promise.resolve({


### PR DESCRIPTION
## Proposal: Order account balances by USD value (descending)

### Problem

The Account view's balance list is currently sorted by `sortBalances`
(`extension/src/popup/helpers/account.ts:36`) — XLM first, classic /
Soroban tokens in iteration order, LP shares last — which is unrelated to
USD value. Issue #2227 asks for balances ordered by USD value so the
most relevant assets surface first.

### Constraints (verified against the codebase)

- The indexer pricing endpoint filters out `:lp` IDs and contract-ID
  issuers (`@shared/api/internal.ts:597-602`). Only **native + classic
  G-issuer assets** are ever priced today.
- `getCanonicalFromAsset(code, issuer?)` returns `"native"` for XLM,
  `"code:issuer"` when an issuer is given, and bare otherwise `code` 
  matching the keys returned by the indexer.
- Mainnet awaits `fetchTokenPrices` before its first
  `FETCH_DATA_SUCCESS` dispatch
  (`extension/src/popup/views/Account/hooks/useGetAccountData.tsx:118-132`).
  No flicker, no two-stage sort.
- Non-mainnet leaves `tokenPrices` as `undefined`. Mainnet failure leaves
  it as `null`.
- `Account/index.tsx` is the only renderer of `<AccountAssets>`. The list
  order only flows through `balances={...}`; everything else
  (`getTotalUsd`, `isFunded`, header/footer, `error.horizon` notices) is
  order-insensitive.
- `LiquidityPoolShareAsset` is the only `AssetType` variant without a
  `token` field, so `"token" in b` cleanly discriminates LP shares.
- `sortBalances` is shared with picker flows via `useGetBalances` →
  `useGetAssetDomainsWithBalances`. **Do not modify `sortBalances`.**
- `AccountAssets` props: `balances: AccountBalances` (non-nullable) and
  `assetPrices?: ApiTokenPrices` (optional, not `null`). Wiring must
  match those exact types.

### Proposed change

#### Helper

`extension/src/popup/helpers/balance.ts`:

```ts
import { ApiTokenPrices } from "@shared/api/types";
// existing imports already include AssetType, BigNumber, getCanonicalFromAsset

/**
 * Re-orders balances for display by descending USD value.
 *
 * Only native + classic G-issuer assets receive prices from the indexer
 * (Soroban, custom tokens, and LP shares are filtered out upstream — see
 * `getTokenPrices` in `@shared/api/internal.ts`). Unpriced balances keep
 * the relative order produced by `sortBalances` and sort below all
 * priced balances. A zero price is a valid USD value; a malformed price
 * is treated as unpriced.
 */
export const sortBalancesByValue = (
  balances: AssetType[],
  prices: ApiTokenPrices | null | undefined,
): AssetType[] => {
  if (!prices || Object.keys(prices).length === 0) {
    return balances;
  }

  const usdValueOf = (b: AssetType): BigNumber | null => {
    if (!("token" in b)) return null; // LP share
    const canonical = getCanonicalFromAsset(
      b.token.code,
      "issuer" in b.token ? b.token.issuer.key : undefined,
    );
    const priceStr = prices[canonical]?.currentPrice;
    if (priceStr === undefined || priceStr === null || priceStr === "") {
      return null;
    }
    const value = new BigNumber(priceStr).multipliedBy(b.total);
    return value.isFinite() ? value : null;
  };

  return balances
    .map((b, i) => ({ b, i, v: usdValueOf(b) }))
    .sort((a, z) => {
      if (a.v && z.v) return z.v.comparedTo(a.v) || a.i - z.i;
      if (a.v) return -1;
      if (z.v) return 1;
      return a.i - z.i;
    })
    .map((x) => x.b);
};
```

#### Wiring

`extension/src/popup/views/Account/index.tsx` keeps its existing top-of-
component variables and only changes the `balances` prop on the
`<AccountAssets>` render. This preserves the surrounding TS narrowing
(`resolvedData?.balances?.isFunded && !hasError && (…)`) and the existing
non-null assertion pattern, and uses the optional-prop types of
`AccountAssets` (`assetPrices?: ApiTokenPrices`) without churn:

```ts
// existing:
const tokenPrices = resolvedData?.tokenPrices || {};
const balances = resolvedData?.balances.balances!;
const totalBalanceUsd = getTotalUsd(tokenPrices, balances);

// new (computed once, used in JSX below):
const sortedBalances = sortBalancesByValue(balances, resolvedData?.tokenPrices);
```

In the JSX (inside the already-narrowed
`resolvedData?.balances?.isFunded && !hasError && (…)` branch), pass a
new object that reuses the rest of `AccountBalances`:

```tsx
<AccountAssets
  balances={{ ...resolvedData.balances, balances: sortedBalances }}
  historyData={historyData.data}
  assetPrices={tokenPrices}
  assetIcons={resolvedIcons}
/>
```

Notes:
- `sortBalancesByValue` accepts `ApiTokenPrices | null | undefined`, so
  passing `resolvedData?.tokenPrices` directly (no coalescing) keeps the
  helper input semantically faithful and the `null` early-return path
  exercised.
- Inside the narrowed JSX branch, `resolvedData.balances` is non-null
  (TS already narrows here today — see existing `balances={resolvedData.balances}`
  call on the same line). So `{ ...resolvedData.balances, balances:
  sortedBalances }` types as `AccountBalances`.
- `tokenPrices = resolvedData?.tokenPrices || {}` is unchanged (it feeds
  `getTotalUsd` and the `assetPrices` prop, both of which want
  `ApiTokenPrices`).
- No `useMemo`. The sort is O(n log n) on ≤ tens of assets. `balances`
  is local `useReducer` state in `useGetAccountData`, so its identity is
  stable between fetch dispatches; recomputing on every render is cheap.

### Behavior

| Scenario | Result |
|---|---|
| Mainnet, prices fetched | Priced first (descending by USD), unpriced after in `sortBalances` order, LP last |
| Mainnet, fetch failed (`tokenPrices === null`) | Unchanged (`sortBalances` order) |
| Non-mainnet (`tokenPrices === undefined`) | Unchanged |
| Empty `prices` object | Unchanged (early return) |
| Asset with `currentPrice === "0"` | In priced group (USD value 0) |
| Asset with malformed `currentPrice` | Treated as unpriced |

### Out of scope

- Send/Swap/Manage-Assets pickers continue to call `sortBalances`.
- Wallets list (per-wallet totals) — unaffected.
- Pricing Soroban / custom tokens (separate workstream). When that
  lands, this helper picks them up automatically.

### Tests

1. **Helper unit tests** in
   `extension/src/popup/helpers/__tests__/balance.test.js`:
   - `prices` is `null`, `undefined`, or `{}` → input returned unchanged.
   - All assets priced → strictly descending by `price * total`.
   - Mixed priced / unpriced → priced first, unpriced after preserving
     original order.
   - LP share present → stays last.
   - `currentPrice === "0"` → asset stays in the priced group.
   - Malformed `currentPrice` (e.g. `"NaN"`, `"abc"`) → treated as
     unpriced; helper does not throw.
   - Identical USD values → original order preserved (stability).
2. **Account view integration tests** in
   `extension/src/popup/views/__tests__/Account.test.tsx`, using the
   existing `jest.spyOn(ApiInternal, "getAccountBalances"/"getTokenPrices")`
   pattern (mainnet scaffolding ~lines 920–1061):
   - **Priced reorder:** mock balances containing XLM (small total) +
     a classic asset (large total) + an LP share, with prices that put
     the classic asset's USD value above XLM's. Assert the rendered row
     order is classic asset → XLM → LP last.
   - **Price fetch failure → unchanged order:** mock `getTokenPrices`
     to throw; assert the rendered order matches today's `sortBalances`
     output (XLM first, LP last). Update or replace the existing
     LP-last assertion at `Account.test.tsx:913-916` if it conflicts;
     otherwise add this as a new case.

### Risk / regressions

- The only on-screen effect is row order in the Account view's balances
  list. No data, totals, navigation, or downstream picker flows change.
- All pricing-failure modes fall back to `sortBalances` behavior, so a
  pricing-API regression cannot break the balances list.
- TS strict null checks are honored: `sortedBalances` types as
  `AssetType[]`, the spread into `AccountBalances` happens in a branch
  where `resolvedData.balances` is already narrowed.



---

Closes #2227
