### PR TITLE
Restore submitProduction Sentry secrets fix on release (re-apply #2783)

### DIFF
--- a/.github/workflows/submitProduction.yml
+++ b/.github/workflows/submitProduction.yml
@@ -2,6 +2,9 @@ name: Production Deployment
 env:
   INDEXER_URL: ${{ secrets.INDEXER_URL }}
   INDEXER_V2_URL: ${{ secrets.INDEXER_V2_URL }}
+  SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+  SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
   HUSKY: 0
 on:
   workflow_dispatch:
@@ -29,17 +32,17 @@ jobs:
           echo "Missing INDEXER_V2_URL"
           gh run cancel ${{ github.run_id }}
           gh run watch ${{ github.run_id }}
-      - if: ${{ secrets.SENTRY_ORG == '' }}
+      - if: ${{ env.SENTRY_ORG == '' }}
         run: |
           echo "Missing SENTRY_ORG"
           gh run cancel ${{ github.run_id }}
           gh run watch ${{ github.run_id }}
-      - if: ${{ secrets.SENTRY_PROJECT == '' }}
+      - if: ${{ env.SENTRY_PROJECT == '' }}
         run: |
           echo "Missing SENTRY_PROJECT"
           gh run cancel ${{ github.run_id }}
           gh run watch ${{ github.run_id }}
-      - if: ${{ secrets.SENTRY_AUTH_TOKEN == '' }}
+      - if: ${{ env.SENTRY_AUTH_TOKEN == '' }}
         run: |
           echo "Missing SENTRY_AUTH_TOKEN"
           gh run cancel ${{ github.run_id }}

--- a/.github/workflows/submitProduction.yml
+++ b/.github/workflows/submitProduction.yml
@@ -2,9 +2,6 @@ name: Production Deployment
 env:
   INDEXER_URL: ${{ secrets.INDEXER_URL }}
   INDEXER_V2_URL: ${{ secrets.INDEXER_V2_URL }}
-  SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-  SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
   HUSKY: 0
 on:
   workflow_dispatch:
@@ -32,21 +29,20 @@ jobs:
           echo "Missing INDEXER_V2_URL"
           gh run cancel ${{ github.run_id }}
           gh run watch ${{ github.run_id }}
-      - if: ${{ env.SENTRY_ORG == '' }}
+      - name: Validate Sentry secrets
+        env:
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          echo "Missing SENTRY_ORG"
-          gh run cancel ${{ github.run_id }}
-          gh run watch ${{ github.run_id }}
-      - if: ${{ env.SENTRY_PROJECT == '' }}
-        run: |
-          echo "Missing SENTRY_PROJECT"
-          gh run cancel ${{ github.run_id }}
-          gh run watch ${{ github.run_id }}
-      - if: ${{ env.SENTRY_AUTH_TOKEN == '' }}
-        run: |
-          echo "Missing SENTRY_AUTH_TOKEN"
-          gh run cancel ${{ github.run_id }}
-          gh run watch ${{ github.run_id }}
+          missing=()
+          [ -z "$SENTRY_ORG" ] && missing+=("SENTRY_ORG")
+          [ -z "$SENTRY_PROJECT" ] && missing+=("SENTRY_PROJECT")
+          [ -z "$SENTRY_AUTH_TOKEN" ] && missing+=("SENTRY_AUTH_TOKEN")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "Missing secrets: ${missing[*]}"
+            exit 1
+          fi
       - name: Checkout code
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

Re-applies the two commits from #2783, which was merged into `release` on 2026-05-15 at commit `48ccfb2a` but was orphaned by a later force-push/reset — the merge commit is no longer reachable from `release`, and the current `submitProduction.yml` still has the broken `if: ${{ secrets.SENTRY_ORG == '' }}` pattern that GitHub Actions rejects ("Unrecognized named-value: 'secrets'").

The two commits cherry-picked from #2783:

- `Fix submitProduction workflow secrets references` — map Sentry secrets into the workflow-level `env:` block and check via `env.*`, matching the existing `INDEXER_*` pattern.
- `Scope Sentry secrets to the validation step only` — collapse the three guard steps into one `Validate Sentry secrets` step with a local `env:` block (credentials no longer in every step's process environment) and replace the `gh run cancel` dance with `exit 1`.

## Test plan

- [ ] Trigger `submitProduction` workflow and confirm it no longer fails at expression parse time
- [ ] Confirm the validation step fails fast with `Missing secrets: …` when any Sentry secret is absent
- [ ] Confirm SENTRY_ORG / SENTRY_PROJECT / SENTRY_AUTH_TOKEN are no longer in the process environment of unrelated steps

Original PR: #2783