### PR TITLE
Clean up Account.test fixtures to remove impossible production states

### DIFF
--- a/@shared/api/__tests__/internal.test.ts
+++ b/@shared/api/__tests__/internal.test.ts
@@ -135,4 +135,42 @@ describe("internalApi", () => {
       );
     });
   });
+
+  describe("getTokenPrices request payload filtering", () => {
+    const mockFetchOk = () =>
+      jest.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ data: {} }),
+      } as unknown as Response);
+
+    it("excludes contract-ID issuers from the indexer request", async () => {
+      const fetchSpy = mockFetchOk();
+
+      await internalApi.getTokenPrices([
+        "native",
+        "USDC:GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM",
+        "DT:CCXVDIGMR6WTXZQX2OEVD6YM6AYCYPXPQ7YYH6OZMRS7U6VD3AVHNGBJ",
+      ]);
+
+      const requestInit = fetchSpy.mock.calls[0][1] as RequestInit;
+      const body = JSON.parse(requestInit.body as string);
+      expect(body.tokens).toEqual([
+        "native",
+        "USDC:GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM",
+      ]);
+    });
+
+    it("excludes liquidity-pool IDs from the indexer request", async () => {
+      const fetchSpy = mockFetchOk();
+
+      await internalApi.getTokenPrices([
+        "native",
+        "abc123:lp",
+      ]);
+
+      const requestInit = fetchSpy.mock.calls[0][1] as RequestInit;
+      const body = JSON.parse(requestInit.body as string);
+      expect(body.tokens).toEqual(["native"]);
+    });
+  });
 });

--- a/extension/src/popup/__testHelpers__/index.tsx
+++ b/extension/src/popup/__testHelpers__/index.tsx
@@ -25,6 +25,14 @@ export const TEST_PUBLIC_KEY =
 export const TEST_CANONICAL =
   "DT:CCXVDIGMR6WTXZQX2OEVD6YM6AYCYPXPQ7YYH6OZMRS7U6VD3AVHNGBJ";
 
+// Classic G-issuer canonical present in `mockBalances`. Use this when a test
+// needs an asset that production `getTokenPrices` would actually price —
+// `TEST_CANONICAL` (DT) has a contract-ID issuer and is filtered out by
+// `isContractId` in `@shared/api/internal.ts`, so it can never carry a real
+// indexer price.
+export const TEST_USDC_CANONICAL =
+  "USDC:GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM";
+
 const rootReducer = combineReducers({
   auth,
   settings,
@@ -74,9 +82,12 @@ export const Wrapper: React.FunctionComponent<any> = ({
 };
 
 export const mockPrices = {
-  [TEST_CANONICAL]: {
-    currentPrice: "0.0008344636737229707",
-    percentagePriceChange24h: "3.975563218688548378",
+  // `TEST_CANONICAL` (DT) has a contract-ID issuer and is filtered out by
+  // production `getTokenPrices` (`@shared/api/internal.ts` →
+  // `isContractId(asset.issuer)`), so it is intentionally absent here.
+  [TEST_USDC_CANONICAL]: {
+    currentPrice: "1",
+    percentagePriceChange24h: "0.50",
   },
   native: {
     currentPrice: "0.27633884304166495",

--- a/extension/src/popup/views/Wallets/hooks/__tests__/useGetWalletsData.test.tsx
+++ b/extension/src/popup/views/Wallets/hooks/__tests__/useGetWalletsData.test.tsx
@@ -31,7 +31,7 @@ jest.mock("@shared/api/internal", () => ({
       currentPrice: "1",
       percentagePriceChange24h: ".5",
     },
-    "DT:CCXVDIGMR6WTXZQX2OEVD6YM6AYCYPXPQ7YYH6OZMRS7U6VD3AVHNGBJ": {
+    "USDC:GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM": {
       currentPrice: "2",
       percentagePriceChange24h: ".25",
     },
@@ -152,7 +152,7 @@ describe("useGetWalletsData", () => {
     expect(result.current.state.state).toBe<RequestState>(RequestState.SUCCESS);
     expect(result.current.state.data).toEqual({
       accountValue: {
-        G1: "$50.00",
+        G1: "$250.00",
       },
       publicKey: "G1",
       allAccounts: [{ publicKey: "G1" }],
@@ -225,13 +225,13 @@ describe("useGetWalletsData", () => {
     ]);
     expect(result.current.state.data).toEqual({
       accountValue: {
-        G1: "$50.00",
-        G2: "$50.00",
-        G3: "$50.00",
-        G4: "$50.00",
-        G5: "$50.00",
-        G6: "$50.00",
-        G7: "$50.00",
+        G1: "$250.00",
+        G2: "$250.00",
+        G3: "$250.00",
+        G4: "$250.00",
+        G5: "$250.00",
+        G6: "$250.00",
+        G7: "$250.00",
       },
       publicKey: "G1",
       allAccounts: [

--- a/extension/src/popup/views/__tests__/Account.test.tsx
+++ b/extension/src/popup/views/__tests__/Account.test.tsx
@@ -36,6 +36,7 @@ import {
   mockPrices,
   TEST_CANONICAL,
   TEST_PUBLIC_KEY,
+  TEST_USDC_CANONICAL,
 } from "../../__testHelpers__";
 import { Account } from "../Account";
 import { ROUTES } from "popup/constants/routes";
@@ -974,18 +975,30 @@ describe("Account view", () => {
     await waitFor(async () => {
       const assetNodes = screen.getAllByTestId("account-assets-item");
       expect(assetNodes.length).toEqual(3);
+      // Classic G-issuer asset (USDC) carries the priced-row assertion;
+      // production `getTokenPrices` only returns prices for these.
       expect(
-        screen.getByTestId(`asset-amount-${TEST_CANONICAL}`),
-      ).toHaveTextContent("$834,463.67");
+        screen.getByTestId(`asset-amount-${TEST_USDC_CANONICAL}`),
+      ).toHaveTextContent("$100.00");
       expect(
-        screen.getByTestId(`asset-price-delta-${TEST_CANONICAL}`),
-      ).toHaveTextContent("3.97%");
+        screen.getByTestId(`asset-price-delta-${TEST_USDC_CANONICAL}`),
+      ).toHaveTextContent("0.50%");
       expect(screen.getByTestId(`asset-amount-native`)).toHaveTextContent(
         "$13.81",
       );
       expect(screen.getByTestId(`asset-price-delta-native`)).toHaveTextContent(
         "1.09%",
       );
+      // Contract-ID issuers are filtered out by production `getTokenPrices`
+      // (`@shared/api/internal.ts` → `isContractId`), so DT can never carry
+      // an indexer price. The row still renders, but with no USD amount
+      // node and a "--" delta.
+      expect(
+        screen.queryByTestId(`asset-amount-${TEST_CANONICAL}`),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId(`asset-price-delta-${TEST_CANONICAL}`),
+      ).toHaveTextContent("--");
     });
   });
 
@@ -1046,12 +1059,23 @@ describe("Account view", () => {
     await waitFor(async () => {
       const assetNodes = screen.getAllByTestId("account-assets-item");
       expect(assetNodes.length).toEqual(3);
+      // When prices are unavailable, no row renders a USD `asset-amount-*`
+      // node and every row's delta reads "--".
       expect(
         screen.queryByTestId(`asset-amount-${TEST_CANONICAL}`),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId(`asset-amount-${TEST_USDC_CANONICAL}`),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("asset-amount-native"),
       ).not.toBeInTheDocument();
       expect(screen.getByTestId("asset-price-delta-native")).toHaveTextContent(
         "--",
       );
+      expect(
+        screen.getByTestId(`asset-price-delta-${TEST_USDC_CANONICAL}`),
+      ).toHaveTextContent("--");
       expect(
         screen.getByTestId(`asset-price-delta-${TEST_CANONICAL}`),
       ).toHaveTextContent("--");
@@ -1238,9 +1262,9 @@ describe("Account view", () => {
       .spyOn(ApiInternal, "getAccountBalances")
       .mockImplementation(() => Promise.resolve(mockBalances));
 
-    jest.spyOn(ApiInternal, "getTokenPrices").mockImplementation(() => {
-      throw new Error("Failed to fetch prices");
-    });
+    jest
+      .spyOn(ApiInternal, "getTokenPrices")
+      .mockRejectedValueOnce(new Error("Failed to fetch prices"));
 
     render(
       <Wrapper


### PR DESCRIPTION
## Proposal (R3): Clean up `Account.test.tsx` test fixtures (contract-id-issuer prices and sync `throw`)

### Problem

Two test-fixture inconsistencies remain after PR #2749 (follow-up to
#2227 internal review):

1. **Bogus contract-id-issuer price.** `extension/src/popup/__testHelpers__/index.tsx:25-27,76-100`
   defines `TEST_CANONICAL = "DT:CCXVDIGM…"` (contract-ID issuer)
   and `mockPrices` assigns it a USD price. Production `getTokenPrices`
   (`@shared/api/internal.ts:597-602`) filters contract-ID issuers
   via `isContractId` before calling the indexer, so this canonical
   can never be returned. The Account test "displays prices, deltas,
   and account balance" then asserts DT renders `$834,463.67` /
   `3.97%`, exercising an impossible state.

   Same anti-pattern at
   `extension/src/popup/views/Wallets/hooks/__tests__/useGetWalletsData.test.tsx:29-38`
   (inline `jest.mock` returns a price for the same DT canonical).
   The pre-filter call payload (lines 221-225) is correct as-is —
   `useGetTokenPrices.tsx:55-64` does not pre-filter; only production
   `getTokenPrices` does.

2. **Synchronous `throw` mock for an awaited rejection.** At
   `Account.test.tsx:1242` (the `polls for account balances` test),
   `getTokenPrices` is mocked with
   `mockImplementation(() => { throw new Error("Failed to fetch prices") })`.
   `getTokenPrices` is `async` and awaited; production rejects via a
   returned `Promise.reject`. PR #2749 already converted the other
   two instances (lines 1024, 1177) to `mockRejectedValueOnce`; this
   one was missed.

### Constraints (verified against `origin/master` @ `f5cd8c5`)

- `getTokenPrices` filters contract-ID issuers and `:lp` IDs
  (`@shared/api/internal.ts:596-602`).
- `useGetTokenPrices.tsx:55-64` passes the unfiltered list to
  `getTokenPrices`.
- `AccountAssets/index.tsx:283-369`: when `assetPrice` is missing,
  no `asset-amount-${canonical}` node is rendered; only
  `asset-price-delta-${canonical}` with text `--`.
- `getBalanceByAsset` (`extension/src/popup/helpers/balance.ts:63-91`)
  matches contract-ID issuers via `balance.contractId === issuer`,
  **not** via `balance.token.issuer.key`. The `mockBalances` DT entry
  (`__testHelpers__/index.tsx:87-100`) has no `contractId` field, so
  `getTotalUsd` already silently drops DT today: only `native` × 50
  contributes to `accountValue` `$50.00` in the existing
  `useGetWalletsData` test. After dropping DT and adding USDC (G-issuer,
  matched via `token.issuer.key`) at price `"2"`, USDC contributes
  100 × 2 = $200 in addition to native 50 × 1 = $50, so the totals
  in that test become `$250.00`.
- `mockPrices` is consumed only by `Account.test.tsx`. Other
  `TEST_CANONICAL` consumers use it for balance/icon/domain keys,
  not price assertions.
- The priced-display test asserts `assetNodes.length === 3` and uses
  `getByTestId(asset-amount-${canonical})`-style lookups — not order-
  dependent. `mockBalances` contains 3 balances (native, DT, USDC),
  each rendered as one `account-assets-item`, so the count holds.
- `formatAmount` + `roundUsdValue` (`extension/src/popup/helpers/formatters.ts:87-113`)
  produce: `$100.00` for 100 × 1, `0.50%` for `"0.50"`, `$13.81` for
  50 × `"0.27633884304166495"`. (Confirmed by mirroring the existing
  PR #2749 test assertions for native.)
- The polling test does not depend on later poll cycles seeing
  successful prices: `_isMainnet` in `useGetAccountData.tsx:118-129`
  is only set on a successful initial `fetchTokenPrices()`, and the
  token-price interval is gated on `_isMainnet`
  (`useGetAccountData.tsx:205-229`); balance polling continues
  independently (`:231-260`). So `mockRejectedValueOnce` is correct
  for the existing balance-poll assertion (`getAccountBalancesSpy`
  called 3× after 30 s of fake-timer advance), and the proposal does
  not need to claim later price polls succeed.
- The existing internal-API test file lives at
  `@shared/api/__tests__/internal.test.ts` and uses
  `jest.spyOn(global, "fetch")` (`:94`) to mock `fetch`. That is the
  established pattern.

### Proposed change

#### 1. Fix the priced-fixture lie in shared helpers

`extension/src/popup/__testHelpers__/index.tsx`:

- Drop the `TEST_CANONICAL` (DT/contract-ID) entry from `mockPrices`.
  DT remains in `mockBalances`/`mockTestnetBalances` — it just stops
  pretending to have an indexer price, matching production.
- Export a stable USDC canonical for use in price assertions:
  ```ts
  export const TEST_USDC_CANONICAL =
    "USDC:GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM";

  export const mockPrices = {
    native: {
      currentPrice: "0.27633884304166495",
      percentagePriceChange24h: "1.09899728516430811",
    },
    [TEST_USDC_CANONICAL]: {
      currentPrice: "1",
      percentagePriceChange24h: "0.50",
    },
  };
  ```

#### 2. Update Account view assertions

`extension/src/popup/views/__tests__/Account.test.tsx`:

- Import `TEST_USDC_CANONICAL` from `popup/__testHelpers__`.
- "displays prices, deltas, and account balance" (~lines 946–990):
  ```ts
  // Priced classic asset (replaces impossible DT assertion)
  expect(screen.getByTestId(`asset-amount-${TEST_USDC_CANONICAL}`))
    .toHaveTextContent("$100.00");
  expect(screen.getByTestId(`asset-price-delta-${TEST_USDC_CANONICAL}`))
    .toHaveTextContent("0.50%");
  // Native is priced
  expect(screen.getByTestId("asset-amount-native"))
    .toHaveTextContent("$13.81");
  expect(screen.getByTestId("asset-price-delta-native"))
    .toHaveTextContent("1.09%");
  // Contract-ID asset is NEVER priced by production indexer
  expect(screen.queryByTestId(`asset-amount-${TEST_CANONICAL}`))
    .not.toBeInTheDocument();
  expect(screen.getByTestId(`asset-price-delta-${TEST_CANONICAL}`))
    .toHaveTextContent("--");
  ```
- "hides prices and deltas on token price failure" (~lines 1018–1062):
  Today only the DT amount-absence + native delta `--` are asserted.
  Add full coverage for all three rows — when prices fail globally,
  none of the three should have an `asset-amount-${canonical}` node,
  and all three deltas should read `--`:
  ```ts
  expect(screen.queryByTestId("asset-amount-native"))
    .not.toBeInTheDocument();
  expect(screen.getByTestId("asset-price-delta-native"))
    .toHaveTextContent("--");
  expect(screen.queryByTestId(`asset-amount-${TEST_USDC_CANONICAL}`))
    .not.toBeInTheDocument();
  expect(screen.getByTestId(`asset-price-delta-${TEST_USDC_CANONICAL}`))
    .toHaveTextContent("--");
  // Existing assertions for TEST_CANONICAL (DT) stay as-is.
  ```

#### 3. Replace the remaining sync `throw` mock

`extension/src/popup/views/__tests__/Account.test.tsx:1240-1242`
("polls for account balances"):

```ts
// Before
jest.spyOn(ApiInternal, "getTokenPrices").mockImplementation(() => {
  throw new Error("Failed to fetch prices");
});

// After
jest
  .spyOn(ApiInternal, "getTokenPrices")
  .mockRejectedValueOnce(new Error("Failed to fetch prices"));
```

Matches PR #2749's convention. The polling test asserts
`getAccountBalancesSpy.toHaveBeenCalledTimes(3)` after 30 s of fake
timer advance; balance polling
(`useGetAccountData.tsx:231-260`) is independent of price-poll state,
so this assertion holds whether or not later price calls happen.

#### 4. Fix `useGetWalletsData.test.tsx` mock return value + totals

`extension/src/popup/views/Wallets/hooks/__tests__/useGetWalletsData.test.tsx`:

- Lines 29-38: drop the DT contract-ID entry from the inline
  `jest.mock` `getTokenPrices` resolved value; add USDC:
  ```ts
  getTokenPrices: jest.fn().mockResolvedValue({
    native: {
      currentPrice: "1",
      percentagePriceChange24h: ".5",
    },
    "USDC:GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM": {
      currentPrice: "2",
      percentagePriceChange24h: ".25",
    },
  }),
  ```
- **Leave the `toHaveBeenCalledWith` assertion at lines 221-225
  unchanged** — the caller hands the full pre-filter list to
  `getTokenPrices`.
- **Update the `accountValue` totals.** Today only `native × 50 = $50`
  hits `getTotalUsd` (DT contract-ID is dropped by `getBalanceByAsset`
  because the fixture has no `contractId` field). After adding USDC
  at `currentPrice: "2"`, USDC contributes 100 × 2 = $200, so totals
  become `$250.00`:
  - Lines 153-156: `accountValue: { G1: "$250.00" }`.
  - Lines 227-234: each of `G1…G7` becomes `"$250.00"`.

#### 5. Pin the production filter as a positive contract

Add cases to `@shared/api/__tests__/internal.test.ts` (the existing
internal-API test file) inside a new `describe("getTokenPrices")`
block, mirroring the file's established `jest.spyOn(global, "fetch")`
pattern (e.g. `:94-100`):

```ts
describe("getTokenPrices", () => {
  it("excludes contract-ID issuers from the indexer request", async () => {
    const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
      ok: true,
      json: jest.fn().mockResolvedValue({ data: {} }),
    } as unknown as Response);

    await internalApi.getTokenPrices([
      "native",
      "USDC:GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM",
      "DT:CCXVDIGMR6WTXZQX2OEVD6YM6AYCYPXPQ7YYH6OZMRS7U6VD3AVHNGBJ",
    ]);
    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
    expect(body.tokens).toEqual([
      "native",
      "USDC:GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM",
    ]);
  });

  it("excludes liquidity-pool IDs from the indexer request", async () => {
    const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
      ok: true,
      json: jest.fn().mockResolvedValue({ data: {} }),
    } as unknown as Response);

    await internalApi.getTokenPrices(["native", "abc123:lp"]);
    const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
    expect(body.tokens).toEqual(["native"]);
  });
});
```

This pins the production filter contract so future fixture edits
don't have to infer pre/post-filter behavior indirectly.

### Behavior

| Scenario | Before | After |
|---|---|---|
| Account view, prices fetched | DT shows fake `$834k`/`3.97%` | USDC `$100`/`0.50%`, native `$13.81`/`1.09%`, DT (contract-ID) no amount node + `--` delta |
| Account view, prices fail | DT amount absent + native `--`; USDC delta unasserted | All three rows: amount absent + delta `--` |
| Account view, polling | Sync `throw` | Awaited `Promise.reject` via `mockRejectedValueOnce`; balance polling still produces 3 calls in 30 s |
| `useGetWalletsData` mainnet (single) | `accountValue` `$50.00` (DT silently dropped, native priced) | `accountValue` `$250.00` (native + USDC priced) |
| `useGetWalletsData` mainnet batches | All 7 wallets at `$50.00` | All 7 wallets at `$250.00` |
| `getTokenPrices` filter contract | Untested | New test pins contract-ID + LP-ID filter |

### Out of scope

- `mockBalances`/`mockTestnetBalances` shape, `TEST_CANONICAL`
  rename, splitting `mockPrices` into named variants, production
  behavior changes.

### Tests / Validation

- All existing tests in touched files must continue to pass.
- New `getTokenPrices` filter-contract test must pass.
- Repo-canonical commands (run from `freighter/`):
  - `yarn test:ci`
  - `yarn build:extension`

### Risk / regressions

- Test-only changes; no production code modified.
- New positive invariants pin contract-ID filter behavior end-to-end
  (UI render absence + indexer payload).
- `mockRejectedValueOnce` is functionally equivalent to the prior
  sync throw for the assertion under test, but exercises the real
  awaited rejection path.


---

Closes #2759
