### PR TITLE
chore(dependabot): add 7-day cooldown to align with Yarn age gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
       day: "sunday"
       time: "02:00"
     open-pull-requests-limit: 2
+    # Mirror the Yarn `npmMinimalAgeGate: 7d` in .yarnrc.yml so Dependabot does
+    # not open PRs (or lock versions) that `yarn install` would then reject for
+    # being younger than 7 days. Note: security updates ignore cooldown.
+    cooldown:
+      default-days: 7
     groups:
       minor-and-patch:
         applies-to: version-updates


### PR DESCRIPTION
## TL;DR

Makes Dependabot wait 7 days after a package is released before opening a PR for it, so it stops proposing versions that our Yarn config (`npmMinimalAgeGate: 7d`) would then refuse to install — which is what's been causing fresh dependency PRs to fail CI on `yarn install`.

<details>
<summary>Implementation details (for agents)</summary>

**What changed** (`.github/dependabot.yml`): added `cooldown: { default-days: 7 }` to the `npm` ecosystem block.

**Why:** `.yarnrc.yml` sets `npmMinimalAgeGate: 7d`, which Yarn enforces *at install time* — `yarn install` refuses any version younger than 7 days. Dependabot doesn't run Yarn and ignores `.yarnrc.yml` entirely; it resolves against the npm registry and opens PRs the instant a release lands. The result is a PR that locks, e.g., `form-data@4.0.6` (published 6/12) into `yarn.lock`, which CI's `yarn` step then rejects until 6/19 (see the age-gate flag on #2851). `cooldown` is Dependabot's native equivalent of the Yarn gate, so the two now align.

**Scope / caveats:**
- Applied to npm only — `npmMinimalAgeGate` is npm-specific. GitHub Actions cooldown is a separate, optional decision (not added here).
- **Security updates ignore cooldown by design** — a fresh security advisory can still trip the Yarn gate; for those, use the `npmPreapprovedPackages` bypass in `.yarnrc.yml` if it's urgent.
- `cooldown` also supports `semver-{major,minor,patch}-days` and `include`/`exclude` lists if per-package tuning is wanted later.
- Independent of the security-grouping change (#2853, already merged); both live in the same npm block.

**Verification:** YAML structure validated (consistent indentation, no tabs). No effect until Dependabot's next run.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
