### PR TITLE
Skip unfunded-destination warning for Soroban on Search address screen

### DIFF
--- a/extension/src/popup/components/send/SendAmount/hooks/__tests__/useSimulateTxData.test.ts
+++ b/extension/src/popup/components/send/SendAmount/hooks/__tests__/useSimulateTxData.test.ts
@@ -1,5 +1,6 @@
 import { getExpectedToFailReason } from "../useSimulateTxData";
 
+const G_DEST = "GA4UFF2WJM7KHHG4R5D5D2MZQ6FWMDOSVITVF7C5OLD5NFP6RBBW2FGV";
 const t = (key: string) => key;
 
 describe("getExpectedToFailReason", () => {
@@ -11,6 +12,8 @@ describe("getExpectedToFailReason", () => {
           assetCanonical:
             "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
           amount: "10",
+          destination: G_DEST,
+          isCollectible: false,
           t,
         }),
       ).toBeNull();
@@ -23,6 +26,8 @@ describe("getExpectedToFailReason", () => {
           assetCanonical:
             "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
           amount: "10",
+          destination: G_DEST,
+          isCollectible: false,
           t,
         }),
       ).toBeNull();
@@ -37,6 +42,8 @@ describe("getExpectedToFailReason", () => {
           assetCanonical:
             "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
           amount: "10",
+          destination: G_DEST,
+          isCollectible: false,
           t,
         }),
       ).toBe("Blockaid unfunded destination");
@@ -49,6 +56,8 @@ describe("getExpectedToFailReason", () => {
           assetCanonical:
             "LONGCODE12:GDMTVHLWJTHSUDMZVVMXXH6VJHA2ZV3HNG5LYNAZ6RTWB7GISM6PGTUV",
           amount: "10",
+          destination: G_DEST,
+          isCollectible: false,
           t,
         }),
       ).toBe("Blockaid unfunded destination");
@@ -66,6 +75,8 @@ describe("getExpectedToFailReason", () => {
           assetCanonical:
             "PBT:CAZXRTOKNUQ2JQQF3NCRU7GYMDJNZ2NMQN6IGN4FCT5DWPODMPVEXSND",
           amount: "10",
+          destination: G_DEST,
+          isCollectible: false,
           t,
         }),
       ).toBeNull();
@@ -78,6 +89,8 @@ describe("getExpectedToFailReason", () => {
           assetCanonical:
             "PBT:CAZXRTOKNUQ2JQQF3NCRU7GYMDJNZ2NMQN6IGN4FCT5DWPODMPVEXSND",
           amount: "0",
+          destination: G_DEST,
+          isCollectible: false,
           t,
         }),
       ).toBeNull();
@@ -93,6 +106,8 @@ describe("getExpectedToFailReason", () => {
           assetCanonical:
             "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef:lp",
           amount: "10",
+          destination: G_DEST,
+          isCollectible: false,
           t,
         }),
       ).toBe("Blockaid unfunded destination");
@@ -106,6 +121,8 @@ describe("getExpectedToFailReason", () => {
           isDestinationFunded: false,
           assetCanonical: "native",
           amount: "0.5",
+          destination: G_DEST,
+          isCollectible: false,
           t,
         }),
       ).toBe("Blockaid unfunded destination native");
@@ -117,6 +134,8 @@ describe("getExpectedToFailReason", () => {
           isDestinationFunded: false,
           assetCanonical: "native",
           amount: "1",
+          destination: G_DEST,
+          isCollectible: false,
           t,
         }),
       ).toBeNull();
@@ -128,6 +147,8 @@ describe("getExpectedToFailReason", () => {
           isDestinationFunded: false,
           assetCanonical: "native",
           amount: "5",
+          destination: G_DEST,
+          isCollectible: false,
           t,
         }),
       ).toBeNull();
@@ -139,9 +160,47 @@ describe("getExpectedToFailReason", () => {
           isDestinationFunded: false,
           assetCanonical: "native",
           amount: "",
+          destination: G_DEST,
+          isCollectible: false,
           t,
         }),
       ).toBe("Blockaid unfunded destination native");
+    });
+  });
+
+  describe("destination is unfunded, collectibles", () => {
+    it("returns null when isCollectible is true regardless of asset", () => {
+      // Collectibles transfer via contract invocation; the destination
+      // never needs to be a funded classic account.
+      expect(
+        getExpectedToFailReason({
+          isDestinationFunded: false,
+          assetCanonical: "native",
+          destination: G_DEST,
+          isCollectible: true,
+          amount: "10",
+          t,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("destination is unfunded, contract destination", () => {
+    it("returns null when destination is a contract address", () => {
+      // Contract destinations have no classic account; the warning rule
+      // does not apply regardless of the asset being sent.
+      expect(
+        getExpectedToFailReason({
+          isDestinationFunded: false,
+          assetCanonical:
+            "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+          destination:
+            "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+          isCollectible: false,
+          amount: "10",
+          t,
+        }),
+      ).toBeNull();
     });
   });
 });

--- a/extension/src/popup/components/send/SendAmount/hooks/useSimulateTxData.tsx
+++ b/extension/src/popup/components/send/SendAmount/hooks/useSimulateTxData.tsx
@@ -44,6 +44,7 @@ import { findAddressBalance } from "popup/helpers/balance";
 import { AppDispatch, AppState } from "popup/App";
 import { useScanTx } from "popup/helpers/blockaid";
 import { cleanAmount } from "popup/helpers/formatters";
+import { shouldCheckUnfundedDestinationWarning } from "popup/helpers/sendWarnings";
 import {
   checkIsMuxedSupported,
   determineMuxedDestination,
@@ -76,28 +77,28 @@ interface SimSoroban {
 const CREATE_ACCOUNT_MIN_XLM = new BigNumber(1);
 
 /**
- * Returns the translated user-facing reason why a transaction is expected to fail,
- * or null if no expected failure.
+ * Returns the translated user-facing reason why a transaction is expected
+ * to fail, or null if no expected failure.
  *
- * The unfunded-destination warning only applies to sends that use classic
- * Stellar account semantics: native XLM, credit_alphanum assets, and
- * Stellar Asset Contracts (SACs) wrapping those — all of which require a
- * funded classic destination. Pure Soroban custom tokens transfer via
- * contract invocation and don't touch the classic account ledger, so an
- * unfunded destination is not a failure condition for them.
- *
- * Asset ids encode the distinction: SACs normalize to their underlying
- * classic G-issuer, while pure Soroban custom tokens use a contract
- * (C-address) issuer.
+ * The unfunded-destination warning rule (qualitative gate) is delegated to
+ * `shouldCheckUnfundedDestinationWarning` in `popup/helpers/sendWarnings.ts`
+ * so the same rule fires on both the Search-address screen
+ * (`SendTo/index.tsx`) and here on Review. This branch overlays the
+ * native ≥ 1 XLM create-account quantitative check, which only matters
+ * once the amount is finalized.
  */
 export const getExpectedToFailReason = ({
   isDestinationFunded,
   assetCanonical,
+  destination,
+  isCollectible,
   amount,
   t,
 }: {
   isDestinationFunded?: boolean;
   assetCanonical: string;
+  destination: string;
+  isCollectible: boolean;
   amount: string;
   t: (key: string) => string;
 }) => {
@@ -105,11 +106,17 @@ export const getExpectedToFailReason = ({
     return null;
   }
 
+  if (
+    !shouldCheckUnfundedDestinationWarning({
+      assetCanonical,
+      destination,
+      isCollectible,
+    })
+  ) {
+    return null;
+  }
+
   if (assetCanonical !== "native") {
-    const [, issuer] = assetCanonical.split(":");
-    if (issuer && isContractId(issuer)) {
-      return null;
-    }
     return t("Blockaid unfunded destination");
   }
 
@@ -408,7 +415,7 @@ function useSimulateTxData({
   const { t } = useTranslation();
   const reduxDispatch = useDispatch<AppDispatch>();
   const store = useStore();
-  const { asset, amount, transactionFee, memo } = useSelector(
+  const { asset, amount, transactionFee, memo, isCollectible } = useSelector(
     transactionDataSelector,
   );
 
@@ -475,6 +482,8 @@ function useSimulateTxData({
       const expectedToFailReason = getExpectedToFailReason({
         isDestinationFunded: destBalancesResult.isFunded ?? undefined,
         assetCanonical: currentAsset,
+        destination,
+        isCollectible,
         amount: currentAmount,
         t,
       });

--- a/extension/src/popup/components/send/SendTo/index.tsx
+++ b/extension/src/popup/components/send/SendTo/index.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Asset, StrKey } from "stellar-sdk";
+import { StrKey } from "stellar-sdk";
 import { useFormik } from "formik";
-import BigNumber from "bignumber.js";
 import {
   Button,
   Input,
@@ -25,6 +24,7 @@ import { IdenticonImg } from "popup/components/identicons/IdenticonImg";
 import { FormRows } from "popup/basics/Forms";
 import { emitMetric } from "helpers/metrics";
 import { isContractId } from "popup/helpers/soroban";
+import { shouldShowAccountDoesntExistWarning } from "popup/helpers/sendWarnings";
 import { METRIC_NAMES } from "popup/constants/metricsNames";
 import { STELLAR_DOCS_CREATE_ACCOUNT_URL } from "popup/constants/externalLinks";
 import { View } from "popup/basics/layout/View";
@@ -45,17 +45,6 @@ import { AppDataType } from "helpers/hooks/useGetAppData";
 import { reRouteOnboarding } from "popup/helpers/route";
 
 import "../styles.scss";
-
-const baseReserve = new BigNumber(1);
-
-export const shouldAccountDoesntExistWarning = (
-  isFunded: boolean,
-  assetID: string,
-  amount: string,
-) =>
-  !isFunded &&
-  (new BigNumber(amount).lt(baseReserve) ||
-    assetID !== Asset.native().toString());
 
 export const AccountDoesntExistWarning = () => {
   const { t } = useTranslation();
@@ -108,7 +97,7 @@ export const SendTo = ({
   const { t } = useTranslation();
   const location = useLocation();
   const dispatch: AppDispatch = useDispatch<AppDispatch>();
-  const { destination, federationAddress } = useSelector(
+  const { destination, federationAddress, asset, isCollectible } = useSelector(
     transactionDataSelector,
   );
   const { state: sendDataState, fetchData } = useSendToData();
@@ -279,10 +268,13 @@ export const SendTo = ({
                 <div>
                   {formik.isValid ? (
                     <>
-                      {sendDataState.data.destinationBalances &&
-                        !sendDataState.data.destinationBalances.isFunded && (
-                          <AccountDoesntExistWarning />
-                        )}
+                      {shouldShowAccountDoesntExistWarning({
+                        assetCanonical: asset,
+                        destination: sendDataState.data.validatedAddress,
+                        isCollectible,
+                        isFunded:
+                          sendDataState.data.destinationBalances?.isFunded,
+                      }) && <AccountDoesntExistWarning />}
                       <div className="SendTo__subheading">
                         <Icon.SearchLg />
                         Suggestions

--- a/extension/src/popup/helpers/__tests__/sendWarnings.test.ts
+++ b/extension/src/popup/helpers/__tests__/sendWarnings.test.ts
@@ -1,0 +1,178 @@
+import {
+  shouldCheckUnfundedDestinationWarning,
+  shouldShowAccountDoesntExistWarning,
+} from "../sendWarnings";
+
+const G_DEST = "GA4UFF2WJM7KHHG4R5D5D2MZQ6FWMDOSVITVF7C5OLD5NFP6RBBW2FGV";
+const C_DEST = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+const G_ISSUER = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+const C_ISSUER = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+
+describe("shouldCheckUnfundedDestinationWarning", () => {
+  it("applies the rule for native XLM to a G-destination", () => {
+    expect(
+      shouldCheckUnfundedDestinationWarning({
+        assetCanonical: "native",
+        destination: G_DEST,
+        isCollectible: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("applies the rule for classic credit_alphanum (G-issuer)", () => {
+    expect(
+      shouldCheckUnfundedDestinationWarning({
+        assetCanonical: `USDC:${G_ISSUER}`,
+        destination: G_DEST,
+        isCollectible: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("applies the rule for SAC-wrapped classic asset (G-issuer)", () => {
+    // SACs normalize to their underlying classic G-issuer in canonical form.
+    expect(
+      shouldCheckUnfundedDestinationWarning({
+        assetCanonical: `EURC:${G_ISSUER}`,
+        destination: G_DEST,
+        isCollectible: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("skips the rule for a pure Soroban custom token (C-issuer)", () => {
+    expect(
+      shouldCheckUnfundedDestinationWarning({
+        assetCanonical: `TOKEN:${C_ISSUER}`,
+        destination: G_DEST,
+        isCollectible: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("skips the rule when isCollectible is true regardless of asset", () => {
+    expect(
+      shouldCheckUnfundedDestinationWarning({
+        assetCanonical: "native",
+        destination: G_DEST,
+        isCollectible: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("skips the rule when destination is a contract address", () => {
+    expect(
+      shouldCheckUnfundedDestinationWarning({
+        assetCanonical: `USDC:${G_ISSUER}`,
+        destination: C_DEST,
+        isCollectible: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats empty assetCanonical as classic (defensive)", () => {
+    // Real redux default is "native"; "" is not a real runtime path but
+    // covered as a defensive case so the helper degrades safely.
+    expect(
+      shouldCheckUnfundedDestinationWarning({
+        assetCanonical: "",
+        destination: G_DEST,
+        isCollectible: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats empty destination as non-contract", () => {
+    expect(
+      shouldCheckUnfundedDestinationWarning({
+        assetCanonical: "native",
+        destination: "",
+        isCollectible: false,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("shouldShowAccountDoesntExistWarning", () => {
+  const baseClassic = {
+    assetCanonical: "native",
+    destination: G_DEST,
+    isCollectible: false,
+  };
+
+  it("shows the warning for default state + unfunded G-destination", () => {
+    expect(
+      shouldShowAccountDoesntExistWarning({
+        ...baseClassic,
+        isFunded: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides the warning for pure Soroban asset + unfunded G-destination", () => {
+    expect(
+      shouldShowAccountDoesntExistWarning({
+        assetCanonical: `TOKEN:${C_ISSUER}`,
+        destination: G_DEST,
+        isCollectible: false,
+        isFunded: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("hides the warning for collectible state with stale native asset", () => {
+    // Reproduces useSendQueryParams.ts:64-85 early-return path where
+    // saveIsCollectible(true) runs but the asset destructure path is
+    // short-circuited, leaving the redux default "native" in place.
+    expect(
+      shouldShowAccountDoesntExistWarning({
+        assetCanonical: "native",
+        destination: G_DEST,
+        isCollectible: true,
+        isFunded: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("hides the warning for contract destination regardless of asset", () => {
+    // useSendToData.tsx:92-93 already skips balance fetch for contract
+    // destinations, so this is belt-and-braces.
+    expect(
+      shouldShowAccountDoesntExistWarning({
+        assetCanonical: `USDC:${G_ISSUER}`,
+        destination: C_DEST,
+        isCollectible: false,
+        isFunded: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("hides the warning when isFunded is null (unknown / fetch fallback)", () => {
+    // Regression guard for the strict-`=== false` change: AccountBalances.isFunded
+    // is `boolean | null` and unknown funding must not warn.
+    expect(
+      shouldShowAccountDoesntExistWarning({
+        ...baseClassic,
+        isFunded: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("hides the warning when isFunded is undefined (no balances loaded)", () => {
+    expect(
+      shouldShowAccountDoesntExistWarning({
+        ...baseClassic,
+        isFunded: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("hides the warning when isFunded is true", () => {
+    expect(
+      shouldShowAccountDoesntExistWarning({
+        ...baseClassic,
+        isFunded: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/extension/src/popup/helpers/sendWarnings.ts
+++ b/extension/src/popup/helpers/sendWarnings.ts
@@ -1,0 +1,71 @@
+import { isContractId } from "popup/helpers/soroban";
+
+/**
+ * Returns true when the "destination is unfunded" warning rule applies to
+ * this send — i.e. the asset transfers via a classic Stellar payment op
+ * AND the destination would be a classic G-account.
+ *
+ *  - Native XLM, credit_alphanum4/12, and SAC-wrapped classic assets all
+ *    use a classic payment op that fails to an unfunded G-account (with
+ *    the special case of native ≥ 1 XLM, which succeeds via create-account
+ *    — that quantitative check is left to the caller; this helper only
+ *    answers the qualitative "should the rule even fire?" question).
+ *  - Pure Soroban custom tokens (issuer is a C-address) and collectibles
+ *    transfer via contract invocation; the classic destination ledger is
+ *    never touched.
+ *  - Contract (C...) destinations have no classic account at all — their
+ *    "balance" lives in the token contract's storage.
+ */
+export const shouldCheckUnfundedDestinationWarning = ({
+  assetCanonical,
+  destination,
+  isCollectible,
+}: {
+  assetCanonical: string;
+  destination: string;
+  isCollectible: boolean;
+}): boolean => {
+  if (isCollectible) {
+    return false;
+  }
+  if (destination && isContractId(destination)) {
+    return false;
+  }
+
+  if (assetCanonical && assetCanonical !== "native") {
+    const [, issuer] = assetCanonical.split(":");
+    if (issuer && isContractId(issuer)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+/**
+ * Compound predicate used at the SendTo "Search address" screen: returns
+ * true only when the destination is known-unfunded (`isFunded === false`,
+ * matching the strict semantics in `getExpectedToFailReason`) AND the
+ * unfunded-destination warning rule applies to this send.
+ *
+ * `isFunded` is `boolean | null | undefined` because `AccountBalances.isFunded`
+ * is `boolean | null` and the surrounding state may not have loaded balances
+ * yet — both null (unknown) and undefined (mid-fetch) must NOT warn.
+ */
+export const shouldShowAccountDoesntExistWarning = ({
+  assetCanonical,
+  destination,
+  isCollectible,
+  isFunded,
+}: {
+  assetCanonical: string;
+  destination: string;
+  isCollectible: boolean;
+  isFunded: boolean | null | undefined;
+}): boolean =>
+  isFunded === false &&
+  shouldCheckUnfundedDestinationWarning({
+    assetCanonical,
+    destination,
+    isCollectible,
+  });

--- a/extension/src/popup/helpers/sendWarnings.ts
+++ b/extension/src/popup/helpers/sendWarnings.ts
@@ -1,4 +1,4 @@
-import { isContractId } from "popup/helpers/soroban";
+import { isContractId } from "@shared/api/helpers/soroban";
 
 /**
  * Returns true when the "destination is unfunded" warning rule applies to


### PR DESCRIPTION
## Problem

PR #2720 removed the misleading "Blockaid unfunded destination" warning for
pure Soroban custom tokens on the **transaction Review** step. The same
warning still appears one step earlier on the **Search address** screen
(`extension/src/popup/components/send/SendTo`), which is what issue #2777
tracks. Freighter Mobile already addresses both screens.

## Root cause

Two surfaces independently decide whether to show the unfunded-destination
warning:

- **Search address** (`SendTo/index.tsx:282-285`) renders
  `<AccountDoesntExistWarning />` based purely on `!destinationBalances.isFunded`,
  with no asset-side check at all.
- **Review** (`SendAmount/hooks/useSimulateTxData.tsx:94-123` —
  `getExpectedToFailReason`) checks `assetCanonical !== "native"` and
  `isContractId(issuer)`, but doesn't consider `isCollectible` or
  contract destinations.

The exported helper `shouldAccountDoesntExistWarning(isFunded, assetID, amount)`
in `SendTo/index.tsx:51-58` is dead code (verified via repo-wide grep) and
encodes a third, incomplete version of the rule.

## Proposed change

### 1. New shared helper

Create `extension/src/popup/helpers/sendWarnings.ts`:

```ts
import { isContractId } from "popup/helpers/soroban";

/**
 * Returns true when the "destination is unfunded" warning rule applies to
 * this send — i.e. the asset transfers via a classic Stellar payment op AND
 * the destination would be a classic G-account.
 *
 *  - Native XLM, credit_alphanum4/12, and SAC-wrapped classic assets all
 *    use a classic payment op that fails to an unfunded G-account (with
 *    the special case of native ≥ 1 XLM, which succeeds via create-account
 *    — that quantitative check is left to the caller; this helper only
 *    answers the qualitative "should the rule even fire?" question).
 *  - Pure Soroban custom tokens (issuer is a C-address) and collectibles
 *    transfer via contract invocation; the classic destination ledger is
 *    never touched.
 *  - Contract (C...) destinations have no classic account at all — their
 *    "balance" lives in the token contract's storage.
 */
export const shouldCheckUnfundedDestinationWarning = ({
  assetCanonical,
  destination,
  isCollectible,
}: {
  assetCanonical: string;
  destination: string;
  isCollectible: boolean;
}): boolean => {
  if (isCollectible) return false;
  if (destination && isContractId(destination)) return false;

  if (assetCanonical && assetCanonical !== "native") {
    const [, issuer] = assetCanonical.split(":");
    if (issuer && isContractId(issuer)) return false;
  }

  return true;
};
```

`isContractId` is the same predicate already used in
`getExpectedToFailReason`, so the two surfaces will agree by construction.

The qualitative/quantitative split (helper answers "does the rule apply?";
caller decides "is the destination actually unfunded enough to fail?") is
deliberate. The native ≥ 1 XLM create-account threshold lives where the
amount is finalized — `getExpectedToFailReason`'s native branch — and the
SendTo screen never needs it (asset is fixed, amount is not yet known).
This addresses the naming concern by making the helper's semantics
unambiguous: it is a precondition gate, not a "this send will fail"
predicate.

### 2. Use the helper in `SendTo/index.tsx`

- Pull `asset` and `isCollectible` from the existing `transactionDataSelector`
  (already imported and used for `destination`/`federationAddress`).
- Replace the inline `!isFunded` check with a single compound
  helper call (see Tests, below, for why the `=== false` and the
  qualitative gate are co-located):

```tsx
{shouldShowAccountDoesntExistWarning({
  assetCanonical: asset,
  destination: sendDataState.data.validatedAddress,
  isCollectible,
  isFunded: sendDataState.data.destinationBalances?.isFunded,
}) && <AccountDoesntExistWarning />}
```

`validatedAddress` is the right thing to pass: federation domains are
resolved to G-addresses there, and `useSendToData` only fetches
`destinationBalances` when the resolved address is non-contract anyway —
but passing it through the helper keeps the rule self-consistent at the
read site.

Note the change from `!destinationBalances.isFunded` to `destinationBalances?.isFunded === false`: `isFunded` is `boolean | null` (`@shared/api/types/backend-api.ts:10-13`), and Review-step logic only warns on `=== false` (`useSimulateTxData.tsx:105-123`). Aligning Search with that strict check means an unknown/null funding state (e.g. mid-fetch or fetch failure) no longer triggers a misleading warning. (Critic round 2.)

- **Delete** the dead `shouldAccountDoesntExistWarning` export and its base
  reserve constant. They are unused (grep confirms). Leaving a stale,
  near-correct helper next to the new one is a footgun for the next
  person tracing this logic. The min-1-XLM check it encoded for native
  sends already lives in `getExpectedToFailReason`'s native branch.

### 3. Refactor `getExpectedToFailReason` — in-place, no API surface change

Per critic feedback (round 1, item 1): do **not** thread new args through
`popup/views/Send/index.tsx`. The hook already has what it needs:

- `useSimulateTxData` already accepts `destination` as a hook arg
  (`useSimulateTxData.tsx:394-405`).
- `useSimulateTxData` already destructures from `transactionDataSelector`
  (`useSimulateTxData.tsx:410-412`); add `isCollectible` to that destructure.
- The single `getExpectedToFailReason(...)` call inside the hook
  (`useSimulateTxData.tsx:472-477`) gains two locally-scoped parameters
  (`destination`, `isCollectible`).
- `Send/index.tsx` is untouched; the hook signature is untouched.

Inside `getExpectedToFailReason`, replace the bespoke
`assetCanonical !== "native"` + issuer parsing with:

```ts
if (
  isDestinationFunded !== false ||
  !shouldCheckUnfundedDestinationWarning({
    assetCanonical,
    destination,
    isCollectible,
  })
) {
  return null;
}
// native min-1-XLM branch unchanged
```

### 4. Tests

**Unit tests** for `shouldCheckUnfundedDestinationWarning` covering:
- Native XLM → true
- credit_alphanum4 with G-issuer → true
- SAC-wrapped classic (G-issuer) → true
- Pure Soroban custom token (C-issuer) → false
- `isCollectible: true` (regardless of asset) → false
- Contract (C...) destination (regardless of asset) → false
- Empty `assetCanonical` (initial-state edge case before
  `useSendQueryParams` resolves) → defaults to "treat as classic" →
  document why this is safe (the warning would only render once
  destinationBalances loads, which gates on a real address, and the
  default redux value for `asset` is `"native"` per
  `transactionSubmission.ts:488`, so empty-string is not a real
  runtime path; covered as a defensive case).

**`SendTo` warning gate as a unit-testable helper.** The
`extension/src/popup/views/__tests__/SendPayment.test.tsx` integration
suite is currently `describe.skip("Send", ...)` (line 128, verified
round 3) — anything added there would not run. Rather than unskip an
unrelated suite or stand up an ad-hoc integration harness for one
boolean, extract the wrapping `=== false` + helper composition into a
second pure helper alongside `shouldCheckUnfundedDestinationWarning`
in `sendWarnings.ts`:

```ts
export const shouldShowAccountDoesntExistWarning = ({
  assetCanonical,
  destination,
  isCollectible,
  isFunded,
}: {
  assetCanonical: string;
  destination: string;
  isCollectible: boolean;
  isFunded: boolean | null | undefined;
}): boolean =>
  isFunded === false &&
  shouldCheckUnfundedDestinationWarning({
    assetCanonical,
    destination,
    isCollectible,
  });
```

The `SendTo` JSX then collapses to:

```tsx
{shouldShowAccountDoesntExistWarning({
  assetCanonical: asset,
  destination: sendDataState.data.validatedAddress,
  isCollectible,
  isFunded: sendDataState.data.destinationBalances?.isFunded,
}) && <AccountDoesntExistWarning />}
```

This puts the strict-`=== false` rule in the same module as the
qualitative gate (one place to update) and makes the integration cases
pure unit tests in `extension/src/popup/helpers/__tests__/sendWarnings.test.ts`:

- Default state (`asset: "native"`, `isCollectible: false`,
  `isFunded: false`) + non-contract G-destination → true.
- Pure Soroban asset (`asset: "TOKEN:CABC...XYZ"`,
  `isCollectible: false`, `isFunded: false`) + G-destination → false.
- Collectible state (`isCollectible: true`, `asset: "native"` —
  reproduces the early-return query-param hydration in
  `useSendQueryParams.ts:64-85` where `saveIsCollectible(true)` runs
  but the asset destructure path is short-circuited) +
  `isFunded: false` → false.
- Contract destination (`destination: "C..."`) regardless of asset +
  `isFunded: false` → false. (Also documents that
  `useSendToData.tsx:92-93` already skips balance fetch for contract
  destinations, so this is belt-and-braces.)
- Unknown funding state (`isFunded: null`, e.g. mid-fetch or backend
  fallback) with classic asset + non-contract destination → false
  (regression guard for the strict-`=== false` change, per critic
  round 2).
- `isFunded: undefined` (no balances loaded yet) with classic asset →
  false (defensive, matches the optional-chaining at the call site).
- `isFunded: true` with classic asset → false (sanity).

**Update** `useSimulateTxData.test.ts`'s existing
`getExpectedToFailReason` cases to pass the new `destination` /
`isCollectible` params, and add a collectible case (collectible flag
true with classic asset / unfunded G-destination → returns `null`).

### 5. Out of scope (file as follow-ups if confirmed)

- Equivalent screens for Swap/Soroswap, account-merge, and the QR-scan
  recipient flow — none called out in #2777, each touches separate UI.
- Aligning extension's helper with mobile's `buildUnfundedContext` shape
  (which feeds Blockaid result merging on mobile). Extension's Review
  step uses a simpler "expected to fail reason" string; cross-platform
  convergence is a separate refactor.
- Promoting the helper into `@shared/helpers/` for cross-submodule
  reuse. Mobile's helper is shaped differently (returns
  `UnfundedDestinationContext`); a shared module would have to bridge
  both shapes, which is out of scope for a one-screen bug fix.

## Verification

Per `freighter/AGENTS.md` (also stored in agent memory): from repo root
run `yarn test:ci` and `yarn build:extension`. Manually exercise the
SendTo screen in the extension dev build with (a) a classic asset →
unfunded G-address (warning shown) and (b) a pure Soroban custom token →
unfunded G-address (warning hidden).


---

Closes #2777
