### PR TITLE
Fix GrantAccess tests broken on master

### DIFF
--- a/extension/src/popup/views/__tests__/GrantAccess.test.tsx
+++ b/extension/src/popup/views/__tests__/GrantAccess.test.tsx
@@ -162,6 +162,7 @@ describe("Grant Access view", () => {
     jest.spyOn(global, "fetch").mockImplementation(() =>
       Promise.resolve({
         ok: true,
+        headers: { get: () => "application/json" },
         json: async () => ({ data: { status: "miss" }, error: null }),
       } as any),
     );
@@ -198,6 +199,7 @@ describe("Grant Access view", () => {
     jest.spyOn(global, "fetch").mockImplementation(() =>
       Promise.resolve({
         ok: true,
+        headers: { get: () => "application/json" },
         json: async () => ({
           data: { status: "hit", is_malicious: true },
           error: null,
@@ -234,18 +236,11 @@ describe("Grant Access view", () => {
   });
 
   it("shows unable to scan label when scan site returns an error on Mainnet", async () => {
-    jest.spyOn(blockAidHelpers, "useScanSite").mockImplementation(() => {
-      return {
-        error: null,
-        isLoading: false,
-        data: {
-          is_malicious: true,
-        } as BlockAidScanSiteResult,
-        scanSite: (_url: string) => {
-          throw new Error("Failed to scan site");
-        },
-      };
-    });
+    jest
+      .spyOn(global, "fetch")
+      .mockImplementation(() =>
+        Promise.reject(new Error("Failed to scan site")),
+      );
 
     render(
       <Wrapper
@@ -282,12 +277,10 @@ describe("Grant Access view", () => {
     // regresses and a `/scan-dapp` (or any other) call leaks through, the
     // test doesn't attempt a real network request and become flaky in CI.
     // The assertion below still verifies no `/scan-dapp` call was made.
-    const fetchSpy = jest
-      .spyOn(global, "fetch")
-      .mockResolvedValue({
-        ok: true,
-        json: async () => ({}),
-      } as Response);
+    const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
     render(
       <Wrapper
         routes={[ROUTES.welcome]}

--- a/extension/src/popup/views/__tests__/GrantAccess.test.tsx
+++ b/extension/src/popup/views/__tests__/GrantAccess.test.tsx
@@ -279,6 +279,8 @@ describe("Grant Access view", () => {
     // The assertion below still verifies no `/scan-dapp` call was made.
     const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
       ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "application/json" }),
       json: async () => ({}),
     } as Response);
     render(


### PR DESCRIPTION
## Summary

Two Jest specs in `extension/src/popup/views/__tests__/GrantAccess.test.tsx` regressed in CI when #2748 landed:

- "shows a miss label when scan site returns a miss status"
- "shows a malicious label when scan site returns a malicious flag"

Confirmed against the CI history:
- Last green run before #2748 (sha `8a2d7a9e`): `Tests: 0 failed`.
- CI on #2748 itself: `Tests: 2 failed` — both the miss and malicious specs (the rendered DOM in the failed assertions shows `GrantAccess__ButtonsContainerMalicious`, i.e. the warning UI rendered but with the wrong label).

### Why they broke

#2748 migrated `useScanSite` from raw `fetch` to `fetchJson`. `fetchJson` reads `res.headers.get("content-type")` to gate JSON parsing, but the existing test mocks didn't include a `headers` field. So the call threw, `useScanSite` caught and returned `null`, and the rendered label fell through to "unable-to-scan" instead of "miss" / "malicious".

### Fix

- Add `headers: { get: () => "application/json" }` to the two `fetch` mocks so `fetchJson` parses the body.

### Drive-by

A third spec, "shows unable to scan label when scan site returns an error on Mainnet", was passing in CI but failing on my local machine — its `useScanSite` spy mocked `scanSite` to throw synchronously, and a sync throw bypasses the `.then(...).catch(...)` chain in `useAsyncSiteScan`. CI tolerates it; my darwin setup does not. Switched the mock to a `global.fetch` rejection so the unable-to-scan path is exercised through the real `useScanSite` catch handler — works in both environments.

## Test plan

- [x] `yarn test:ci --testPathPattern="GrantAccess.test"` — all 12 specs pass (1 skipped, unrelated)
- [x] `yarn test:ci` — full suite green (870 passed, 72 skipped, 0 failed)
- [x] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)