### PR TITLE
Port to master: V2-precondition signing fix + Amplitude remote-code stripping

### DIFF
--- a/extension/src/background/helpers/__tests__/transactionInfo.test.ts
+++ b/extension/src/background/helpers/__tests__/transactionInfo.test.ts
@@ -1,0 +1,112 @@
+import { TransactionBuilder, Networks, xdr } from "stellar-sdk";
+
+import { encodeObject, decodeString } from "helpers/urls";
+import { getSerializableTransaction } from "background/helpers/transactionInfo";
+
+/**
+ * Real mainnet Soroban swap (Soroswap aggregator `strict_send`) built with V2
+ * preconditions. On stellar-sdk v16 the parsed transaction carries a native
+ * BigInt (`_minAccountSequenceAge`), which used to make `encodeObject`'s
+ * JSON.stringify throw and prevented the signing popup from ever opening.
+ */
+const V2_PRECONDITION_XDR =
+  "AAAAAgAAAABVZkfzT8IUCc68cala6hWfNx8vR5j+La0nQf3V+7AGYwAQn7kCkAfAAAAAOwAAAAIAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABlXCTplJcIn0KX7h14VbaEyo+rli4KX/mhPsIHHlY8V0AAAALc3RyaWN0X3NlbmQAAAAABgAAABIAAAAAAAAAAFVmR/NPwhQJzrxxqVrqFZ83Hy9HmP4trSdB/dX7sAZjAAAAEgAAAAAAAAAAVWZH80/CFAnOvHGpWuoVnzcfL0eY/i2tJ0H91fuwBmMAAAAJAAAAAAAAAAAAAAAAAJiWgAAAAAkAAAAAAAAAAAAAAAACgIbjAAAAEAAAAAEAAAACAAAAEAAAAAEAAAAEAAAAAwAAAAIAAAADAAAAGQAAAAMAAAP4AAAAAwAAAAgAAAAQAAAAAQAAAAQAAAADAAAABQAAAAMAAAAIAAAAAwAABIsAAAADAAAAJQAAABAAAAABAAAAAAAAAAEAAAAAAAAAAAAAAAGVcJOmUlwifQpfuHXhVtoTKj6uWLgpf+aE+wgceVjxXQAAAAtzdHJpY3Rfc2VuZAAAAAAGAAAAEgAAAAAAAAAAVWZH80/CFAnOvHGpWuoVnzcfL0eY/i2tJ0H91fuwBmMAAAASAAAAAAAAAABVZkfzT8IUCc68cala6hWfNx8vR5j+La0nQf3V+7AGYwAAAAkAAAAAAAAAAAAAAAAAmJaAAAAACQAAAAAAAAAAAAAAAAKAhuMAAAAQAAAAAQAAAAIAAAAQAAAAAQAAAAQAAAADAAAAAgAAAAMAAAAZAAAAAwAAA/gAAAADAAAACAAAABAAAAABAAAABAAAAAMAAAAFAAAAAwAAAAgAAAADAAAEiwAAAAMAAAAlAAAAEAAAAAEAAAAAAAAAAQAAAAAAAAABre/OWa7lKWj3YGHUlMJSW3Vln6QpamX0me8p5WR35JYAAAAIdHJhbnNmZXIAAAADAAAAEgAAAAAAAAAAVWZH80/CFAnOvHGpWuoVnzcfL0eY/i2tJ0H91fuwBmMAAAASAAAAAZVwk6ZSXCJ9Cl+4deFW2hMqPq5YuCl/5oT7CBx5WPFdAAAACgAAAAAAAAAAAAAAAACYloAAAAAAAAAAAQAAAAAAAAAOAAAABgAAAAEltPzYWa7C+mNIQ4xImzw8EMmLbSG+T9PLMMtolT75dwAAABQAAAABAAAABgAAAAFRKi8O7k0t6tNogsIUTVNkstxQ5ndz1G/l+FW+RALNLAAAAA8AAAAGQ09ORklHAAAAAAABAAAABgAAAAFRKi8O7k0t6tNogsIUTVNkstxQ5ndz1G/l+FW+RALNLAAAABQAAAABAAAABgAAAAGVcJOmUlwifQpfuHXhVtoTKj6uWLgpf+aE+wgceVjxXQAAABAAAAABAAAAAgAAAA8AAAADTWFwAAAAAAMAAAAIAAAAAQAAAAYAAAABlXCTplJcIn0KX7h14VbaEyo+rli4KX/mhPsIHHlY8V0AAAAQAAAAAQAAAAIAAAAPAAAAA01hcAAAAAADAAAAGQAAAAEAAAAGAAAAAZVwk6ZSXCJ9Cl+4deFW2hMqPq5YuCl/5oT7CBx5WPFdAAAAEAAAAAEAAAACAAAADwAAAANNYXAAAAAAAwAAACUAAAABAAAABgAAAAGVcJOmUlwifQpfuHXhVtoTKj6uWLgpf+aE+wgceVjxXQAAABAAAAABAAAAAgAAAA8AAAADTWFwAAAAAAMAAAP4AAAAAQAAAAYAAAABlXCTplJcIn0KX7h14VbaEyo+rli4KX/mhPsIHHlY8V0AAAAQAAAAAQAAAAIAAAAPAAAAA01hcAAAAAADAAAEiwAAAAEAAAAGAAAAAZVwk6ZSXCJ9Cl+4deFW2hMqPq5YuCl/5oT7CBx5WPFdAAAAFAAAAAEAAAAGAAAAAa3vzlmu5Slo92Bh1JTCUlt1ZZ+kKWpl9JnvKeVkd+SWAAAAFAAAAAEAAAAGAAAAAean2et1IwBqRpqnSDrREHJHRDwNguYnY95nCEjE6XyQAAAAFAAAAAEAAAAHFnq0FKImQn3jTBmUfvnFzzjGwO2R7Pk5L3zvMnj/UGwAAAAHGAUUVoFrZvEudzpW93xXlPrBsft6tuItT61aQSdw9z4AAAAHwrPsV/vUXVut6d8q0wxGTRWIzq0YSVpc4yepjEXAIhkAAAANAAAAAAAAAAAfF+cCRXcHsFO0ojbj3CJZlokloKaTwHBtvRT70yVIfgAAAAAAAAAAVWZH80/CFAnOvHGpWuoVnzcfL0eY/i2tJ0H91fuwBmMAAAABAAAAAFVmR/NPwhQJzrxxqVrqFZ83Hy9HmP4trSdB/dX7sAZjAAAAAVVTREMAAAAAO5kROA7+mIugqJAOsc/kTzZvfb6Ua+0HckD39iTfFcUAAAAGAAAAASW0/NhZrsL6Y0hDjEibPDwQyYttIb5P08swy2iVPvl3AAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAABUSovDu5NLerTaILCFE1TZLLcUOZ3c9Rv5fhVvkQCzSwAAAABAAAABgAAAAEltPzYWa7C+mNIQ4xImzw8EMmLbSG+T9PLMMtolT75dwAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAAZVwk6ZSXCJ9Cl+4deFW2hMqPq5YuCl/5oT7CBx5WPFdAAAAAQAAAAYAAAABUSovDu5NLerTaILCFE1TZLLcUOZ3c9Rv5fhVvkQCzSwAAAADAAAAAQAAAAEAAAAGAAAAAVEqLw7uTS3q02iCwhRNU2Sy3FDmd3PUb+X4Vb5EAs0sAAAAAwAAAAIAAAABAAAABgAAAAGt785ZruUpaPdgYdSUwlJbdWWfpClqZfSZ7ynlZHfklgAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAAZVwk6ZSXCJ9Cl+4deFW2hMqPq5YuCl/5oT7CBx5WPFdAAAAAQAAAAYAAAABre/OWa7lKWj3YGHUlMJSW3Vln6QpamX0me8p5WR35JYAAAAQAAAAAQAAAAIAAAAPAAAAB0JhbGFuY2UAAAAAEgAAAAG+IZcaqYbhp/Z7tpQrTLrcC6+LjAQubokYQITyVSu2dgAAAAEAAAAGAAAAAb4hlxqphuGn9nu2lCtMutwLr4uMBC5uiRhAhPJVK7Z2AAAAFAAAAAEAAAAGAAAAAean2et1IwBqRpqnSDrREHJHRDwNguYnY95nCEjE6XyQAAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAABUSovDu5NLerTaILCFE1TZLLcUOZ3c9Rv5fhVvkQCzSwAAAABAAAABgAAAAHmp9nrdSMAakaap0g60RByR0Q8DYLmJ2PeZwhIxOl8kAAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAAZVwk6ZSXCJ9Cl+4deFW2hMqPq5YuCl/5oT7CBx5WPFdAAAAAQAAAAYAAAAB5qfZ63UjAGpGmqdIOtEQckdEPA2C5idj3mcISMTpfJAAAAAQAAAAAQAAAAIAAAAPAAAAB0JhbGFuY2UAAAAAEgAAAAG+IZcaqYbhp/Z7tpQrTLrcC6+LjAQubokYQITyVSu2dgAAAAEAkF+wAAABlAAAClgAAAAAAAFdeQAAAAA=";
+
+describe("getSerializableTransaction", () => {
+  it("produces a JSON-serializable popup blob for a V2-precondition Soroban tx", () => {
+    const transaction = TransactionBuilder.fromXDR(
+      V2_PRECONDITION_XDR,
+      Networks.PUBLIC,
+    );
+
+    const transactionInfo = {
+      transaction: getSerializableTransaction(transaction),
+      transactionXdr: V2_PRECONDITION_XDR,
+      tab: {},
+      url: "https://soroswap.finance",
+      flaggedKeys: {},
+      uuid: "test-uuid",
+    };
+
+    // Regression: this used to throw `TypeError: Do not know how to serialize
+    // a BigInt` because the live transaction's `_minAccountSequenceAge` is a
+    // native bigint on stellar-sdk v16+.
+    let encoded = "";
+    expect(() => {
+      encoded = encodeObject(transactionInfo);
+    }).not.toThrow();
+
+    // ...and it round-trips back to exactly the fields the popup consumes.
+    const decoded = JSON.parse(decodeString(encoded));
+    expect(decoded.transaction._networkPassphrase).toBe(Networks.PUBLIC);
+    expect(decoded.transaction._fee).toBe((transaction as any).fee);
+    expect(decoded.transaction._operations).toEqual([
+      { type: "invokeHostFunction" },
+    ]);
+    expect(decoded.transactionXdr).toBe(V2_PRECONDITION_XDR);
+  });
+
+  it("emits no BigInt values for any V2-precondition transaction", () => {
+    const transaction = TransactionBuilder.fromXDR(
+      V2_PRECONDITION_XDR,
+      Networks.PUBLIC,
+    );
+
+    // Sanity-check the precondition really is V2 (the trigger for the bug).
+    const cond = xdr.TransactionEnvelope.fromXDR(V2_PRECONDITION_XDR, "base64")
+      .v1()
+      .tx()
+      .cond();
+    expect(cond.switch().name).toBe("precondV2");
+
+    const serialized = getSerializableTransaction(transaction);
+    const hasBigInt = (value: unknown): boolean => {
+      if (typeof value === "bigint") {
+        return true;
+      }
+      if (value && typeof value === "object") {
+        return Object.values(value).some(hasBigInt);
+      }
+      return false;
+    };
+    expect(hasBigInt(serialized)).toBe(false);
+  });
+
+  it("avoids the BigInt that makes the live transaction object unserializable", () => {
+    const transaction = TransactionBuilder.fromXDR(
+      V2_PRECONDITION_XDR,
+      Networks.PUBLIC,
+    );
+
+    // This is the regression we are guarding against: embedding the live
+    // stellar-sdk Transaction (as the handler used to) is not serializable on
+    // v16+ because the V2 `minSeqAge` precondition is a native bigint.
+    const minSeqAge = (transaction as any)._minAccountSequenceAge;
+    if (typeof minSeqAge === "bigint") {
+      expect(() => encodeObject({ transaction } as any)).toThrow(/BigInt/);
+    }
+
+    // The serialized form must always be safe.
+    expect(() =>
+      encodeObject({ transaction: getSerializableTransaction(transaction) }),
+    ).not.toThrow();
+  });
+
+  it("preserves operation types for a fee-bump transaction", () => {
+    const inner = TransactionBuilder.fromXDR(
+      V2_PRECONDITION_XDR,
+      Networks.PUBLIC,
+    );
+    const feeBump = TransactionBuilder.buildFeeBumpTransaction(
+      "GBKWMR7TJ7BBICOOXRY2SWXKCWPTOHZPI6MP4LNNE5A73VP3WADGG3CH",
+      "2000000",
+      inner as any,
+      Networks.PUBLIC,
+    );
+
+    const serialized = getSerializableTransaction(feeBump);
+    expect(serialized._networkPassphrase).toBe(Networks.PUBLIC);
+    expect(serialized._operations).toEqual([{ type: "invokeHostFunction" }]);
+    expect(() => encodeObject({ transaction: serialized })).not.toThrow();
+  });
+});

--- a/extension/src/background/helpers/transactionInfo.ts
+++ b/extension/src/background/helpers/transactionInfo.ts
@@ -1,0 +1,39 @@
+import * as StellarSdk from "stellar-sdk";
+
+/**
+ * Build the minimal, JSON-serializable representation of a transaction that we
+ * embed in the signing popup URL blob (see `freighterApiMessageListener`).
+ *
+ * We intentionally do NOT serialize the live stellar-sdk `Transaction` object.
+ * As of stellar-sdk v16 (Protocol 27), a parsed transaction can carry native
+ * `BigInt` fields — most notably the V2 precondition `minSeqAge`, which surfaces
+ * as `transaction._minAccountSequenceAge` (e.g. `0n`). `JSON.stringify` throws
+ * `TypeError: Do not know how to serialize a BigInt` on those, which broke
+ * signing for ANY V2-precondition transaction (common for Soroban dApp txs
+ * assembled via soroban-rpc) — the signing popup never opened.
+ *
+ * The popup rebuilds the full transaction from `transactionXdr`; the only fields
+ * read off this serialized object are `_fee`, `_networkPassphrase`, and the
+ * operation `type`s (used for metrics and the network-mismatch guard).
+ */
+const getOperations = (
+  transaction: StellarSdk.Transaction | StellarSdk.FeeBumpTransaction,
+) => {
+  if ("innerTransaction" in transaction) {
+    return transaction.innerTransaction.operations;
+  }
+  if ("operations" in transaction) {
+    return transaction.operations;
+  }
+  return [];
+};
+
+export const getSerializableTransaction = (
+  transaction: StellarSdk.Transaction | StellarSdk.FeeBumpTransaction,
+) => ({
+  _networkPassphrase: transaction.networkPassphrase,
+  _fee: transaction.fee,
+  _operations: getOperations(transaction).map((operation) => ({
+    type: operation.type,
+  })),
+});

--- a/extension/src/background/messageListener/freighterApiMessageListener.ts
+++ b/extension/src/background/messageListener/freighterApiMessageListener.ts
@@ -33,6 +33,7 @@ import {
   NetworkDetails,
 } from "@shared/constants/stellar";
 import { getSdk } from "@shared/helpers/stellar";
+import { getSerializableTransaction } from "background/helpers/transactionInfo";
 
 import { MessageResponder } from "background/types";
 import { STELLAR_EXPERT_MEMO_REQUIRED_ACCOUNTS_URL } from "background/constants/apiUrls";
@@ -437,7 +438,11 @@ export const freighterApiMessageListener = (
       const uuid = crypto.randomUUID();
 
       const transactionInfo = {
-        transaction,
+        // Serialize only the fields the popup reads. Embedding the live
+        // stellar-sdk Transaction breaks `encodeObject`'s JSON.stringify on
+        // v16+ txs that carry native BigInt fields (e.g. V2 precondition
+        // minSeqAge). The popup rebuilds the full tx from `transactionXdr`.
+        transaction: getSerializableTransaction(transaction),
         transactionXdr,
         tab,
         url: tabUrl,

--- a/extension/webpack.common.js
+++ b/extension/webpack.common.js
@@ -47,6 +47,18 @@ const commonConfig = (
   },
   resolve: {
     extensions: [".ts", ".tsx", ".js"],
+    alias: {
+      // Strip Amplitude's autocapture plugin from the bundle. It statically
+      // pulls in "visual tagging" / "background capture" code that loads
+      // remotely-hosted scripts from cdn.amplitude.com, which gets the build
+      // rejected by the Chrome Web Store / Firefox AMO. We run with
+      // `autocapture: false` so this code is dead anyway. See the stub for the
+      // full rationale.
+      "@amplitude/plugin-autocapture-browser": path.resolve(
+        __dirname,
+        "./webpack/amplitude-autocapture-stub.js",
+      ),
+    },
     plugins: [
       new TsconfigPathsPlugin({
         configFile: path.resolve(__dirname, "./tsconfig.json"),

--- a/extension/webpack/amplitude-autocapture-stub.js
+++ b/extension/webpack/amplitude-autocapture-stub.js
@@ -19,10 +19,10 @@
  *
  * Since we never use autocapture, we alias the package to these no-ops via
  * webpack `resolve.alias` (see webpack.common.js). This deterministically strips
- * the remotely-hosted-script strings from the bundle. Because nothing else imports
- * `getOrCreateWindowMessenger` / `enableBackgroundCapture` from
- * `@amplitude/analytics-core`, tree-shaking also drops the related messenger code.
- * that holds the background-capture URL.
+ * the remotely-hosted-script strings from the bundle. Because nothing else
+ * imports Amplitude's window messenger / background capture helpers from
+ * `@amplitude/analytics-core`, tree-shaking also drops the related code that
+ * holds the remaining remote URL.
  *
  * If autocapture is ever genuinely needed, remove the alias rather than
  * re-enabling the runtime flag — and confirm the store policy implications of

--- a/extension/webpack/amplitude-autocapture-stub.js
+++ b/extension/webpack/amplitude-autocapture-stub.js
@@ -1,0 +1,56 @@
+/**
+ * Build-time stub for `@amplitude/plugin-autocapture-browser`.
+ *
+ * `@amplitude/analytics-browser` statically imports this plugin, which in turn
+ * pulls in Amplitude's "visual tagging" and "background capture" features.
+ * Those features fetch remotely-hosted scripts from Amplitude's CDN at runtime
+ * (the "visual-tagging-selector" and "background-capture" libs).
+ *
+ * NOTE: the blocked CDN URLs are deliberately NOT written out literally here.
+ * The production build emits source maps with `sourcesContent`, and the store
+ * submission zips the build dir recursively — so any literal blocked URL in
+ * this comment could ride into the shipped artifact via the .map files and
+ * re-trigger the very store rejection this stub exists to fix.
+ *
+ * We initialize Amplitude with `autocapture: false` (see helpers/metrics.ts), so
+ * none of this code ever executes. But `autocapture: false` is only a runtime
+ * flag — the remote-script URLs still survive into the production bundle as
+ * dead code, and the Chrome Web Store / Firefox AMO reviewers scan the static
+ * bundle and reject the build for "remotely hosted code".
+ *
+ * Since we never use autocapture, we alias the package to these no-ops via
+ * webpack `resolve.alias` (see webpack.common.js). This strips both
+ * cdn.amplitude.com references from the bundle. Because nothing else imports
+ * `getOrCreateWindowMessenger` / `enableBackgroundCapture` from
+ * `@amplitude/analytics-core`, tree-shaking also drops the core messenger code
+ * that holds the background-capture URL.
+ *
+ * If autocapture is ever genuinely needed, remove the alias rather than
+ * re-enabling the runtime flag — and confirm the store policy implications of
+ * shipping remotely-hosted code first.
+ *
+ * This file is plain ESM with no loader transform; keep it loader-agnostic.
+ */
+
+// A benign, never-invoked enrichment plugin matching the shape `client.add()`
+// expects, in case the stubbed factory is ever called despite autocapture:false.
+const noopPlugin = (name) => () => ({
+  name,
+  type: "enrichment",
+  setup: () => Promise.resolve(undefined),
+  execute: (event) => Promise.resolve(event),
+});
+
+export const autocapturePlugin = noopPlugin(
+  "@amplitude/plugin-autocapture-browser",
+);
+export const frustrationPlugin = noopPlugin(
+  "@amplitude/plugin-frustration-browser",
+);
+
+// Mirror the real package's named exports so any importer resolves cleanly.
+export const plugin = autocapturePlugin;
+export const enableVisualTagging = () => undefined;
+export class DataExtractor {}
+
+export default autocapturePlugin;

--- a/extension/webpack/amplitude-autocapture-stub.js
+++ b/extension/webpack/amplitude-autocapture-stub.js
@@ -18,10 +18,10 @@
  * bundle and reject the build for "remotely hosted code".
  *
  * Since we never use autocapture, we alias the package to these no-ops via
- * webpack `resolve.alias` (see webpack.common.js). This strips both
- * cdn.amplitude.com references from the bundle. Because nothing else imports
+ * webpack `resolve.alias` (see webpack.common.js). This deterministically strips
+ * the remotely-hosted-script strings from the bundle. Because nothing else imports
  * `getOrCreateWindowMessenger` / `enableBackgroundCapture` from
- * `@amplitude/analytics-core`, tree-shaking also drops the core messenger code
+ * `@amplitude/analytics-core`, tree-shaking also drops the related messenger code.
  * that holds the background-capture URL.
  *
  * If autocapture is ever genuinely needed, remove the alias rather than

--- a/extension/webpack/amplitude-autocapture-stub.js
+++ b/extension/webpack/amplitude-autocapture-stub.js
@@ -1,11 +1,10 @@
 /**
  * Build-time stub for `@amplitude/plugin-autocapture-browser`.
  *
- * `@amplitude/analytics-browser` statically imports this plugin, which in turn
- * pulls in Amplitude's "visual tagging" and "background capture" features.
- * Those features fetch remotely-hosted scripts from Amplitude's CDN at runtime
- * (the "visual-tagging-selector" and "background-capture" libs).
- *
+ * `@amplitude/analytics-browser` statically imports this plugin, which can pull in
+ * Amplitude autocapture features.
+ * Those features attempt to load additional scripts at runtime, and reviewers scan
+ * the static bundle (including source maps) for those remote-script strings.
  * NOTE: the blocked CDN URLs are deliberately NOT written out literally here.
  * The production build emits source maps with `sourcesContent`, and the store
  * submission zips the build dir recursively — so any literal blocked URL in


### PR DESCRIPTION
## TL;DR

Ports two fixes from the `5.42.1` emergency release into `master` so the next regular release doesn't regress them:

1. **Soroban/V2-precondition transactions can be signed again.** On the current SDK, signing any transaction with V2 preconditions (most Soroban dApp txs, e.g. Soroswap swaps) silently failed — the confirm popup never opened.
2. **Amplitude autocapture remote-code is deterministically stripped from the build.** This is the code that gets the extension rejected by the Chrome Web Store ("remotely hosted code"); a guard so a dependency bump can't silently reintroduce it.

Both shipped in the `5.42.1` emergency release but were never on `master`, so `master` currently has both regressions.

<details>
<summary>Implementation details (for agents)</summary>

**Why master is missing these:** the emergency-release fix (PR #2860) merged into the `v5.42.1` branch, not `master`. The Amplitude stripping originally landed via #2822 into the `v5.41.2` release line and was likewise never forward-ported. So `master` has neither.

**Change 1 — V2-precondition signing fix** (`b04acf1e`)
- `freighterApiMessageListener.ts` embedded the live stellar-sdk `Transaction` in the signing-popup URL blob and `JSON.stringify`'d it in `encodeObject`. On stellar-sdk v16, a V2-precondition tx carries a native `BigInt` (`_minAccountSequenceAge`), which `JSON.stringify` throws on (`Do not know how to serialize a BigInt`). The throw was swallowed as `FreighterApiInternalError`, so the popup never opened.
- Fix: new `extension/src/background/helpers/transactionInfo.ts` → `getSerializableTransaction()` serializes only the fields the popup reads (`_networkPassphrase`, `_fee`, operation `type`s). The popup already rebuilds the full tx from `transactionXdr`. No BigInt path, future-proof against other BigInt fields.
- Test: `extension/src/background/helpers/__tests__/transactionInfo.test.ts` (4 cases) against a real V2-precondition Soroban XDR.

**Change 2 — Amplitude autocapture stripping** (`6f6c3d78`, re-applies #2822's mechanism)
- `webpack.common.js`: `resolve.alias` maps `@amplitude/plugin-autocapture-browser` → a no-op stub.
- `extension/webpack/amplitude-autocapture-stub.js`: the stub.
- The flagged remote-code (`loadScriptOnce("https://cdn.amplitude.com/libs/visual-tagging-selector-1.0.0-alpha.js.gz")`) **still exists in the installed dependency** (`@amplitude/plugin-autocapture-browser`). It currently tree-shakes out of the bundle, but that's an incidental side effect of the resolved dep versions — master's amplitude deps have already drifted (`analytics-browser` 2.44.1 here vs 2.37.0 in 5.42.1), and the next bump could silently reintroduce it. We run `autocapture: false`, so the alias is behavior-neutral; it just makes exclusion deterministic and version-independent.

**Verification (on master's dependency set):**
- `yarn jest .../transactionInfo.test.ts` → 4/4 pass (stellar-sdk v16).
- `yarn build:extension:production` → succeeds; recursive grep of the build dir incl. `.map` files → `0` occurrences of `cdn.amplitude.com` / `visual-tagging-selector`.
- `npx tsc --noEmit -p extension/tsconfig.json` clean; `eslint` clean on changed source.

Permalinks (head `6f6c3d788c454b27cdc500e87ec9cf2af10783f2`):
- https://github.com/stellar/freighter/blob/6f6c3d788c454b27cdc500e87ec9cf2af10783f2/extension/src/background/helpers/transactionInfo.ts
- https://github.com/stellar/freighter/blob/6f6c3d788c454b27cdc500e87ec9cf2af10783f2/extension/webpack/amplitude-autocapture-stub.js

**Follow-up (out of scope):** the emergency-release tooling (`newRelease`/`submitBeta`/`submitProduction`) has a `target_commitish` vs `commitish` typo that mis-tags releases, and `newRelease` branched the hotfix from `master` instead of the release tag — both tracked separately.

</details>
