### PR TITLE
fix(sign-tx): show asset issuer for value-bearing operations

### DIFF
--- a/extension/src/popup/components/__tests__/Operations.test.tsx
+++ b/extension/src/popup/components/__tests__/Operations.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, waitFor, screen } from "@testing-library/react";
-import { Address, Operation, xdr, StrKey, ScInt } from "stellar-sdk";
+import { Address, Asset, Operation, xdr, StrKey, ScInt } from "stellar-sdk";
 
 import { mockAccounts, TEST_PUBLIC_KEY, Wrapper } from "popup/__testHelpers__";
 import { Operations } from "../signTransaction/Operations";
@@ -247,6 +247,100 @@ describe("Operations", () => {
         "[data-testid='OperationKeyVal__value']",
       );
       expect(limitValue).toHaveTextContent("100");
+    });
+  });
+
+  describe("value-bearing operations show the asset issuer", () => {
+    const renderOp = (op: Operation) =>
+      render(
+        <Wrapper
+          routes={[ROUTES.signTransaction]}
+          state={{
+            auth: {
+              error: null,
+              applicationState: APPLICATION_STATE.PASSWORD_CREATED,
+              TEST_PUBLIC_KEY,
+              allAccounts: mockAccounts,
+              hasPrivateKey: true,
+            },
+            settings: {
+              networkDetails: TESTNET_NETWORK_DETAILS,
+              networksList: DEFAULT_NETWORKS,
+              isSorobanPublicEnabled: true,
+              isRpcHealthy: true,
+            },
+          }}
+        >
+          <Operations
+            operations={[op]}
+            flaggedKeys={{}}
+            isMemoRequired={false}
+          />
+        </Wrapper>,
+      );
+
+    const valueOf = (label: string) =>
+      screen
+        .getByText(label)
+        .parentNode?.querySelector("[data-testid='OperationKeyVal__value']");
+
+    // Regression test for HackerOne #3768317: the signing UI must show the
+    // issuer for value-bearing assets so a counterfeit USDC:<attacker> is
+    // distinguishable from a non-native asset using the same code.
+    it("renders the issuer for the non-native asset in a manageSellOffer", async () => {
+      const op = {
+        offerId: "0",
+        selling: Asset.native(),
+        buying: new Asset("USDC", TEST_PUBLIC_KEY),
+        amount: "5000",
+        price: "1",
+        type: "manageSellOffer",
+      } as Operation.ManageSellOffer;
+
+      renderOp(op);
+
+      await waitFor(() => screen.getAllByTestId("OperationKeyVal"));
+
+      expect(valueOf("Selling")).toHaveTextContent("XLM");
+      expect(valueOf("Buying")).toHaveTextContent("USDC");
+
+      // Native XLM has no issuer, so exactly one issuer row is rendered, and it
+      // carries the (truncated, copyable) issuer of the non-native buying asset.
+      const issuerRows = screen.getAllByText("Asset Issuer");
+      expect(issuerRows).toHaveLength(1);
+      expect(valueOf("Asset Issuer")).toHaveTextContent("GBTY…JZOF");
+    });
+
+    it("renders the issuer for a payment of a non-native asset", async () => {
+      const op = {
+        destination: TEST_PUBLIC_KEY,
+        asset: new Asset("USDC", TEST_PUBLIC_KEY),
+        amount: "100",
+        type: "payment",
+      } as Operation.Payment;
+
+      renderOp(op);
+
+      await waitFor(() => screen.getAllByTestId("OperationKeyVal"));
+
+      expect(valueOf("Asset Code")).toHaveTextContent("USDC");
+      expect(valueOf("Asset Issuer")).toHaveTextContent("GBTY…JZOF");
+    });
+
+    it("does not render an issuer row for a native (XLM) payment", async () => {
+      const op = {
+        destination: TEST_PUBLIC_KEY,
+        asset: Asset.native(),
+        amount: "100",
+        type: "payment",
+      } as Operation.Payment;
+
+      renderOp(op);
+
+      await waitFor(() => screen.getAllByTestId("OperationKeyVal"));
+
+      expect(valueOf("Asset Code")).toHaveTextContent("XLM");
+      expect(screen.queryByText("Asset Issuer")).toBeNull();
     });
   });
 });

--- a/extension/src/popup/components/signTransaction/Operations/index.tsx
+++ b/extension/src/popup/components/signTransaction/Operations/index.tsx
@@ -16,6 +16,7 @@ import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
 import { truncateString, truncatedPoolId } from "helpers/stellar";
 import { scanAsset } from "popup/helpers/blockaid";
 import { addressToString, getCreateContractArgs } from "popup/helpers/soroban";
+import { CopyValue } from "popup/components/CopyValue";
 import {
   KeyValueClaimants,
   KeyValueInvokeHostFn,
@@ -94,6 +95,24 @@ const DestinationWarning = ({
       ) : null}
     </>
   );
+};
+
+// On Stellar a non-native asset is identified by (code, issuer), not by code
+// alone, so the signing UI must show the issuer for any value-bearing asset to
+// let the user distinguish a legitimate asset from a look-alike using the same
+// code. Native XLM has no issuer, so nothing is rendered for it. Mirrors the
+// issuer row already shown by changeTrust (KeyValueLine) and PathList.
+const KeyValueAssetIssuer = ({ issuer }: { issuer?: string }) => {
+  const { t } = useTranslation();
+
+  return issuer ? (
+    <KeyValueList
+      operationKey={t("Asset Issuer")}
+      operationValue={
+        <CopyValue value={issuer} displayValue={truncateString(issuer)} />
+      }
+    />
+  ) : null;
 };
 
 export const Operations = ({
@@ -218,6 +237,7 @@ export const Operations = ({
               operationKey={t("Asset Code")}
               operationValue={asset.code}
             />
+            <KeyValueAssetIssuer issuer={asset.issuer} />
             <KeyValueList operationKey={t("Amount")} operationValue={amount} />
           </>
         );
@@ -232,6 +252,7 @@ export const Operations = ({
               operationKey={t("Asset Code")}
               operationValue={sendAsset.code}
             />
+            <KeyValueAssetIssuer issuer={sendAsset.issuer} />
             <KeyValueList
               operationKey={t("Send Max")}
               operationValue={sendMax}
@@ -249,6 +270,7 @@ export const Operations = ({
               operationKey={t("Destination Asset")}
               operationValue={destAsset.code}
             />
+            <KeyValueAssetIssuer issuer={destAsset.issuer} />
             <KeyValueList
               operationKey={t("Destination Amount")}
               operationValue={destAmount}
@@ -267,6 +289,7 @@ export const Operations = ({
               operationKey={t("Asset Code")}
               operationValue={sendAsset.code}
             />
+            <KeyValueAssetIssuer issuer={sendAsset.issuer} />
             <KeyValueList
               operationKey={t("Send Amount")}
               operationValue={sendAmount}
@@ -284,6 +307,7 @@ export const Operations = ({
               operationKey={t("Destination Asset")}
               operationValue={destAsset.code}
             />
+            <KeyValueAssetIssuer issuer={destAsset.issuer} />
             <KeyValueList
               operationKey={t("Destination Minimum")}
               operationValue={destMin}
@@ -301,11 +325,13 @@ export const Operations = ({
               operationKey={t("Buying")}
               operationValue={buying.code}
             />
+            <KeyValueAssetIssuer issuer={buying.issuer} />
             <KeyValueList operationKey={t("Amount")} operationValue={amount} />
             <KeyValueList
               operationKey={t("Selling")}
               operationValue={selling.code}
             />
+            <KeyValueAssetIssuer issuer={selling.issuer} />
             <KeyValueList operationKey={t("Price")} operationValue={price} />
           </>
         );
@@ -323,10 +349,12 @@ export const Operations = ({
               operationKey={t("Selling")}
               operationValue={selling.code}
             />
+            <KeyValueAssetIssuer issuer={selling.issuer} />
             <KeyValueList
               operationKey={t("Buying")}
               operationValue={buying.code}
             />
+            <KeyValueAssetIssuer issuer={buying.issuer} />
             <KeyValueList operationKey={t("Amount")} operationValue={amount} />
             <KeyValueList operationKey={t("Price")} operationValue={price} />
           </>
@@ -345,6 +373,7 @@ export const Operations = ({
               operationKey={t("Buying")}
               operationValue={buying.code}
             />
+            <KeyValueAssetIssuer issuer={buying.issuer} />
             <KeyValueList
               operationKey={t("Buy Amount")}
               operationValue={buyAmount}
@@ -353,6 +382,7 @@ export const Operations = ({
               operationKey={t("Selling")}
               operationValue={selling.code}
             />
+            <KeyValueAssetIssuer issuer={selling.issuer} />
             <KeyValueList operationKey={t("Price")} operationValue={price} />
           </>
         );
@@ -510,6 +540,7 @@ export const Operations = ({
               operationKey={t("Asset Code")}
               operationValue={asset.code}
             />
+            <KeyValueAssetIssuer issuer={asset.issuer} />
             <KeyValueList operationKey={t("Amount")} operationValue={amount} />
             <KeyValueClaimants claimants={claimants} />
           </>


### PR DESCRIPTION
## TL;DR

On Stellar, a non-native asset is identified by both its code **and** its issuer — two different assets can share the same code (e.g. a real `USDC` and a look-alike `USDC` from a different issuer). The transaction signing screen showed only the asset **code** for operations that move or trade value (payments, path payments, DEX offers, claimable balances), so two assets with the same code looked identical at the moment you decide whether to sign.

This PR shows the issuer alongside the code for every non-native asset in those operations, so what you see matches what you sign — consistent with the trustline and path-hop screens, which already show the issuer. Native XLM has no issuer and is unchanged. Presentational only.

> Stacked on #2829 (it edits the same file). Targets `fix/sign-tx-show-all-operation-fields`; will retarget to `master` once #2829 merges. Tracking: internal `wallet-eng-monorepo#13`.

<details>
<summary>Implementation details (for agents)</summary>

**What changed** — two files, presentational only; the issuer was already present on every parsed op object and is unchanged in the XDR.

- `extension/src/popup/components/signTransaction/Operations/index.tsx`
  - New file-local helper `KeyValueAssetIssuer({ issuer?: string })` that renders an "Asset Issuer" row using the existing copy-value pattern, or `null` when there is no issuer (native XLM → no row):
    https://github.com/stellar/freighter/blob/9e8b2c0a7931c1e5595fa9ed74139fb1ae6158cd/extension/src/popup/components/signTransaction/Operations/index.tsx#L79-L94
  - The helper's body is the same `<CopyValue value={issuer} displayValue={truncateString(issuer)} />` pattern that `changeTrust` already uses for its issuer row (see `KeyVal`'s `KeyValueLine`), so the new rows render and copy identically to what's already shipped.
  - An issuer row is inserted after each non-native asset's code row in the seven value-bearing ops — `payment`, `pathPaymentStrictReceive`, `pathPaymentStrictSend`, `createPassiveSellOffer`, `manageSellOffer`, `manageBuyOffer`, `createClaimableBalance` (12 rows total; path-payment and offer ops carry two assets each). `clawback`, the trust-flag ops, and liquidity-pool ops are intentionally excluded (issuer's own asset, or no `(code, issuer)` exposed on the op).
- `extension/src/popup/components/__tests__/Operations.test.tsx` — three regression tests:
  https://github.com/stellar/freighter/blob/9e8b2c0a7931c1e5595fa9ed74139fb1ae6158cd/extension/src/popup/components/__tests__/Operations.test.tsx#L252-L346
  - non-native asset in a `manageSellOffer` renders exactly one issuer row (native selling side renders none),
  - non-native `payment` renders the issuer row,
  - native (XLM) `payment` renders no issuer row.

**Verification**
- Full `Operations.test.tsx` suite green (6/6, output reviewed).
- `prettier --check` clean on both files.
- No new TypeScript errors introduced (the pre-existing `Operation`-union diagnostics on this stack are unchanged base→head and resolve at current master).

**Follow-ups / out of scope**
- Resolving `(code, issuer)` to a verified, human-readable label (e.g. `USDC · centre.io`) and warning on look-alike collisions — separate defense-in-depth work.
- Mobile port of the same gap — tracked separately (`wallet-eng-monorepo#5`).
- This branch is based on #2829's branch (older `master`). Two pre-existing stack conditions — a `jest.config.js` `esModules` gap and raw-`tsc` union-narrowing noise — are not introduced here and clear when the stack reaches `master`. On retarget, re-confirm the 12 insertion points still sit after the correct code rows, since #2829 restructured these `case` blocks.

</details>
