### PR TITLE
chore: drop legacy pre-SEP-53 signMessage code path

### DIFF
--- a/extension/src/background/messageListener/__tests__/signBlob.test.ts
+++ b/extension/src/background/messageListener/__tests__/signBlob.test.ts
@@ -243,4 +243,93 @@ describe("signBlob handler", () => {
 
     expect(result).toEqual({ error: "Session timed out" });
   });
+
+  it("applies SEP-53 framing when apiVersion is legacy (3.0.0)", async () => {
+    const stellarHelpers = require("helpers/stellar");
+    blobQueue.push(makeBlobData("uuid-1"));
+    responseQueue.push({
+      response: mockResponseFn,
+      uuid: "uuid-1",
+      createdAt: Date.now(),
+    });
+
+    const request: SignBlobMessage = {
+      type: SERVICE_TYPES.SIGN_BLOB,
+      activePublicKey: MOCK_PUBLIC_KEY,
+      uuid: "uuid-1",
+      apiVersion: "3.0.0",
+    };
+
+    await signBlob({
+      request,
+      localStore: mockLocalStore,
+      sessionStore: mockSessionStore,
+      blobQueue,
+      responseQueue,
+    });
+
+    expect(stellarHelpers.encodeSep53Message).toHaveBeenCalledWith(
+      btoa("test-message"),
+    );
+    expect(mockResponseFn).toHaveBeenCalled();
+  });
+
+  it("applies SEP-53 framing when apiVersion is missing", async () => {
+    const stellarHelpers = require("helpers/stellar");
+    blobQueue.push(makeBlobData("uuid-1"));
+    responseQueue.push({
+      response: mockResponseFn,
+      uuid: "uuid-1",
+      createdAt: Date.now(),
+    });
+
+    const request: SignBlobMessage = {
+      type: SERVICE_TYPES.SIGN_BLOB,
+      activePublicKey: MOCK_PUBLIC_KEY,
+      uuid: "uuid-1",
+    };
+
+    await signBlob({
+      request,
+      localStore: mockLocalStore,
+      sessionStore: mockSessionStore,
+      blobQueue,
+      responseQueue,
+    });
+
+    expect(stellarHelpers.encodeSep53Message).toHaveBeenCalledWith(
+      btoa("test-message"),
+    );
+    expect(mockResponseFn).toHaveBeenCalled();
+  });
+
+  it("applies SEP-53 framing when apiVersion is current (5.0.0)", async () => {
+    const stellarHelpers = require("helpers/stellar");
+    blobQueue.push(makeBlobData("uuid-1"));
+    responseQueue.push({
+      response: mockResponseFn,
+      uuid: "uuid-1",
+      createdAt: Date.now(),
+    });
+
+    const request: SignBlobMessage = {
+      type: SERVICE_TYPES.SIGN_BLOB,
+      activePublicKey: MOCK_PUBLIC_KEY,
+      uuid: "uuid-1",
+      apiVersion: "5.0.0",
+    };
+
+    await signBlob({
+      request,
+      localStore: mockLocalStore,
+      sessionStore: mockSessionStore,
+      blobQueue,
+      responseQueue,
+    });
+
+    expect(stellarHelpers.encodeSep53Message).toHaveBeenCalledWith(
+      btoa("test-message"),
+    );
+    expect(mockResponseFn).toHaveBeenCalled();
+  });
 });

--- a/extension/src/background/messageListener/__tests__/signBlob.test.ts
+++ b/extension/src/background/messageListener/__tests__/signBlob.test.ts
@@ -58,7 +58,7 @@ const makeBlobData = (uuid: string) => ({
   blob: {
     apiVersion: "5.0.0",
     domain: "example.com",
-    message: btoa("test-message"),
+    message: "test-message",
     url: "https://example.com",
     uuid,
   } as any,
@@ -269,7 +269,7 @@ describe("signBlob handler", () => {
     });
 
     expect(stellarHelpers.encodeSep53Message).toHaveBeenCalledWith(
-      btoa("test-message"),
+      "test-message",
     );
     expect(mockResponseFn).toHaveBeenCalled();
   });
@@ -298,7 +298,7 @@ describe("signBlob handler", () => {
     });
 
     expect(stellarHelpers.encodeSep53Message).toHaveBeenCalledWith(
-      btoa("test-message"),
+      "test-message",
     );
     expect(mockResponseFn).toHaveBeenCalled();
   });
@@ -328,7 +328,7 @@ describe("signBlob handler", () => {
     });
 
     expect(stellarHelpers.encodeSep53Message).toHaveBeenCalledWith(
-      btoa("test-message"),
+      "test-message",
     );
     expect(mockResponseFn).toHaveBeenCalled();
   });

--- a/extension/src/background/messageListener/handlers/signBlob.ts
+++ b/extension/src/background/messageListener/handlers/signBlob.ts
@@ -1,12 +1,11 @@
 import { Store } from "redux";
-import semver from "semver";
 import { captureException } from "@sentry/browser";
 
 import { DataStorageAccess } from "background/helpers/dataStorageAccess";
 import { getEncryptedTemporaryData } from "background/helpers/session";
 import { KEY_ID } from "constants/localStorageTypes";
 import { getNetworkDetails } from "background/helpers/account";
-import { getSdk, isPlaywright } from "@shared/helpers/stellar";
+import { getSdk } from "@shared/helpers/stellar";
 import {
   BlobQueue,
   ResponseQueue,
@@ -28,7 +27,7 @@ export const signBlob = async ({
   blobQueue: BlobQueue;
   responseQueue: ResponseQueue<SignBlobResponse>;
 }) => {
-  const { uuid, apiVersion } = request;
+  const { uuid } = request;
 
   if (!uuid) {
     captureException("signBlob: missing uuid in request");
@@ -64,11 +63,7 @@ export const signBlob = async ({
       return { error: "Transaction not found" };
     }
 
-    const supportsSep53 =
-      (apiVersion && semver.gte(apiVersion, "5.0.0")) || isPlaywright;
-    const signPayload = supportsSep53
-      ? encodeSep53Message(blob.message)
-      : Buffer.from(blob.message, "base64");
+    const signPayload = encodeSep53Message(blob.message);
     const response = sourceKeys.sign(signPayload);
 
     const responseIndex = responseQueue.findIndex((item) => item.uuid === uuid);


### PR DESCRIPTION
## Summary
- Removes the `apiVersion`-gated legacy branch in `signBlob`. SEP-53 framing (`SHA-256("Stellar Signed Message:\n" || msg)`) is now the only signing path.
- Adds tests covering legacy (`3.0.0`), missing, and current (`5.0.0`) `apiVersion` values — all routed through `encodeSep53Message`.

## Why
All supported `@stellar/freighter-api` clients are on `5.0.0+`. The pre-5.0.0 compatibility branch is no longer needed; collapsing to a single signing path removes a version-gated code path that no current client exercises.

## Test plan
- [x] `yarn jest --testPathPattern signBlob` — 9/9 pass (3 new)
- [x] Lint + build clean on touched files
- [ ] Manual: confirm a current-version dapp still completes the Sign Message flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)