### PR TITLE
Fix submitProduction workflow secrets references

### DIFF
--- a/.github/workflows/submitProduction.yml
+++ b/.github/workflows/submitProduction.yml
@@ -2,6 +2,9 @@ name: Production Deployment
 env:
   INDEXER_URL: ${{ secrets.INDEXER_URL }}
   INDEXER_V2_URL: ${{ secrets.INDEXER_V2_URL }}
+  SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+  SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
   HUSKY: 0
 on:
   workflow_dispatch:
@@ -29,17 +32,17 @@ jobs:
           echo "Missing INDEXER_V2_URL"
           gh run cancel ${{ github.run_id }}
           gh run watch ${{ github.run_id }}
-      - if: ${{ secrets.SENTRY_ORG == '' }}
+      - if: ${{ env.SENTRY_ORG == '' }}
         run: |
           echo "Missing SENTRY_ORG"
           gh run cancel ${{ github.run_id }}
           gh run watch ${{ github.run_id }}
-      - if: ${{ secrets.SENTRY_PROJECT == '' }}
+      - if: ${{ env.SENTRY_PROJECT == '' }}
         run: |
           echo "Missing SENTRY_PROJECT"
           gh run cancel ${{ github.run_id }}
           gh run watch ${{ github.run_id }}
-      - if: ${{ secrets.SENTRY_AUTH_TOKEN == '' }}
+      - if: ${{ env.SENTRY_AUTH_TOKEN == '' }}
         run: |
           echo "Missing SENTRY_AUTH_TOKEN"
           gh run cancel ${{ github.run_id }}

--- a/.github/workflows/submitProduction.yml
+++ b/.github/workflows/submitProduction.yml
@@ -2,9 +2,6 @@ name: Production Deployment
 env:
   INDEXER_URL: ${{ secrets.INDEXER_URL }}
   INDEXER_V2_URL: ${{ secrets.INDEXER_V2_URL }}
-  SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-  SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
   HUSKY: 0
 on:
   workflow_dispatch:
@@ -32,21 +29,20 @@ jobs:
           echo "Missing INDEXER_V2_URL"
           gh run cancel ${{ github.run_id }}
           gh run watch ${{ github.run_id }}
-      - if: ${{ env.SENTRY_ORG == '' }}
+      - name: Validate Sentry secrets
+        env:
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          echo "Missing SENTRY_ORG"
-          gh run cancel ${{ github.run_id }}
-          gh run watch ${{ github.run_id }}
-      - if: ${{ env.SENTRY_PROJECT == '' }}
-        run: |
-          echo "Missing SENTRY_PROJECT"
-          gh run cancel ${{ github.run_id }}
-          gh run watch ${{ github.run_id }}
-      - if: ${{ env.SENTRY_AUTH_TOKEN == '' }}
-        run: |
-          echo "Missing SENTRY_AUTH_TOKEN"
-          gh run cancel ${{ github.run_id }}
-          gh run watch ${{ github.run_id }}
+          missing=()
+          [ -z "$SENTRY_ORG" ] && missing+=("SENTRY_ORG")
+          [ -z "$SENTRY_PROJECT" ] && missing+=("SENTRY_PROJECT")
+          [ -z "$SENTRY_AUTH_TOKEN" ] && missing+=("SENTRY_AUTH_TOKEN")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "Missing secrets: ${missing[*]}"
+            exit 1
+          fi
       - name: Checkout code
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- The Sentry env-var guards in `.github/workflows/submitProduction.yml` referenced `secrets.SENTRY_*` inside step-level `if:` expressions, which GitHub Actions does not allow (`Unrecognized named-value: 'secrets'`). The workflow failed to queue.
- The three separate guard steps are collapsed into a single `Validate Sentry secrets` step whose **local** `env:` pulls in the Sentry secrets. This is intentional for security: keeping the secrets in a step-scoped `env:` (instead of the workflow-level `env:`) means `SENTRY_AUTH_TOKEN` is **not** exposed to the process environment of the other steps in the job — including all third-party actions (`montudor/action-zip`, `kewisch/action-web-ext`, `restackio/update-json-file-action`, `mnao305/chrome-extension-upload`, `rtCamp/action-slack-notify`). Only the validation step and the existing build step (which already declares its own local `env:`) see the token.
- The validation step uses a plain `exit 1` to fail the job when a secret is missing, replacing the previous `gh run cancel` + `gh run watch` dance.

<img width="1380" height="265" alt="Screenshot 2026-05-15 at 13 12 25" src="https://github.com/user-attachments/assets/ea178b81-7e39-446a-81cb-802e3619d535" />

## Test plan
- [ ] Trigger the `Production Deployment` workflow via `workflow_dispatch` and confirm it queues without the parse error.
- [ ] Confirm the validation step fails the job (with the list of missing names in the log) when any of the three Sentry secrets is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)