### PR TITLE
Set anonymous Sentry user so alerts report users affected

### DIFF
--- a/config/jest/setupTests.tsx
+++ b/config/jest/setupTests.tsx
@@ -79,6 +79,7 @@ jest.mock("helpers/metrics", () => ({
   registerHandler: () => {},
   emitMetric: () => {},
   initAmplitude: () => {},
+  getUserId: () => "test-user-id",
   metricsMiddleware: jest.fn(
     () => () => (next: any) => (action: any) => next(action),
   ),

--- a/extension/src/helpers/metrics.ts
+++ b/extension/src/helpers/metrics.ts
@@ -111,7 +111,10 @@ const AMPLITUDE_FLUSH_INTERVAL_MS = 500;
 
 /** Mirrors mobile's `generateRandomUserId` — a numeric decimal string. */
 const generateRandomUserId = (): string =>
-  Math.random().toString().split(".")[1];
+  // Math.random() can yield values < 1e-6 (exponential notation, e.g. "4e-7")
+  // or exactly 0 ("0"), where `split(".")[1]` is undefined. Fall back to "0"
+  // so we never persist or hand Sentry/Amplitude an undefined user id.
+  Math.random().toString().split(".")[1] ?? "0";
 
 /** Session-level cache, mirrors mobile's module-level `sessionUserId` fallback. */
 let sessionUserId: string | null = null;
@@ -122,7 +125,7 @@ let sessionUserId: string | null = null;
  * - Reads from localStorage under key `"metrics_user_id"`
  * - Falls back to a session-only ID if storage is unavailable
  */
-const getUserId = (): string => {
+export const getUserId = (): string => {
   try {
     const stored = localStorage.getItem(METRICS_USER_ID);
     if (stored) {

--- a/extension/src/popup/components/ErrorTracking/index.tsx
+++ b/extension/src/popup/components/ErrorTracking/index.tsx
@@ -2,6 +2,7 @@ import { useSelector } from "react-redux";
 import * as Sentry from "@sentry/browser";
 
 import { SENTRY_KEY } from "constants/env";
+import { getUserId } from "helpers/metrics";
 import { settingsDataSharingSelector } from "popup/ducks/settings";
 import { scrubPathGkey } from "popup/helpers/formatters";
 import { INDEXER_URL } from "@shared/constants/mercury";
@@ -45,6 +46,13 @@ export const ErrorTracking = () => {
         return event;
       },
     });
+
+    // Attach a stable anonymous user ID so Sentry can report "users
+    // affected" counts. Reuses the same persisted random ID as Amplitude
+    // (helpers/metrics getUserId) so user counts stay aligned across the two.
+    // No PII / wallet address — just an opaque per-install identifier.
+    // Mirrors freighter-mobile's Sentry.setUser in src/components/App.tsx.
+    Sentry.setUser({ id: getUserId() });
   }
 
   if (!isDataSharingAllowed) {

--- a/extension/src/popup/components/ErrorTracking/index.tsx
+++ b/extension/src/popup/components/ErrorTracking/index.tsx
@@ -56,11 +56,15 @@ export const ErrorTracking = () => {
   }
 
   if (!isDataSharingAllowed) {
-    /* 
-    Note: Sentry.close does not completely disable calls to Sentry. Sentry will still report, but with a completely anonymized payload. 
+    /*
+    Note: Sentry.close does not completely disable calls to Sentry. Sentry will still report, but with a completely anonymized payload.
     When you refresh/reopen the app after disabling tracking, it will not initialize Sentry, thus disabling *all* calls to Sentry
     */
 
+    // Clear the per-install user id before closing. Sentry.close may still
+    // report (anonymized) until the next refresh; without this, those reports
+    // would keep the user id attached and defeat the anonymization.
+    Sentry.setUser(null);
     Sentry.close(500);
   }
 


### PR DESCRIPTION
## TL;DR

Sentry alerts for the Freighter extension all showed **"Users: 0"**, so we couldn't tell how many people a given error actually affected. The cause: error events were never tagged with a user, so Sentry had no one to count. This attaches a stable, anonymous per-install identifier to Sentry events (only when error reporting is already enabled), so alerts now show real "users affected" counts. No personal data or wallet addresses are involved — it's the same opaque ID analytics already uses, so the two stay in agreement. This matches how the mobile app already works.

<details>
<summary>Implementation details (for agents)</summary>

**Root cause:** `@sentry/browser` is on v9, where `sendDefaultPii` defaults to `false` (no IP capture), and `Sentry.init` was never followed by a `Sentry.setUser` call. Every event therefore arrived with an empty `user`, and Sentry's "users affected" counts distinct user identifiers → 0.

**What changed:**

- Attach an anonymous user id during Sentry init, inside the existing `SENTRY_KEY && isDataSharingAllowed` consent gate, reusing the persisted analytics id (same one Amplitude uses, so counts stay aligned):
  https://github.com/stellar/freighter/blob/459c3afc4774551705729084497db82b4288ddf5/extension/src/popup/components/ErrorTracking/index.tsx#L48-L55

- Export the existing `getUserId` helper so the Sentry init can reuse it rather than minting a separate id:
  https://github.com/stellar/freighter/blob/459c3afc4774551705729084497db82b4288ddf5/extension/src/helpers/metrics.ts#L128-L128

- Harden the id generator: `Math.random()` can yield values `< 1e-6` (rendered in exponential notation, e.g. `"4e-7"`) or exactly `0` (`"0"`), where `split(".")[1]` is `undefined`. That `undefined` would flow into `Sentry.setUser({ id: undefined })` and `amplitude.setUserId(undefined)`, reproducing "Users: 0" for that install. Fall back to `"0"`:
  https://github.com/stellar/freighter/blob/459c3afc4774551705729084497db82b4288ddf5/extension/src/helpers/metrics.ts#L113-L117

**Design notes:**
- Gated on consent — only set inside the existing data-sharing check, and cleared by the existing `Sentry.close()` on opt-out.
- No PII — opaque random id, never the public key / wallet address. Same `metrics_user_id` localStorage key as Amplitude, so Sentry and Amplitude user counts agree.
- Mirrors freighter-mobile, which already does `Sentry.setUser({ id: await getUserId() })` in `src/components/App.tsx` off the same shared `getUserId`.

**Verification:**
- `tsc --noEmit -p extension/tsconfig.json` → exit 0, 0 errors.
- Pre-commit hooks (lint + i18next-scanner) passed.
- Behavior is forward-only: existing open issues stay at 0 affected users; counts populate as new events arrive from updated installs.

**Follow-up / out of scope:**
- The same `generateRandomUserId` `undefined` edge case exists in freighter-mobile's generator; worth the same one-line `?? "0"` hardening in that repo as a separate PR.

</details>
