### PR TITLE
Sort token pickers by USD value via TokenList

### DIFF
--- a/extension/src/popup/components/InternalTransaction/TokenList/__tests__/TokenList.test.tsx
+++ b/extension/src/popup/components/InternalTransaction/TokenList/__tests__/TokenList.test.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import BigNumber from "bignumber.js";
+
+import { defaultBlockaidScanAssetResult } from "@shared/helpers/stellar";
+
+import { TokenList } from "../index";
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("popup/components/account/AccountAssets", () => ({
+  AssetIcon: () => <div data-testid="asset-icon" />,
+}));
+
+const USDC_ISSUER = "GCK3D3V2XNLLKRFGFFFDEJXA4O2J4X36HET2FE446AV3M4U7DPHO3PEM";
+const AQUA_ISSUER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+
+const USDC_CANONICAL = `USDC:${USDC_ISSUER}`;
+const AQUA_CANONICAL = `AQUA:${AQUA_ISSUER}`;
+
+const XLM_BALANCE = {
+  token: { code: "XLM", type: "native" as const },
+  total: new BigNumber("500"),
+  available: new BigNumber("500"),
+  blockaidData: defaultBlockaidScanAssetResult,
+};
+
+const USDC_BALANCE = {
+  token: {
+    code: "USDC",
+    issuer: { key: USDC_ISSUER },
+  },
+  total: new BigNumber("200"),
+  available: new BigNumber("200"),
+  blockaidData: defaultBlockaidScanAssetResult,
+};
+
+const AQUA_BALANCE = {
+  token: {
+    code: "AQUA",
+    issuer: { key: AQUA_ISSUER },
+  },
+  total: new BigNumber("10000"),
+  available: new BigNumber("10000"),
+  blockaidData: defaultBlockaidScanAssetResult,
+};
+
+const LP_BALANCE = {
+  liquidityPoolId:
+    "a468d41d8e9b8f3c7209651608b74b7db7ac9952dcae0cdf24871d1d9c7b0088",
+  total: new BigNumber("10"),
+  limit: new BigNumber("100"),
+};
+
+const TOKEN_PRICES = {
+  native: { currentPrice: "0.10" },
+  [USDC_CANONICAL]: { currentPrice: "1.00" },
+  [AQUA_CANONICAL]: { currentPrice: "0.005" },
+};
+
+const defaultProps = {
+  icons: {},
+  tokenPrices: TOKEN_PRICES,
+  onClickAsset: jest.fn(),
+  hiddenAssets: [] as string[],
+};
+
+describe("TokenList", () => {
+  describe("value sort ordering", () => {
+    it("renders tokens in descending USD value order", () => {
+      // USDC: 200 * 1.00 = $200
+      // XLM: 500 * 0.10 = $50
+      // AQUA: 10000 * 0.005 = $50 (tie with XLM, preserves input order)
+      const tokens = [XLM_BALANCE, USDC_BALANCE, AQUA_BALANCE] as any[];
+
+      render(<TokenList {...defaultProps} tokens={tokens} />);
+
+      const rows = screen.getAllByTestId(/^SendRow-/);
+      expect(rows[0]).toHaveAttribute("data-testid", `SendRow-${USDC_CANONICAL}`);
+      expect(rows[1]).toHaveAttribute("data-testid", "SendRow-native");
+      expect(rows[2]).toHaveAttribute("data-testid", `SendRow-${AQUA_CANONICAL}`);
+    });
+
+    it("preserves original order when tokenPrices is empty", () => {
+      const tokens = [XLM_BALANCE, USDC_BALANCE, AQUA_BALANCE] as any[];
+
+      render(<TokenList {...defaultProps} tokens={tokens} tokenPrices={{}} />);
+
+      const rows = screen.getAllByTestId(/^SendRow-/);
+      expect(rows[0]).toHaveAttribute("data-testid", "SendRow-native");
+      expect(rows[1]).toHaveAttribute("data-testid", `SendRow-${USDC_CANONICAL}`);
+      expect(rows[2]).toHaveAttribute("data-testid", `SendRow-${AQUA_CANONICAL}`);
+    });
+
+    it("sorts priced assets before unpriced ones", () => {
+      const partialPrices = {
+        [USDC_CANONICAL]: { currentPrice: "1.00" },
+      };
+      const tokens = [XLM_BALANCE, AQUA_BALANCE, USDC_BALANCE] as any[];
+
+      render(
+        <TokenList {...defaultProps} tokens={tokens} tokenPrices={partialPrices} />,
+      );
+
+      const rows = screen.getAllByTestId(/^SendRow-/);
+      // USDC (priced) comes first
+      expect(rows[0]).toHaveAttribute("data-testid", `SendRow-${USDC_CANONICAL}`);
+      // Unpriced assets preserve input order
+      expect(rows[1]).toHaveAttribute("data-testid", "SendRow-native");
+      expect(rows[2]).toHaveAttribute("data-testid", `SendRow-${AQUA_CANONICAL}`);
+    });
+  });
+
+  describe("filtering", () => {
+    it("excludes LP share assets from the list", () => {
+      const tokens = [XLM_BALANCE, LP_BALANCE, USDC_BALANCE] as any[];
+
+      render(<TokenList {...defaultProps} tokens={tokens} />);
+
+      const rows = screen.getAllByTestId(/^SendRow-/);
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toHaveAttribute("data-testid", `SendRow-${USDC_CANONICAL}`);
+      expect(rows[1]).toHaveAttribute("data-testid", "SendRow-native");
+    });
+
+    it("excludes hidden assets from the list", () => {
+      const tokens = [XLM_BALANCE, USDC_BALANCE, AQUA_BALANCE] as any[];
+      const hiddenAssets = [USDC_CANONICAL];
+
+      render(
+        <TokenList {...defaultProps} tokens={tokens} hiddenAssets={hiddenAssets} />,
+      );
+
+      const rows = screen.getAllByTestId(/^SendRow-/);
+      expect(rows).toHaveLength(2);
+      // USDC is hidden, XLM and AQUA remain (sorted by value)
+      expect(rows[0]).toHaveAttribute("data-testid", "SendRow-native");
+      expect(rows[1]).toHaveAttribute("data-testid", `SendRow-${AQUA_CANONICAL}`);
+    });
+  });
+
+  it("shows empty state when no tokens provided", () => {
+    render(<TokenList {...defaultProps} tokens={[]} />);
+
+    expect(
+      screen.getByText(
+        "You have no assets added. Get started by adding an asset.",
+      ),
+    ).toBeDefined();
+  });
+});

--- a/extension/src/popup/components/InternalTransaction/TokenList/index.tsx
+++ b/extension/src/popup/components/InternalTransaction/TokenList/index.tsx
@@ -11,6 +11,7 @@ import { getCanonicalFromAsset } from "helpers/stellar";
 import { ApiTokenPrices, AssetIcons } from "@shared/api/types";
 import { getAvailableBalance } from "popup/helpers/soroban";
 import { formatAmount, roundUsdValue } from "popup/helpers/formatters";
+import { sortBalancesByValue } from "popup/helpers/balance";
 import { AssetIcon } from "popup/components/account/AccountAssets";
 import { title } from "helpers/transaction";
 
@@ -34,6 +35,7 @@ export const TokenList = ({
   isShowingHeader,
 }: TokenListProps) => {
   const { t } = useTranslation();
+  const sortedTokens = sortBalancesByValue(tokens, tokenPrices);
   return (
     <div
       className={classnames("TokenList__Assets", {
@@ -41,7 +43,7 @@ export const TokenList = ({
       })}
       data-testid="token-list"
     >
-      {!tokens.length ? (
+      {!sortedTokens.length ? (
         <div className="TokenList__Assets__empty">
           {`${t("You have no assets added.")} ${t("Get started by adding an asset.")}`}
         </div>
@@ -50,7 +52,7 @@ export const TokenList = ({
           {isShowingHeader && (
             <div className="TokenList__Assets__Header">{t("Your Tokens")}</div>
           )}
-          {tokens
+          {sortedTokens
             .filter(
               (
                 balance,

--- a/extension/src/popup/components/InternalTransaction/TokenList/index.tsx
+++ b/extension/src/popup/components/InternalTransaction/TokenList/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import BigNumber from "bignumber.js";
 import classnames from "classnames";
@@ -35,7 +35,10 @@ export const TokenList = ({
   isShowingHeader,
 }: TokenListProps) => {
   const { t } = useTranslation();
-  const sortedTokens = sortBalancesByValue(tokens, tokenPrices);
+  const sortedTokens = useMemo(
+    () => sortBalancesByValue(tokens, tokenPrices),
+    [tokens, tokenPrices],
+  );
   return (
     <div
       className={classnames("TokenList__Assets", {


### PR DESCRIPTION
## Proposal: Apply value sort to token pickers via TokenList

### Problem

The Account view sorts token balances by descending USD value (via `sortBalancesByValue` in `popup/helpers/balance.ts`). The Send flow's token picker (`SendDestinationAsset`) and the Swap flow's token picker (`SwapAsset`) both render tokens in `sortBalances` order — XLM first, LP shares last, everything else in API insertion order. This is not value-sorted and is inconsistent with the Account view.

### Solution

Centralize the value-sort inside `TokenList` itself. `TokenList` is exclusively a picker component — it is only used by `SendDestinationAsset` (`popup/components/send/SendDestinationAsset/index.tsx`) and `SwapAsset` (`popup/components/swap/SwapAsset/index.tsx`), never by the Account view (which has its own rendering path via `AccountAssets` + `useStableSortedBalances`). Since `TokenList` already receives `tokenPrices` as a prop and is the single shared picker renderer, it is the natural place to own the picker ordering policy.

**Why TokenList and not a shared hook?** Putting the sort in a hook or helper that callers must remember to invoke is the same pattern that produced this bug — the sort existed (`sortBalancesByValue`), but nobody called it in the picker paths. Placing it inside `TokenList` makes correct ordering structural: every picker gets it automatically, and no future caller can accidentally skip it. The Account view is unaffected because it uses a completely separate rendering path (`AccountAssets` component with `useStableSortedBalances`).

### Changes

**File: `extension/src/popup/components/InternalTransaction/TokenList/index.tsx`**

1. Import `sortBalancesByValue` from `popup/helpers/balance`.
2. At the top of the component body, sort the incoming `tokens` before rendering:
   ```tsx
   const sortedTokens = sortBalancesByValue(tokens, tokenPrices);
   ```
3. Replace `tokens` with `sortedTokens` in the render body (the `.filter().filter().map()` chain).

This is a single change point — both callers automatically get value-sorted rendering with zero modifications.

### Testing

**New tests for `TokenList`:**
- Tokens render in descending USD value order when `tokenPrices` has entries.
- Original order is preserved when `tokenPrices` is empty `{}` (no-op behavior).
- Hidden assets and LP shares remain excluded regardless of sort order.

Note: `sortBalancesByValue` already has direct unit tests in `popup/helpers/__tests__/balance.test.js` covering its sorting logic, edge cases, and tie-breaking. No additional helper-level tests are needed.

### Edge Cases

- **Swap search filtering:** In `SwapAsset`, filtering only applies for search terms > 2 characters (`useSwapFromData.tsx:107-127`). When no search is active, the full balance list reaches `TokenList`; when search is active, a filtered subset reaches it. In both cases, `sortBalancesByValue` applied inside `TokenList` produces the correct descending-value order for whatever subset it receives.
- **Empty prices:** `sortBalancesByValue` is a no-op when prices is empty or null — tokens keep their existing `sortBalances` order (XLM first, LP last).
- **Zero price:** Assets with price `"0"` are treated as priced with value 0 (sorting them below assets with positive value but above unpriced assets). This matches the existing `sortBalancesByValue` semantics.

### What this does NOT change

- XLM pinning is not applied (per updated issue description).
- The stable-sort behavior on the Account view is unchanged (different rendering path entirely).
- The baseline `sortBalances` in `useGetBalances` remains (provides tie-breaking insertion order for assets without price data).


---

Closes #2820
