### PR TITLE
ci: fix create-release commitish input (was target_commitish)

### DIFF
--- a/.github/workflows/submitBeta.yml
+++ b/.github/workflows/submitBeta.yml
@@ -129,7 +129,7 @@ jobs:
             github.event.inputs.version }}
           draft: false
           prerelease: true
-          target_commitish: ${{ steps.checkout_sha.outputs.sha }}
+          commitish: ${{ steps.checkout_sha.outputs.sha }}
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/submitProduction.yml
+++ b/.github/workflows/submitProduction.yml
@@ -102,7 +102,7 @@ jobs:
           body: ${{ steps.package_version.outputs.version }}
           draft: false
           prerelease: false
-          target_commitish: ${{ steps.checkout_sha.outputs.sha }}
+          commitish: ${{ steps.checkout_sha.outputs.sha }}
       - name: Build for Firefox
         id: web-ext-build
         uses: kewisch/action-web-ext@fe10addf5d5e5ba6b78ffde720dd488a27d10e8c #v1


### PR DESCRIPTION
## TL;DR

Fixes a typo in the beta/production release workflows so the GitHub Release tag attaches to the commit that was actually built, instead of the input being silently ignored.

<details>
<summary>Implementation details (for agents)</summary>

`actions/create-release@v1`'s input is `commitish`, not `target_commitish`. The wrong key was silently ignored (`Unexpected input(s) 'target_commitish'`), so the API defaulted the new tag to the repo's default branch (`master`) instead of `steps.checkout_sha.outputs.sha`.

- **`submitBeta.yml`** — real fix: `create-release@v1` creates the tag, so the wrong key put beta tags on `master`'s HEAD rather than the built ref (observed with `5.42.1-beta.1`, which had to be repointed manually).
- **`submitProduction.yml`** — the tag is pre-created in an earlier `Create and push git tag` step, so `commitish` is effectively a no-op here; corrected for consistency so the two workflows match.

Only the `actions/create-release@v1` steps were touched; no `softprops/action-gh-release` or REST usages (which legitimately use `target_commitish`).

**Note:** the forward-port automation that was originally part of this PR has been removed and parked on `parked/forward-port-workflow` — it needs a non-`GITHUB_TOKEN` identity (PAT/GitHub App) so the auto-opened PR triggers required status checks before it's viable.

</details>
