### PR TITLE
chore(dependabot): group security updates into consolidated PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,10 @@ updates:
         applies-to: version-updates
         update-types:
           - "major"
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -33,4 +37,7 @@ updates:
     groups:
       all-actions:
         applies-to: version-updates
+        patterns: ["*"]
+      actions-security:
+        applies-to: security-updates
         patterns: ["*"]


### PR DESCRIPTION
## TL;DR

Makes Dependabot batch **security updates** into a single consolidated PR per ecosystem, instead of opening one PR per advisory. We already group regular version updates; security updates were slipping through individually (and bypassing our open-PR limit), which is the source of the recent flood of one-off dependency PRs.

<details>
<summary>Implementation details (for agents)</summary>

**What changed** (`.github/dependabot.yml`):
- npm ecosystem: added a `security` group with `applies-to: security-updates` and `patterns: ["*"]`.
- github-actions ecosystem: added an `actions-security` group, same shape.

**Why the individual PRs happened:** every existing group (`minor-and-patch`, `major`, `all-actions`) is scoped `applies-to: version-updates`. A group's `applies-to` defaults to `version-updates`, and security updates are a separate channel — so with no security-scoped group, Dependabot raised each security advisory as its own PR. Compounding it, `open-pull-requests-limit` does **not** apply to security updates, so they ignored the limit of 2 and accumulated one-per-advisory.

**Effect:** all pending npm security fixes now land in one grouped PR (spanning the 5 configured directories), mirroring the existing `minor-and-patch` batching.

**Trade-off:** a grouped security PR is all-or-nothing — if one bump in the batch breaks CI, the whole group is blocked until resolved. That's the intended consolidation behavior.

**Verification:** YAML structure validated (consistent indentation, no tabs); groups parse with the expected `applies-to` scoping. No runtime impact until Dependabot's next run.

**Follow-up / out of scope:** the Ruby `bundler` ecosystem (source of #2703) is not declared in this file — it's coming from a separate config or auto-detection. If we want its security updates grouped too, that needs a separate explicit `bundler` entry.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
