### PR TITLE
Fix GrantAccess tests broken on master

### DIFF
--- a/extension/src/popup/views/__tests__/GrantAccess.test.tsx
+++ b/extension/src/popup/views/__tests__/GrantAccess.test.tsx
@@ -162,6 +162,7 @@ describe("Grant Access view", () => {
     jest.spyOn(global, "fetch").mockImplementation(() =>
       Promise.resolve({
         ok: true,
+        headers: { get: () => "application/json" },
         json: async () => ({ data: { status: "miss" }, error: null }),
       } as any),
     );
@@ -198,6 +199,7 @@ describe("Grant Access view", () => {
     jest.spyOn(global, "fetch").mockImplementation(() =>
       Promise.resolve({
         ok: true,
+        headers: { get: () => "application/json" },
         json: async () => ({
           data: { status: "hit", is_malicious: true },
           error: null,
@@ -234,18 +236,11 @@ describe("Grant Access view", () => {
   });
 
   it("shows unable to scan label when scan site returns an error on Mainnet", async () => {
-    jest.spyOn(blockAidHelpers, "useScanSite").mockImplementation(() => {
-      return {
-        error: null,
-        isLoading: false,
-        data: {
-          is_malicious: true,
-        } as BlockAidScanSiteResult,
-        scanSite: (_url: string) => {
-          throw new Error("Failed to scan site");
-        },
-      };
-    });
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementation(() =>
+        Promise.reject(new Error("Failed to scan site")),
+      );
 
     render(
       <Wrapper
@@ -282,12 +277,10 @@ describe("Grant Access view", () => {
     // regresses and a `/scan-dapp` (or any other) call leaks through, the
     // test doesn't attempt a real network request and become flaky in CI.
     // The assertion below still verifies no `/scan-dapp` call was made.
-    const fetchSpy = jest
-      .spyOn(global, "fetch")
-      .mockResolvedValue({
-        ok: true,
-        json: async () => ({}),
-      } as Response);
+    const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
     render(
       <Wrapper
         routes={[ROUTES.welcome]}


### PR DESCRIPTION
## Summary

Three Jest specs in `extension/src/popup/views/__tests__/GrantAccess.test.tsx` were failing on master. After this PR, the suite is green again.

- "shows a miss label when scan site returns a miss status"
- "shows a malicious label when scan site returns a malicious flag"
- "shows unable to scan label when scan site returns an error on Mainnet"

### Why they broke

The first two regressed in #2748 when `useScanSite` migrated from a raw `fetch` call to the new `fetchJson` helper. `fetchJson` reads `res.headers.get("content-type")` to gate JSON parsing; the existing test mocks didn't include a `headers` field, so the call threw, `useScanSite` caught and returned `null`, and the rendered label fell through to "unable-to-scan" instead of "miss" / "malicious".

The third was pre-existing. The mock replaced `useScanSite` with a `scanSite` that threw **synchronously**. `useAsyncSiteScan` chains `.then(...).catch(...)` on the call result, so a synchronous throw bypasses `.catch` entirely — `scanData` stayed `undefined`, which `getSiteSecurityStates` treats as an in-flight scan and suppresses the warning UI.

### Fix

- Add `headers: { get: () => "application/json" }` to the two `fetch` mocks so `fetchJson` parses the body.
- Replace the third test's `useScanSite` spy with a `global.fetch` rejection — same exercise of the unable-to-scan path, but routed through the real `useScanSite` catch handler instead of an unreachable code path.

## Test plan

- [x] `yarn test:ci --testPathPattern="GrantAccess.test"` — all 12 specs pass (1 skipped, unrelated)
- [x] `yarn test:ci` — full suite green (870 passed, 72 skipped, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)