### PR TITLE
Guard popup views against RequestState.ERROR data dereferences

### DIFF
--- a/extension/src/popup/components/manageAssets/AssetVisibility/__tests__/AssetVisibility.errorState.test.tsx
+++ b/extension/src/popup/components/manageAssets/AssetVisibility/__tests__/AssetVisibility.errorState.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { RequestState } from "constants/request";
+import { Wrapper } from "popup/__testHelpers__";
+import { AssetVisibility } from "popup/components/manageAssets/AssetVisibility";
+import * as UseGetAssetData from "popup/components/manageAssets/AssetVisibility/hooks/useGetAssetData";
+
+describe("AssetVisibility RequestState.ERROR", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders the fetch-fail notification without throwing on RequestState.ERROR", () => {
+    jest.spyOn(UseGetAssetData, "useGetAssetData").mockReturnValue({
+      state: {
+        state: RequestState.ERROR,
+        data: null,
+        error: new Error("boom"),
+      },
+      fetchData: jest.fn().mockResolvedValue(undefined),
+      changeAssetVisibility: jest.fn().mockResolvedValue(undefined),
+    } as any);
+
+    render(
+      <Wrapper state={{}} routes={["/"]}>
+        <AssetVisibility />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.getByTestId("asset-visibility-fetch-fail"),
+    ).toBeInTheDocument();
+  });
+});

--- a/extension/src/popup/components/manageAssets/AssetVisibility/index.tsx
+++ b/extension/src/popup/components/manageAssets/AssetVisibility/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from "react";
 import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
-import { Loader } from "@stellar/design-system";
+import { Loader, Notification } from "@stellar/design-system";
 
 import { View } from "popup/basics/layout/View";
 import { SubviewHeader } from "popup/components/SubviewHeader";
@@ -59,7 +59,19 @@ export const AssetVisibility = () => {
     domainState.state === RequestState.IDLE ||
     domainState.state === RequestState.LOADING;
 
-  const hasError = domainState.state === RequestState.ERROR;
+  if (domainState.state === RequestState.ERROR) {
+    return (
+      <div
+        className="ToggleAsset__fetch-fail"
+        data-testid="asset-visibility-fetch-fail"
+      >
+        <Notification variant="error" title={t("Failed to load assets.")}>
+          {t("Your assets could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
+
   if (domainState.data?.type === AppDataType.REROUTE) {
     if (domainState.data.shouldOpenTab) {
       openTab(newTabHref(domainState.data.routeTarget));
@@ -74,21 +86,21 @@ export const AssetVisibility = () => {
     );
   }
 
-  if (!isLoading && !hasError) {
+  const data = domainState.data;
+
+  if (!isLoading && data) {
     reRouteOnboarding({
-      type: domainState.data.type,
-      applicationState: domainState.data?.applicationState,
+      type: data.type,
+      applicationState: data.applicationState,
       state: domainState.state,
     });
   }
-
-  const data = domainState.data;
 
   return (
     <>
       <SubviewHeader customBackAction={goBack} title={t("Toggle Assets")} />
       <View.Content hasNoTopPadding>
-        {isLoading ? (
+        {isLoading || !data ? (
           <div className="ToggleAsset__loader">
             <Loader size="2rem" />
           </div>
@@ -96,15 +108,13 @@ export const AssetVisibility = () => {
           <div className="ToggleAsset__wrapper">
             <div
               className={`ToggleAsset__assets${
-                domainState.data?.isManagingAssets && isSorobanSuported
-                  ? "--short"
-                  : ""
+                data.isManagingAssets && isSorobanSuported ? "--short" : ""
               }`}
               ref={ManageAssetRowsWrapperRef}
             >
               <ToggleAssetRows
-                assetRows={domainState.data!.domains}
-                hiddenAssets={domainState.data!.hiddenAssets}
+                assetRows={data.domains}
+                hiddenAssets={data.hiddenAssets}
                 changeAssetVisibility={async ({
                   issuer,
                   visibility,
@@ -115,7 +125,7 @@ export const AssetVisibility = () => {
                   return await changeAssetVisibility({
                     issuer,
                     visibility,
-                    publicKey: data!.publicKey,
+                    publicKey: data.publicKey,
                   });
                 }}
               />

--- a/extension/src/popup/components/manageAssets/AssetVisibility/styles.scss
+++ b/extension/src/popup/components/manageAssets/AssetVisibility/styles.scss
@@ -1,6 +1,12 @@
+@use "../../../styles/utils.scss" as *;
+
 .ToggleAsset {
   &__close-btn {
     color: var(--sds-clr-gray-10);
+  }
+
+  &__fetch-fail {
+    padding: pxToRem(16px);
   }
 
   &__hide-btn {

--- a/extension/src/popup/components/manageAssets/ChooseAsset/__tests__/ChooseAsset.errorState.test.tsx
+++ b/extension/src/popup/components/manageAssets/ChooseAsset/__tests__/ChooseAsset.errorState.test.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { RequestState } from "constants/request";
+import { Wrapper } from "popup/__testHelpers__";
+import { ChooseAsset } from "popup/components/manageAssets/ChooseAsset";
+import * as UseGetAssetDomainsWithBalances from "helpers/hooks/useGetAssetDomainsWithBalances";
+
+describe("ChooseAsset RequestState.ERROR", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders the fetch-fail notification without throwing on RequestState.ERROR", () => {
+    jest
+      .spyOn(
+        UseGetAssetDomainsWithBalances,
+        "useGetAssetDomainsWithBalances",
+      )
+      .mockReturnValue({
+        state: {
+          state: RequestState.ERROR,
+          data: null,
+          error: new Error("boom"),
+        },
+        fetchData: jest.fn().mockResolvedValue(undefined),
+      } as any);
+
+    render(
+      <Wrapper state={{}} routes={["/"]}>
+        <ChooseAsset goBack={jest.fn()} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByTestId("choose-asset-fetch-fail")).toBeInTheDocument();
+  });
+});

--- a/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/ChooseAsset/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import { useSelector } from "react-redux";
 import { Link, Navigate, useLocation } from "react-router-dom";
-import { Button, Icon, Loader } from "@stellar/design-system";
+import { Button, Icon, Loader, Notification } from "@stellar/design-system";
 import { useTranslation } from "react-i18next";
 
 import { ROUTES } from "popup/constants/routes";
@@ -66,6 +66,19 @@ export const ChooseAsset = ({
   }
 
   const hasError = domainState.state === RequestState.ERROR;
+  if (hasError) {
+    return (
+      <div
+        className="ChooseAsset__fetch-fail"
+        data-testid="choose-asset-fetch-fail"
+      >
+        <Notification variant="error" title={t("Failed to load assets.")}>
+          {t("Your assets could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
+
   if (domainState.data?.type === AppDataType.REROUTE) {
     if (domainState.data.shouldOpenTab) {
       openTab(newTabHref(domainState.data.routeTarget));
@@ -80,21 +93,20 @@ export const ChooseAsset = ({
     );
   }
 
-  if (!hasError) {
-    reRouteOnboarding({
-      type: domainState.data.type,
-      applicationState: domainState.data?.applicationState,
-      state: domainState.state,
-    });
-  }
+  // Past the ERROR and REROUTE guards, domainState holds resolved data.
+  const data = domainState.data;
+
+  reRouteOnboarding({
+    type: data.type,
+    applicationState: data.applicationState,
+    state: domainState.state,
+  });
 
   return (
     <React.Fragment>
       <SubviewHeader
         title={t("Your assets")}
-        customBackIcon={
-          !domainState.data?.isManagingAssets ? <Icon.X /> : undefined
-        }
+        customBackIcon={!data.isManagingAssets ? <Icon.X /> : undefined}
         customBackAction={goBack}
         rightButton={
           showHideAssets ? (
@@ -115,7 +127,7 @@ export const ChooseAsset = ({
       />
       <View.Content hasNoTopPadding>
         <div className="ChooseAsset__wrapper" data-testid="ChooseAssetWrapper">
-          {!domainState.data?.domains.length ? (
+          {!data.domains.length ? (
             <div className="ChooseAsset__empty">
               <p>
                 {`${t("You have no assets added.")} ${t("Get started by adding an asset.")}`}
@@ -124,23 +136,21 @@ export const ChooseAsset = ({
           ) : (
             <div
               className={`ChooseAsset__assets${
-                domainState.data.isManagingAssets && isSorobanSuported
-                  ? "--short"
-                  : ""
+                data.isManagingAssets && isSorobanSuported ? "--short" : ""
               }`}
               ref={ManageAssetRowsWrapperRef}
             >
-              {domainState.data.isManagingAssets ? (
+              {data.isManagingAssets ? (
                 <ManageAssetRows
                   shouldSplitAssetsByVerificationStatus={false}
-                  verifiedAssetRows={domainState.data.domains}
+                  verifiedAssetRows={data.domains}
                   unverifiedAssetRows={[]}
-                  balances={domainState.data.balances}
+                  balances={data.balances}
                 />
               ) : (
                 <SelectAssetRows
-                  assetRows={domainState.data.domains}
-                  balances={domainState.data.balances}
+                  assetRows={data.domains}
+                  balances={data.balances}
                   onSelect={goBack}
                 />
               )}
@@ -148,7 +158,7 @@ export const ChooseAsset = ({
           )}
         </div>
       </View.Content>
-      {domainState.data?.isManagingAssets && (
+      {data.isManagingAssets && (
         <View.Footer isInline allowWrap>
           <div className="ChooseAsset__button">
             <Link to={ROUTES.searchAsset}>

--- a/extension/src/popup/components/manageAssets/ChooseAsset/styles.scss
+++ b/extension/src/popup/components/manageAssets/ChooseAsset/styles.scss
@@ -1,4 +1,8 @@
 .ChooseAsset {
+  &__fetch-fail {
+    padding: pxToRem(16px);
+  }
+
   &__close-btn {
     color: var(--sds-clr-gray-10);
   }

--- a/extension/src/popup/components/send/SendAmount/__tests__/SendAmount.errorState.test.tsx
+++ b/extension/src/popup/components/send/SendAmount/__tests__/SendAmount.errorState.test.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { RequestState } from "constants/request";
+import { Wrapper } from "popup/__testHelpers__";
+import { SendAmount } from "popup/components/send/SendAmount";
+import * as UseGetSendAmountData from "popup/components/send/SendAmount/hooks/useSendAmountData";
+
+describe("SendAmount RequestState.ERROR", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders the fetch-fail notification without throwing on RequestState.ERROR", () => {
+    jest
+      .spyOn(UseGetSendAmountData, "useGetSendAmountData")
+      .mockReturnValue({
+        state: {
+          state: RequestState.ERROR,
+          data: null,
+          error: new Error("boom"),
+        },
+        fetchData: jest.fn().mockResolvedValue(undefined),
+      } as any);
+
+    render(
+      <Wrapper state={{}} routes={["/"]}>
+        <SendAmount
+          goBack={jest.fn()}
+          goToNext={jest.fn()}
+          goToChooseDest={jest.fn()}
+          goToChooseAsset={jest.fn()}
+          simulationState={
+            {
+              state: RequestState.IDLE,
+              data: null,
+              error: null,
+            } as any
+          }
+          fetchSimulationData={jest.fn().mockResolvedValue(undefined)}
+          networkCongestion={"LOW" as any}
+          recommendedFee="0.00001"
+        />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.getByTestId("send-amount-fetch-fail"),
+    ).toBeInTheDocument();
+  });
+});

--- a/extension/src/popup/components/send/SendAmount/index.tsx
+++ b/extension/src/popup/components/send/SendAmount/index.tsx
@@ -434,7 +434,19 @@ export const SendAmount = ({
     return <Loading />;
   }
 
-  const hasError = sendAmountData.state === RequestState.ERROR;
+  if (sendAmountData.state === RequestState.ERROR) {
+    return (
+      <div
+        className="SendAmount__fetch-fail"
+        data-testid="send-amount-fetch-fail"
+      >
+        <Notification variant="error" title={t("Failed to load send data.")}>
+          {t("Your send data could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
+
   if (sendAmountData.data?.type === AppDataType.REROUTE) {
     if (sendAmountData.data.shouldOpenTab) {
       openTab(newTabHref(sendAmountData.data.routeTarget));
@@ -449,15 +461,15 @@ export const SendAmount = ({
     );
   }
 
-  if (!hasError) {
-    reRouteOnboarding({
-      type: sendAmountData.data.type,
-      applicationState: sendAmountData.data.applicationState,
-      state: sendAmountData.state,
-    });
-  }
+  const data = sendAmountData.data;
 
-  const sendData = sendAmountData.data!;
+  reRouteOnboarding({
+    type: data.type,
+    applicationState: data.applicationState,
+    state: sendAmountData.state,
+  });
+
+  const sendData = data;
   const assetIcon = sendData.icons[asset];
 
   // Use getBalanceByKey for tokens (contract ID), getBalanceByAsset for classic assets
@@ -495,8 +507,7 @@ export const SendAmount = ({
         ),
       )}`
     : null;
-  const supportsUsd =
-    isMainnet(sendAmountData.data?.networkDetails!) && assetPrice;
+  const supportsUsd = isMainnet(data.networkDetails) && assetPrice;
   const availableBalance = getAvailableBalance({
     assetCanonical: asset,
     balances: sendData.userBalances.balances,
@@ -1053,7 +1064,7 @@ export const SendAmount = ({
           <ReviewTx
             assetIcon={assetIcon}
             fee={fee}
-            networkDetails={sendAmountData.data?.networkDetails!}
+            networkDetails={data.networkDetails}
             onCancel={() => setIsReviewingTx(false)}
             onConfirm={goToNext}
             onAddMemo={() => {

--- a/extension/src/popup/components/send/styles.scss
+++ b/extension/src/popup/components/send/styles.scss
@@ -11,6 +11,10 @@
   flex-direction: column;
   height: 100%;
 
+  &__fetch-fail {
+    padding: pxToRem(16px);
+  }
+
   &__subtitle {
     text-align: center;
   }

--- a/extension/src/popup/components/swap/SwapAmount/__tests__/SwapAmount.errorState.test.tsx
+++ b/extension/src/popup/components/swap/SwapAmount/__tests__/SwapAmount.errorState.test.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { RequestState } from "constants/request";
+import { Wrapper } from "popup/__testHelpers__";
+import { SwapAmount } from "popup/components/swap/SwapAmount";
+import * as UseGetSwapAmountData from "popup/components/swap/SwapAmount/hooks/useGetSwapAmountData";
+import * as UseSimulateSwapData from "popup/components/swap/SwapAmount/hooks/useSimulateSwapData";
+import * as UseNetworkFees from "popup/helpers/useNetworkFees";
+
+describe("SwapAmount RequestState.ERROR", () => {
+  beforeEach(() => {
+    jest.spyOn(UseNetworkFees, "useNetworkFees").mockReturnValue({
+      networkCongestion: "LOW",
+      recommendedFee: "0.00001",
+    } as any);
+    jest.spyOn(UseSimulateSwapData, "useSimulateTxData").mockReturnValue({
+      simulationState: {
+        state: RequestState.IDLE,
+        data: null,
+        error: null,
+      },
+      fetchData: jest.fn().mockResolvedValue(undefined),
+    } as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders the fetch-fail notification without throwing on RequestState.ERROR", () => {
+    jest
+      .spyOn(UseGetSwapAmountData, "useGetSwapAmountData")
+      .mockReturnValue({
+        state: {
+          state: RequestState.ERROR,
+          data: null,
+          error: new Error("boom"),
+        },
+        fetchData: jest.fn().mockResolvedValue(undefined),
+      } as any);
+
+    render(
+      <Wrapper state={{}} routes={["/"]}>
+        <SwapAmount
+          inputType="crypto"
+          setInputType={jest.fn()}
+          goBack={jest.fn()}
+          goToNext={jest.fn()}
+          goToEditSrc={jest.fn()}
+          goToEditDst={jest.fn()}
+        />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.getByTestId("swap-amount-fetch-fail"),
+    ).toBeInTheDocument();
+  });
+});

--- a/extension/src/popup/components/swap/SwapAmount/index.tsx
+++ b/extension/src/popup/components/swap/SwapAmount/index.tsx
@@ -5,7 +5,13 @@ import { useTranslation } from "react-i18next";
 import { Form, Field, FieldProps, Formik, useFormik } from "formik";
 import BigNumber from "bignumber.js";
 import { object as YupObject, number as YupNumber } from "yup";
-import { Button, Card, Icon, Input } from "@stellar/design-system";
+import {
+  Button,
+  Card,
+  Icon,
+  Input,
+  Notification,
+} from "@stellar/design-system";
 
 import { View } from "popup/basics/layout/View";
 import { SubviewHeader } from "popup/components/SubviewHeader";
@@ -215,7 +221,19 @@ export const SwapAmount = ({
     return <Loading />;
   }
 
-  const hasError = swapAmountData.state === RequestState.ERROR;
+  if (swapAmountData.state === RequestState.ERROR) {
+    return (
+      <div
+        className="SwapAsset__fetch-fail"
+        data-testid="swap-amount-fetch-fail"
+      >
+        <Notification variant="error" title={t("Failed to load swap data.")}>
+          {t("Your swap data could not be fetched at this time.")}
+        </Notification>
+      </div>
+    );
+  }
+
   if (swapAmountData.data?.type === AppDataType.REROUTE) {
     if (swapAmountData.data.shouldOpenTab) {
       openTab(newTabHref(swapAmountData.data.routeTarget));
@@ -230,15 +248,15 @@ export const SwapAmount = ({
     );
   }
 
-  if (!hasError) {
-    reRouteOnboarding({
-      type: swapAmountData.data.type,
-      applicationState: swapAmountData.data.applicationState,
-      state: swapAmountData.state,
-    });
-  }
+  const data = swapAmountData.data;
 
-  const sendData = swapAmountData.data!;
+  reRouteOnboarding({
+    type: data.type,
+    applicationState: data.applicationState,
+    state: swapAmountData.state,
+  });
+
+  const sendData = data;
   const assetIcon = sendData.icons[asset];
   const dstAssetIcon = sendData.icons[destinationAsset];
   const dstAssetBalance = dstAsset
@@ -271,8 +289,7 @@ export const SwapAmount = ({
         ),
       )}`
     : null;
-  const supportsUsd =
-    isMainnet(swapAmountData.data?.networkDetails!) && assetPrice;
+  const supportsUsd = isMainnet(data.networkDetails) && assetPrice;
   const availableBalance = getAvailableBalance({
     assetCanonical: asset,
     balances: sendData.userBalances.balances,

--- a/extension/src/popup/components/swap/SwapAmount/styles.scss
+++ b/extension/src/popup/components/swap/SwapAmount/styles.scss
@@ -5,6 +5,10 @@
   flex-direction: column;
   height: 100%;
 
+  &__fetch-fail {
+    padding: pxToRem(16px);
+  }
+
   &__subtitle {
     text-align: center;
   }


### PR DESCRIPTION
# Proposal (R4): Guard SwapAmount / SendAmount / AssetVisibility against `RequestState.ERROR` data dereferences

Closes #2758. Follow-up from #2227 / PR #2749. Revised after critic R1, R2, and R3.

## Problem

Three popup views read `State<T, K>` from `constants/request` (the
discriminated request-state union; defined in
`extension/src/constants/request.ts`). Their hooks
(`useGetSwapAmountData`, `useSendAmountData`, `useGetAssetData`) build
`State<T, K>` via the reducer in `extension/src/helpers/request.ts`,
which sets `data: null` and `error: <unknown>` on
`FETCH_DATA_ERROR`. Each view checks `hasError` but does **not**
early-return, then dereferences `…Data.data!` (or `data!.x`)
downstream. Reachable crash paths today:

- `extension/src/popup/components/swap/SwapAmount/index.tsx`: import
  `RequestState` from `constants/request` (line 32). After the
  `isLoading` early return at line 214, `hasError` is computed at 218,
  the REROUTE branch at 219 is null-safe, then
  `if (!hasError) { reRouteOnboarding(...) }` correctly skips on
  error — but the very next line
  `const sendData = swapAmountData.data!` (line 241) is **always**
  evaluated. In `RequestState.ERROR`, `data` is `null` → `TypeError`
  on `sendData.icons[asset]`. `swapAmountData.data?.networkDetails!`
  at line 275 has the same shape on the same path.
- `extension/src/popup/components/send/SendAmount/index.tsx`: imports
  `{ RequestState, State }` from `constants/request` (line 47). Lines
  314–413: after `isLoading` returns at 314, `hasError` at 318,
  REROUTE at 319, `if (!hasError) { reRouteOnboarding(...) }` at 333.
  Then `const sendData = sendAmountData.data!` (line 341),
  `sendAmountData.data?.networkDetails!` (line 380), and
  `priceValue!` (line 411) all run. Same crash on ERROR.
- `extension/src/popup/components/manageAssets/AssetVisibility/index.tsx`:
  imports `RequestState` from `constants/request` (line 15).
  REROUTE check at line 63 is null-safe,
  `if (!isLoading && !hasError) { reRouteOnboarding(...) }` at line
  77 correctly skips on error, but the JSX at line 91 renders
  `isLoading ? <loader/> : <wrapper>` — `isLoading` is false in
  ERROR, so the renderer reaches `domainState.data!.domains` (line
  106), `domainState.data!.hiddenAssets` (107), and
  `data!.publicKey` (118). `data` (= `domainState.data`) is null →
  crash.

`AddAsset` (which uses `helpers/hooks/fetchHookInterface` instead) is
*not* in this list — it already implements the early-return pattern
this PR adopts and is referenced as a code sample only.

## Approach

Apply the **convention already used in `AddAsset` and `Wallets`**:
early-return an inline `<Notification variant="error">` wrapped in a
view-local `__fetch-fail` div, **before** any `data!` dereference.

`State<T, K>` from `constants/request` is a discriminated union on
`state: RequestState`; only the `SuccessState<T>` variant has non-null
`data`. The success payloads are:

- `SwapAmount`: `T = NeedsReRoute | ResolvedSwapAmountData`
- `SendAmount`: `T = NeedsReRoute | ResolvedSendAmountData`
- `AssetVisibility`: `T = NeedsReRoute | ResolvedAssetVisibilityData`

After three sequential early returns —
(1) `isLoading` → `<Loading />` / inline loader,
(2) `hasError` → error notification,
(3) `data?.type === AppDataType.REROUTE` → `<Navigate>` —
TypeScript strict mode narrows `…Data` to `SuccessState<Resolved…>`,
so `…Data.data` is non-null and is the resolved variant. **The
implementation binds `const data = …Data.data` once after the guards
and uses it everywhere downstream — no `?.` chains, no `!` non-null
assertions on the success path.** This is a hard rule for this PR;
the changes below remove every existing `!` / `?.…!` access on
`data` in each component.

### No new shared component, no new hook

The bug is a runtime crash, not a styling debt. Introducing a shared
component for only three new sites while leaving the three existing
ones (`AddAsset__fetch-fail`, `Wallets__fail`, `AccountView__fetch-fail`
— the last has its own `animateNotification` keyframe and
`margin-top: 1.5rem` at `Account/styles.scss:44-47`) on the old
pattern would add a fourth pattern, not consolidate. A typed
`useResolvedState` projection has heterogeneous consumers (`Account`
intentionally renders past ERROR) and is design-doc territory. Both
deferred to a follow-up issue (Step 6 below).

## Changes

### 1. `extension/src/popup/components/swap/SwapAmount/index.tsx`

Add `Notification` to the existing `@stellar/design-system` import on
line 8 (currently
`import { Button, Card, Icon, Input } from "@stellar/design-system";`).
Replace the lines ~214–275 region with:

```tsx
if (isLoading) {
  return <Loading />;
}

const hasError = swapAmountData.state === RequestState.ERROR;
if (hasError) {
  return (
    <div
      className="SwapAsset__fetch-fail"
      data-testid="swap-amount-fetch-fail"
    >
      <Notification
        variant="error"
        title={t("Failed to load swap data.")}
      >
        {t("Your swap data could not be fetched at this time.")}
      </Notification>
    </div>
  );
}

if (swapAmountData.data?.type === AppDataType.REROUTE) {
  // unchanged Navigate block
}

// Past the guards above, swapAmountData is SuccessState<ResolvedSwapAmountData>.
const data = swapAmountData.data;

reRouteOnboarding({
  type: data.type,
  applicationState: data.applicationState,
  state: swapAmountData.state,
});

// Replace every `swapAmountData.data!` and `swapAmountData.data?.…!`
// in the rest of the function with `data.…`. Concretely:
//   const sendData = data;
//   …
//   const supportsUsd = isMainnet(data.networkDetails) && assetPrice;
```

Drop the existing `if (!hasError) { reRouteOnboarding(...) }` wrapper —
control no longer reaches it on ERROR.

SCSS: add to `extension/src/popup/components/swap/SwapAmount/styles.scss`
under the existing `.SwapAsset` root (this file is rooted at
`.SwapAsset`, not `.SwapAmount` — important):

```scss
.SwapAsset {
  // existing rules…

  &__fetch-fail {
    padding: pxToRem(16px);
  }
}
```

`pxToRem` is already in scope via the existing
`@use "../../../styles/utils.scss" as *;` in that file.

### 2. `extension/src/popup/components/send/SendAmount/index.tsx`

`Notification` is already imported by SendAmount
(`extension/src/popup/components/send/SendAmount/index.tsx:6`). Insert
immediately after the
`isLoading` guard at line 314:

```tsx
if (isLoading) {
  return <Loading />;
}

const hasError = sendAmountData.state === RequestState.ERROR;
if (hasError) {
  return (
    <div
      className="SendAmount__fetch-fail"
      data-testid="send-amount-fetch-fail"
    >
      <Notification
        variant="error"
        title={t("Failed to load send data.")}
      >
        {t("Your send data could not be fetched at this time.")}
      </Notification>
    </div>
  );
}

if (sendAmountData.data?.type === AppDataType.REROUTE) {
  // unchanged Navigate block
}

const data = sendAmountData.data;

reRouteOnboarding({
  type: data.type,
  applicationState: data.applicationState,
  state: sendAmountData.state,
});

// Then in the rest of the function, replace every
// `sendAmountData.data!` and `sendAmountData.data?.networkDetails!`
// with `data.…`. Note: there is also a `sendAmountData.data?.networkDetails!`
// at SendAmount/index.tsx:826 (later in the JSX) — replace it too. The
// `priceValue!` non-null assertion at the `isAmountTooHigh` computation
// depends on the local `assetPrice` guard, not on data nullability —
// leave it untouched.
```

SCSS: SendAmount imports `../styles.scss` (the parent `send/styles.scss`),
which is rooted at `.SendAmount`. Add:

```scss
.SendAmount {
  // existing rules…

  &__fetch-fail {
    padding: pxToRem(16px);
  }
}
```

`pxToRem` is in scope via the existing `@use "../../styles/utils.scss" as *;`
in that file.

### 3. `extension/src/popup/components/manageAssets/AssetVisibility/index.tsx`

Add `Notification` to the existing `@stellar/design-system` import on
line 5 (currently `import { Loader } from "@stellar/design-system";`).
Insert the early-return *before* the REROUTE check, since this view
inlines its loader rather than top-level early-returning on loading:

```tsx
const isLoading =
  domainState.state === RequestState.IDLE ||
  domainState.state === RequestState.LOADING;

const hasError = domainState.state === RequestState.ERROR;
if (hasError) {
  return (
    <div
      className="ToggleAsset__fetch-fail"
      data-testid="asset-visibility-fetch-fail"
    >
      <Notification
        variant="error"
        title={t("Failed to load assets.")}
      >
        {t("Your assets could not be fetched at this time.")}
      </Notification>
    </div>
  );
}

if (domainState.data?.type === AppDataType.REROUTE) {
  // unchanged Navigate block
}

// `data` is null only while loading; non-null and resolved in every
// other reachable branch (ERROR returned early, REROUTE returned
// early, SUCCESS reaches here).
const data = domainState.data;

if (!isLoading && data) {
  reRouteOnboarding({
    type: data.type,
    applicationState: data.applicationState,
    state: domainState.state,
  });
}

return (
  <>
    <SubviewHeader customBackAction={goBack} title={t("Toggle Assets")} />
    <View.Content hasNoTopPadding>
      {isLoading || !data ? (
        <div className="ToggleAsset__loader">
          <Loader size="2rem" />
        </div>
      ) : (
        <div className="ToggleAsset__wrapper">
          <div
            className={`ToggleAsset__assets${
              data.isManagingAssets && isSorobanSuported ? "--short" : ""
            }`}
            ref={ManageAssetRowsWrapperRef}
          >
            <ToggleAssetRows
              assetRows={data.domains}
              hiddenAssets={data.hiddenAssets}
              changeAssetVisibility={async ({ issuer, visibility }) =>
                changeAssetVisibility({
                  issuer,
                  visibility,
                  publicKey: data.publicKey,
                })
              }
            />
          </div>
        </div>
      )}
    </View.Content>
  </>
);
```

`isLoading || !data` is the explicit, non-asserting form of
"loading branch shows the loader; otherwise renders the resolved
data". No `!` after the guards.

SCSS: AssetVisibility imports `./styles.scss`, rooted at `.ToggleAsset`.
That file does **not** currently `@use ".../utils.scss"`, so add the
use line at the top, then the rule inside `.ToggleAsset`:

```scss
// Top of extension/src/popup/components/manageAssets/AssetVisibility/styles.scss
@use "../../../styles/utils.scss" as *;

.ToggleAsset {
  // existing rules…

  &__fetch-fail {
    padding: pxToRem(16px);
  }
}
```

(Path verified: `extension/src/popup/components/manageAssets/AssetVisibility/styles.scss`
→ `extension/src/popup/styles/utils.scss` is `../../../styles/utils.scss`.)

### 4. Regression tests (one per component)

Three new standalone tests under `__tests__` siblings to each
component. Each is **independent** of the skipped `Swap.test.tsx`
view-level scaffolding.

Test files:

```
extension/src/popup/components/swap/SwapAmount/__tests__/SwapAmount.errorState.test.tsx
extension/src/popup/components/send/SendAmount/__tests__/SendAmount.errorState.test.tsx
extension/src/popup/components/manageAssets/AssetVisibility/__tests__/AssetVisibility.errorState.test.tsx
```

Use `Wrapper` from `popup/__testHelpers__` (named export at
`extension/src/popup/__testHelpers__/index.tsx:49`). Spy on the
data-fetching hook to return `RequestState.ERROR`, plus mock any
other hooks called before the early return (the ERROR path bails
before formik/Sentry/etc., but `useNetworkFees` runs at the top of
SwapAmount/SendAmount and must be mocked).

Concrete shape for SwapAmount:

```tsx
import { render, screen } from "@testing-library/react";
import * as UseGetSwapAmountData from "popup/components/swap/SwapAmount/hooks/useGetSwapAmountData";
import * as UseNetworkFees from "popup/helpers/useNetworkFees";
import { RequestState } from "constants/request";
import { Wrapper } from "popup/__testHelpers__";
import { SwapAmount } from "popup/components/swap/SwapAmount";

jest.spyOn(UseNetworkFees, "useNetworkFees").mockImplementation(() => ({
  networkCongestion: "LOW",
  recommendedFee: "0.00001",
} as any));

describe("SwapAmount RequestState.ERROR", () => {
  it("renders the fetch-fail notification without throwing", () => {
    jest
      .spyOn(UseGetSwapAmountData, "useGetSwapAmountData")
      .mockReturnValue({
        state: { state: RequestState.ERROR, data: null, error: new Error("boom") },
        fetchData: jest.fn().mockResolvedValue(undefined),
      } as any);

    render(
      <Wrapper state={{}}>
        <SwapAmount
          inputType="crypto"
          setInputType={jest.fn()}
          goBack={jest.fn()}
          goToNext={jest.fn()}
          goToEditSrc={jest.fn()}
          goToEditDst={jest.fn()}
        />
      </Wrapper>,
    );

    expect(
      screen.getByTestId("swap-amount-fetch-fail"),
    ).toBeInTheDocument();
  });
});
```

For SendAmount: same structure, but **do not mock `useNetworkFees`** —
`SendAmount` does not call that hook (it's called by the parent
`popup/views/Send/index.tsx` and the values are passed in as
`networkCongestion` / `recommendedFee` props). Pass them directly
in the test props instead. Pass minimal required props including
`simulationState: { state: RequestState.IDLE, data: null, error: null }`
(verified safe — SendAmount does not read `simulationState` before
the error early-return; its uses are in the rendered footer/buttons,
which are unreachable on ERROR), `networkCongestion: "LOW" as any`,
and `recommendedFee: "0.00001"`. Spy on `useGetSendAmountData` (path:
`popup/components/send/SendAmount/hooks/useSendAmountData`).

For AssetVisibility: simplest — no props, no `useNetworkFees`. Spy
on `useGetAssetData` (path:
`popup/components/manageAssets/AssetVisibility/hooks/useGetAssetData`)
and assert `asset-visibility-fetch-fail` testid renders.

Each test is a single `it` that asserts the rendered fetch-fail
testid. RTL surfaces the regression-time `TypeError` automatically.

### 5. Verification

Inside the worktree:

```
yarn test:ci
yarn build:extension
```

Both must pass. (Per repo memory, these are the canonical validation
commands.)

### 6. Deferred follow-up

File one issue: "Consolidate popup `__fetch-fail` blocks behind a
shared component / typed `useResolvedState` projection". Mention:

- Six current call sites: `AddAsset__fetch-fail`, `Wallets__fail`,
  `AccountView__fetch-fail`, plus the three added by this PR
  (`SwapAsset__fetch-fail`, `SendAmount__fetch-fail`,
  `ToggleAsset__fetch-fail`).
- Visual differences worth preserving: `AccountView__fetch-fail`
  has the `animateNotification` keyframe and `margin-top: 1.5rem`
  (`Account/styles.scss:44-47`).
- The hook-level refactor (typed projection of `State<T, K>`) is
  the more ambitious form; call it design-doc-worthy before any
  implementation, because some consumers (`Account`) intentionally
  render past ERROR with partial defaults, which is incompatible
  with a hook that hard-returns an error UI.

## Out of scope

- Migrating existing fetch-fail call sites or introducing the
  shared component / hook — see Deferred follow-up.
- Touching `fetchHookInterface.tsx` / `helpers/request.ts` /
  `constants/request.ts` themselves.
- Behavior changes for the SUCCESS / REROUTE / LOADING paths.
- The unrelated `priceValue!` non-null assertion in SendAmount —
  it depends on `assetPrice` truthiness, not on data nullability.

## Risk

- **Inline SCSS rule placement**: each component owns its
  `__fetch-fail` class on the existing root (`.SwapAsset`,
  `.SendAmount`, `.ToggleAsset`). No collisions; the class is
  scoped under each file's root selector.
- **Reroute path unchanged**: the REROUTE check still runs after
  the ERROR early return, exactly as today. No behavior change for
  the success or reroute flows.
- **`reRouteOnboarding` post-guard call**: safe.
  `popup/helpers/route.ts` only acts when `type === AppDataType.RESOLVED`
  and the application state is one of the onboarding restart
  states. Past the REROUTE early return, only resolved data
  reaches the call.
- **Leaf views**: `SwapAmount`, `SendAmount`, and `AssetVisibility`
  are leaf views in their respective parents (`Swap`, `Send`,
  `ManageAssets`). Returning a different element on ERROR doesn't
  affect parent control flow.


---

Closes #2758