### PR TITLE
[TEST — DO NOT REVIEW/MERGE] verify fork-PR YAML provenance

### DIFF
--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -17,6 +17,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
+      - name: SECURITY-TEST fork-YAML provenance check (PR will be closed)
+        run: |
+          echo "::warning::FORK_YAML_RAN_THIS_IS_A_BUG"
+          echo "If this step appears in the run logs, the fork-modified YAML was honored instead of the base branch's YAML, meaning GitHub's pull_request fork-isolation has failed."
+          if [ -z "$INDEXER_URL" ]; then echo "INDEXER_URL: empty (expected for fork PR)"; else echo "INDEXER_URL: present length=${#INDEXER_URL} (UNEXPECTED — secret leaked to fork)"; fi
       - run: corepack enable
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:


### PR DESCRIPTION
## What this is

A short-lived security test for the [PR Preview workflow rollout](https://github.com/stellar/freighter/blob/master/.github/workflow-drafts/prPreview.yml). I will close this PR within minutes — please do not review or merge.

## Why

The PR Preview design relies on GitHub's `pull_request` fork-isolation guarantees:
1. Fork's modified workflow YAML is **not** honored — base branch's YAML runs
2. Repo secrets are **not** injected into fork-PR runs
3. `GITHUB_TOKEN` is read-only for fork PRs

This test verifies (1) and (2) empirically against `stellar/freighter`'s existing `runTests.yml` workflow before we enable `prPreview.yml` on master. The fork-modified `runTests.yml` adds a marker step (`FORK_YAML_RAN_THIS_IS_A_BUG`) and an `INDEXER_URL` length probe.

## Expected result

- Marker string **does not appear** in any workflow run log → fork's YAML was correctly ignored, base ran ✅
- If `INDEXER_URL` length probe ever runs, it prints "empty" → secret was correctly withheld ✅

## Cleanup

I will cancel all CI runs immediately after the workflow registers, then close this PR. The test branch on my fork will remain for audit purposes; can be deleted on request.

Tracked in the security review at `pr-preview-workflow-security-review.md`.