### PR TITLE
fix(styles): replace undefined --font-weight-* vars with SDS tokens

### DIFF
--- a/extension/src/popup/basics/TransactionHeading/styles.scss
+++ b/extension/src/popup/basics/TransactionHeading/styles.scss
@@ -1,7 +1,7 @@
 .TransactionHeading {
   border-bottom: 1px solid var(--sds-clr-gray-03);
   font-size: 0.875rem;
-  font-weight: var(--font-weight-medium);
+  font-weight: var(--sds-fw-medium);
   line-height: 0.72rem;
   margin-bottom: 1rem;
   padding-bottom: 1rem;

--- a/extension/src/popup/basics/buttons/BackButton/styles.scss
+++ b/extension/src/popup/basics/buttons/BackButton/styles.scss
@@ -17,7 +17,7 @@
 
   &__copy {
     font-size: 0.875rem;
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     margin-left: 0.5rem;
     text-transform: uppercase;
   }

--- a/extension/src/popup/components/AssetListRow/styles.scss
+++ b/extension/src/popup/components/AssetListRow/styles.scss
@@ -24,7 +24,7 @@
   &__code {
     color: var(--sds-clr-gray-12);
     font-size: pxToRem(16px);
-    font-weight: var(--font-weight-regular);
+    font-weight: var(--sds-fw-regular);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/extension/src/popup/components/BlockaidBanner/styles.scss
+++ b/extension/src/popup/components/BlockaidBanner/styles.scss
@@ -36,7 +36,7 @@
   // both render text larger and in a different family.
   &__message {
     font-size: pxToRem(12px);
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     line-height: pxToRem(18px);
     text-align: left;
   }

--- a/extension/src/popup/components/InternalTransaction/EditMemo/styles.scss
+++ b/extension/src/popup/components/InternalTransaction/EditMemo/styles.scss
@@ -11,7 +11,7 @@
 
     &--warning {
       color: var(--sds-clr-amber-11);
-      font-weight: var(--font-weight-medium);
+      font-weight: var(--sds-fw-medium);
     }
   }
 

--- a/extension/src/popup/components/InternalTransaction/FeesPane/styles.scss
+++ b/extension/src/popup/components/InternalTransaction/FeesPane/styles.scss
@@ -71,7 +71,7 @@
       }
 
       &__Label {
-        font-weight: var(--font-weight-medium);
+        font-weight: var(--sds-fw-medium);
         color: var(--sds-clr-gray-11);
 
         &--total {
@@ -80,7 +80,7 @@
       }
 
       &__Value {
-        font-weight: var(--font-weight-medium);
+        font-weight: var(--sds-fw-medium);
         color: var(--sds-clr-gray-12);
 
         &--total {

--- a/extension/src/popup/components/InternalTransaction/ReviewTransaction/styles.scss
+++ b/extension/src/popup/components/InternalTransaction/ReviewTransaction/styles.scss
@@ -160,7 +160,7 @@
     &__Title {
       color: var(--sds-clr-gray-12);
       font-size: pxToRem(18px);
-      font-weight: var(--font-weight-medium);
+      font-weight: var(--sds-fw-medium);
       margin-bottom: pxToRem(4px);
     }
 
@@ -416,7 +416,7 @@
       width: 100%;
       margin: pxToRem(12px) 0;
       font-size: pxToRem(20px);
-      font-weight: var(--font-weight-medium);
+      font-weight: var(--sds-fw-medium);
     }
 
     &__Content {
@@ -471,7 +471,7 @@
       align-items: center;
       gap: pxToRem(8px);
       font-size: pxToRem(12px);
-      font-weight: var(--font-weight-medium);
+      font-weight: var(--sds-fw-medium);
       line-height: pxToRem(18px);
       text-align: left;
     }

--- a/extension/src/popup/components/ModalInfo/styles.scss
+++ b/extension/src/popup/components/ModalInfo/styles.scss
@@ -57,7 +57,7 @@
     color: var(--color-red-70);
     display: flex;
     font-size: 0.875rem;
-    font-weight: var(--font-weight-semi-bold);
+    font-weight: var(--sds-fw-semi-bold);
     justify-content: center;
     line-height: 1.25rem;
     text-align: center;

--- a/extension/src/popup/components/Notification/styles.scss
+++ b/extension/src/popup/components/Notification/styles.scss
@@ -76,7 +76,7 @@
   }
 
   &__header {
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     font-size: 1rem;
     line-height: 1.5rem;
     color: var(--sds-clr-gray-12);

--- a/extension/src/popup/components/SubviewHeader/styles.scss
+++ b/extension/src/popup/components/SubviewHeader/styles.scss
@@ -9,7 +9,7 @@
 
   &--title {
     flex-grow: 1;
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     text-align: center;
   }
 

--- a/extension/src/popup/components/WarningMessages/styles.scss
+++ b/extension/src/popup/components/WarningMessages/styles.scss
@@ -303,7 +303,7 @@
   }
 
   &__header {
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     font-size: 1rem;
     line-height: 1.5rem;
     color: var(--sds-clr-gray-12);
@@ -615,7 +615,7 @@
   }
 
   .Message {
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
   }
 
   .ScanLabel__Action svg {

--- a/extension/src/popup/components/account/AccountAssets/styles.scss
+++ b/extension/src/popup/components/account/AccountAssets/styles.scss
@@ -46,7 +46,7 @@ $loader-light-color: #444961;
       align-items: center;
       justify-content: center;
       font-size: 0.875rem;
-      font-weight: var(--font-weight-semi-bold);
+      font-weight: var(--sds-fw-semi-bold);
       line-height: 1.5rem;
       color: var(--sds-clr-gray-12);
     }
@@ -118,7 +118,7 @@ $loader-light-color: #444961;
   &__copy-left {
     min-width: 0;
     display: flex;
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
 
     .asset-icon {
       display: flex;
@@ -146,7 +146,7 @@ $loader-light-color: #444961;
 
   &__copy-right {
     min-width: 0;
-    font-weight: var(--font-weight-regular);
+    font-weight: var(--sds-fw-regular);
 
     .asset-usd-amount {
       text-align: right;

--- a/extension/src/popup/components/account/AccountHeader/styles.scss
+++ b/extension/src/popup/components/account/AccountHeader/styles.scss
@@ -54,7 +54,7 @@
   &__network-copy {
     font-size: pxToRem(14px);
     line-height: 1.5rem;
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     white-space: nowrap;
   }
 
@@ -86,7 +86,7 @@
 
   &__account-name {
     color: var(--sds-clr-gray-11);
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     margin: 0 pxToRem(4px);
   }
 

--- a/extension/src/popup/components/account/AddWallet/styles.scss
+++ b/extension/src/popup/components/account/AddWallet/styles.scss
@@ -36,7 +36,7 @@
       color: var(--sds-clr-gray-12);
       font-size: pxToRem(14px);
       line-height: pxToRem(20px);
-      font-weight: var(--font-weight-medium);
+      font-weight: var(--sds-fw-medium);
     }
 
     &__description {
@@ -44,7 +44,7 @@
       color: var(--sds-clr-gray-11);
       font-size: pxToRem(12px);
       line-height: pxToRem(18px);
-      font-weight: var(--font-weight-medium);
+      font-weight: var(--sds-fw-medium);
     }
   }
 }

--- a/extension/src/popup/components/account/AssetDetail/styles.scss
+++ b/extension/src/popup/components/account/AssetDetail/styles.scss
@@ -123,7 +123,7 @@
       align-items: center;
       display: flex;
       font-size: 2rem;
-      font-weight: var(--font-weight-medium);
+      font-weight: var(--sds-fw-medium);
       line-height: 150%;
 
       &--isSuspicious {
@@ -294,7 +294,7 @@
 
     &__label {
       font-size: 0.875rem;
-      font-weight: var(--font-weight-medium);
+      font-weight: var(--sds-fw-medium);
     }
 
     &__background {

--- a/extension/src/popup/components/accountHistory/TransactionDetail/styles.scss
+++ b/extension/src/popup/components/accountHistory/TransactionDetail/styles.scss
@@ -9,7 +9,7 @@
     border-bottom: 1px solid var(--sds-clr-gray-04);
     color: var(--color-white);
     font-size: 2rem;
-    font-weight: var(--font-weight-light);
+    font-weight: var(--sds-fw-light);
     padding-bottom: 1.5rem;
     text-align: center;
     white-space: nowrap;
@@ -380,7 +380,7 @@
     }
 
     .AssetDiff__value {
-      font-weight: var(--sds-font-weight-medium);
+      font-weight: var(--sds-fw-medium);
 
       &.credit {
         color: var(--sds-clr-green-11);

--- a/extension/src/popup/components/accountMigration/basics/styles.scss
+++ b/extension/src/popup/components/accountMigration/basics/styles.scss
@@ -93,7 +93,7 @@
 
   &__name {
     color: var(--color-white);
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
   }
 
   &__identicon-wrapper {

--- a/extension/src/popup/components/amount/AmountCard/styles.scss
+++ b/extension/src/popup/components/amount/AmountCard/styles.scss
@@ -57,7 +57,7 @@
   &__amount-label-usd {
     font-size: pxToRem(24px);
     line-height: 1;
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     color: var(--sds-clr-gray-12);
     flex-shrink: 0;
   }
@@ -65,7 +65,7 @@
   &__input-amount {
     font-size: pxToRem(24px);
     line-height: 1;
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     color: var(--sds-clr-gray-12);
     background: none;
     border: none;
@@ -175,7 +175,7 @@
 
   &__asset-code {
     font-size: pxToRem(14px);
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
   }
 
   &__balance-row {

--- a/extension/src/popup/components/identicons/AccountListIdenticon/styles.scss
+++ b/extension/src/popup/components/identicons/AccountListIdenticon/styles.scss
@@ -41,7 +41,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     width: 100%;
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
   }
 
   &__account-num {

--- a/extension/src/popup/components/manageAssets/ManageAssetRowButton/styles.scss
+++ b/extension/src/popup/components/manageAssets/ManageAssetRowButton/styles.scss
@@ -7,7 +7,7 @@
 
   &__label {
     font-size: 0.875rem;
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
   }
 
   &__ellipsis {

--- a/extension/src/popup/components/manageAssets/ManageAssetRows/ChangeTrustInternal/styles.scss
+++ b/extension/src/popup/components/manageAssets/ManageAssetRows/ChangeTrustInternal/styles.scss
@@ -402,7 +402,7 @@
 
     &__label {
       font-size: 0.875rem;
-      font-weight: var(--font-weight-medium);
+      font-weight: var(--sds-fw-medium);
     }
 
     &__background {

--- a/extension/src/popup/components/manageNetwork/NetworkForm/styles.scss
+++ b/extension/src/popup/components/manageNetwork/NetworkForm/styles.scss
@@ -2,7 +2,7 @@
   &__modal {
     &__title {
       color: var(--color-white);
-      font-weight: var(--font-weight-medium);
+      font-weight: var(--sds-fw-medium);
       text-transform: uppercase;
     }
 

--- a/extension/src/popup/components/manageNetwork/NetworkSettings/styles.scss
+++ b/extension/src/popup/components/manageNetwork/NetworkSettings/styles.scss
@@ -6,7 +6,7 @@ $activeColor: rgba(61, 204, 152, 1);
   &__header {
     color: var(--sds-clr-gray-11);
     font-size: pxToRem(14px);
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     margin-bottom: pxToRem(16px);
     margin-top: pxToRem(32px);
   }
@@ -15,7 +15,7 @@ $activeColor: rgba(61, 204, 152, 1);
     align-items: center;
     display: flex;
     font-size: 0.875rem;
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
 
     &--active {
       color: $activeColor;

--- a/extension/src/popup/components/mnemonicPhrase/DisplayMnemonicPhrase/styles.scss
+++ b/extension/src/popup/components/mnemonicPhrase/DisplayMnemonicPhrase/styles.scss
@@ -2,7 +2,7 @@
   &__content {
     font-size: 1rem;
     line-height: 1.5rem;
-    font-weight: var(--font-weight-regular);
+    font-weight: var(--sds-fw-regular);
 
     p {
       color: var(--sds-clr-gray-12);

--- a/extension/src/popup/components/send/styles.scss
+++ b/extension/src/popup/components/send/styles.scss
@@ -92,14 +92,14 @@
 
   &__amount-label {
     font-size: 2.5rem;
-    font-weight: var(--font-weight-light);
+    font-weight: var(--sds-fw-light);
     margin-left: pxToRem(6px);
   }
 
   &__amount-label-usd {
     font-size: pxToRem(24px);
     line-height: 1;
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     color: var(--sds-clr-gray-12);
     flex-shrink: 0;
   }
@@ -107,7 +107,7 @@
   &__input-amount {
     font-size: pxToRem(24px);
     line-height: 1;
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     color: var(--sds-clr-gray-12);
     background: none;
     border: none;
@@ -273,7 +273,7 @@
 
   &__asset-code {
     font-size: pxToRem(14px);
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
   }
 
   &__balance-row {
@@ -353,7 +353,7 @@
     margin-top: 1.5rem;
     font-size: 0.875rem;
     line-height: 1.375rem;
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     color: var(--sds-clr-gray-11);
 
     svg {
@@ -384,7 +384,7 @@
     font-size: 0.875rem;
     line-height: 1.375rem;
     color: var(--sds-clr-gray-12);
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     background: none;
     border: 0;
     display: flex;

--- a/extension/src/popup/components/swap/SwapAmount/styles.scss
+++ b/extension/src/popup/components/swap/SwapAmount/styles.scss
@@ -138,18 +138,18 @@
 
   &__amount-label {
     font-size: 2.5rem;
-    font-weight: var(--font-weight-light);
+    font-weight: var(--sds-fw-light);
     margin-left: pxToRem(6px);
   }
 
   &__amount-label-usd {
     font-size: 2.5rem;
-    font-weight: var(--font-weight-light);
+    font-weight: var(--sds-fw-light);
   }
 
   &__input-amount {
     font-size: 2.5rem;
-    font-weight: var(--font-weight-light);
+    font-weight: var(--sds-fw-light);
     background: none;
     border: none;
     text-align: right;
@@ -294,7 +294,7 @@
 
     .Card {
       cursor: pointer;
-      font-weight: var(--font-weight-medium);
+      font-weight: var(--sds-fw-medium);
       font-size: 1rem;
       height: 2.9rem;
       display: flex;

--- a/extension/src/popup/components/swap/SwapAsset/SwapPickerSections/styles.scss
+++ b/extension/src/popup/components/swap/SwapAsset/SwapPickerSections/styles.scss
@@ -18,7 +18,7 @@
     // The message is passed as the Notification title, whose text SDS renders
     // semi-bold; show it at regular weight.
     .Notification__title__text {
-      font-weight: var(--font-weight-regular);
+      font-weight: var(--sds-fw-regular);
     }
   }
 
@@ -78,7 +78,7 @@
     background-color: var(--sds-clr-gray-03);
     color: var(--sds-clr-gray-11);
     font-size: 0.875rem;
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     line-height: 1.25rem;
     text-align: center;
     // A pasted address has no spaces, so wrap it across lines instead of

--- a/extension/src/popup/views/About/styles.scss
+++ b/extension/src/popup/views/About/styles.scss
@@ -16,7 +16,7 @@
 
   &__links-header {
     color: var(--sds-clr-gray-12);
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     margin-bottom: 1rem;
   }
 

--- a/extension/src/popup/views/AddAccount/ImportAccount/styles.scss
+++ b/extension/src/popup/views/AddAccount/ImportAccount/styles.scss
@@ -6,7 +6,7 @@
   &__warning-header {
     font-size: 0.875rem;
     text-transform: uppercase;
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     margin-bottom: 0.75rem;
   }
 

--- a/extension/src/popup/views/AddAccount/connect/PluginWallet/styles.scss
+++ b/extension/src/popup/views/AddAccount/connect/PluginWallet/styles.scss
@@ -13,7 +13,7 @@
   &__caption {
     margin-bottom: 0.5rem;
     font-size: 0.875rem;
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     line-height: 1.375rem;
     color: var(--sds-clr-gray-12);
   }

--- a/extension/src/popup/views/AdvancedSettings/styles.scss
+++ b/extension/src/popup/views/AdvancedSettings/styles.scss
@@ -35,7 +35,7 @@
 
       &__title {
         line-height: 1.5rem;
-        font-weight: var(--font-weight-medium);
+        font-weight: var(--sds-fw-medium);
         display: flex;
         position: relative;
         align-items: flex-start;

--- a/extension/src/popup/views/ConfirmSidebarRequest/styles.scss
+++ b/extension/src/popup/views/ConfirmSidebarRequest/styles.scss
@@ -32,7 +32,7 @@
 
   &__title {
     font-size: pxToRem(18px);
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
     line-height: pxToRem(26px);
     color: var(--sds-clr-gray-12);
     margin: 0;
@@ -40,7 +40,7 @@
 
   &__body {
     font-size: pxToRem(14px);
-    font-weight: var(--font-weight-regular);
+    font-weight: var(--sds-fw-regular);
     font-style: normal;
     line-height: pxToRem(20px);
     color: var(--sds-clr-gray-11);

--- a/extension/src/popup/views/FullscreenSuccessMessage/styles.scss
+++ b/extension/src/popup/views/FullscreenSuccessMessage/styles.scss
@@ -4,7 +4,7 @@
   &__header {
     color: var(--sds-clr-gray-12);
     display: inline-block;
-    font-weight: var(--font-weight-bold);
+    font-weight: var(--sds-fw-bold);
     font-size: 1.1rem;
     padding-left: 0.65rem;
     margin: 0;

--- a/extension/src/popup/views/ViewPublicKey/styles.scss
+++ b/extension/src/popup/views/ViewPublicKey/styles.scss
@@ -41,14 +41,14 @@
     &__name {
       color: var(--sds-clr-gray-12);
       font-size: pxToRem(16px);
-      font-weight: var(--font-weight-medium);
+      font-weight: var(--sds-fw-medium);
       line-height: pxToRem(24px);
     }
 
     &__address {
       color: var(--sds-clr-gray-11);
       font-size: pxToRem(14px);
-      font-weight: var(--font-weight-regular);
+      font-weight: var(--sds-fw-regular);
       line-height: pxToRem(20px);
     }
   }
@@ -90,7 +90,7 @@
     &__caption {
       color: var(--sds-clr-gray-11);
       font-size: pxToRem(14px);
-      font-weight: var(--font-weight-regular);
+      font-weight: var(--sds-fw-regular);
       line-height: pxToRem(20px);
       text-align: center;
     }

--- a/extension/src/popup/views/Wallets/styles.scss
+++ b/extension/src/popup/views/Wallets/styles.scss
@@ -56,7 +56,7 @@
 
   &__label {
     font-size: 0.875rem;
-    font-weight: var(--font-weight-medium);
+    font-weight: var(--sds-fw-medium);
   }
 
   &__background {


### PR DESCRIPTION
## What

The SCSS in `extension/src` referenced `var(--font-weight-light|regular|medium|semi-bold|bold)` in 59 places. **None of those custom properties are defined anywhere** — not in `extension/src`, not in `@stellar/design-system`. Every one of those declarations has been silently doing nothing.

This swaps all of them for the real SDS tokens, plus one mistyped `var(--sds-font-weight-medium)` that was broken the same way. 60 replacements, 35 files, no other changes.

## Why they're undefined

Tailwind v4 *is* loaded globally (`popup/styles/vendor/tailwind.css` → `popup/index.tsx`), and its `theme.css` does define `--font-weight-medium: 500`. But v4 prunes unused theme variables. Extracting the emitted `:root, :host` block from a fresh `extension/build/index.min.js`, the only font-weight variable that reaches the cascade is:

```
--font-weight-semibold: 600
```

…which is a different spelling from the `--font-weight-semi-bold` this repo uses.

The full Tailwind list *does* appear in the bundle, but only inside an `@theme default { … }` at-rule — a compile-time construct browsers discard as unknown. A naive grep of the build makes it look live, so this is worth knowing if you go verifying.

Since `font-weight` is inherited, each declaration was invalid at computed-value time → `unset` → inherited the parent's weight (usually 400).

## Mapping

| Replaced | With | Value | Sites |
| --- | --- | --- | --- |
| `--font-weight-light` | `--sds-fw-light` | 300 | 5 |
| `--font-weight-regular` | `--sds-fw-regular` | 400 | 7 |
| `--font-weight-medium` | `--sds-fw-medium` | 500 | 44 |
| `--font-weight-semi-bold` | `--sds-fw-semi-bold` | 600 | 2 |
| `--font-weight-bold` | `--sds-fw-bold` | 700 | 1 |
| `--sds-font-weight-medium` (typo) | `--sds-fw-medium` | 500 | 1 |

## ⚠️ This is a visual change, not a refactor

Text at the medium / semi-bold / bold sites **gets heavier** — that's the fix landing, but it touches many screens and reviewers should expect a visible diff.

Two things worth a human eyeball:

1. **The five `light` sites go the other direction — 400 → 300, i.e. thinner.** All are large display numerals, so it's plausibly intended, but it's the least-expected part of this change:
   - `components/send/styles.scss` → `__amount-label` (2.5rem)
   - `components/swap/SwapAmount/styles.scss` → `__amount-label`, `__amount-label-usd`, `__input-amount` (2.5rem)
   - `components/accountHistory/TransactionDetail/styles.scss` → `__header` (2rem)

2. **The 7 `regular` sites are true no-ops.** Each was checked for an ancestor setting a heavier weight; none nest under one, so all were already inheriting 400 and now get an explicit 400.

`swap/SwapAsset/SwapPickerSections/styles.scss` deserves a note: it carries a comment saying SDS renders the Notification title semi-bold and this rule wants it regular. SDS does set that. But the broken override still won the cascade and became `unset` → 400, so the comment's intent was already being met by accident. No visual change there either.

## Deliberately left alone

`components/manageAssetsLists/DeleteModal/styles.scss:26` is the one remaining `--font-weight-` reference, and it's genuinely corrupt:

```scss
color: --font-weight-medium --font-weight-medium;
```

Not a `var()` usage, so this sweep correctly skipped it. `git log -L` shows it was `color: var(--color-gray-70);` until `3aec8c8c` ("Release/5.20.0"), where a bad find-and-replace clobbered the *value* of a `color` property with two bare font-weight idents. It's invalid CSS, dropped at parse time, so `.DeleteModal__body` currently inherits its color. Left as-is because picking the right modern SDS gray is a design decision, not a mechanical one.

**Related rot, out of scope for this PR:** `--color-white`, `--color-red-70`, and `--color-gray-70` are likewise undefined and still referenced in several files (`ModalInfo`, `NetworkForm`, `accountMigration/basics`). Same silent-failure class — worth a follow-up.

## Testing

```
yarn test:ci
  Test Suites: 6 skipped, 197 passed, 197 of 203 total
  Tests:       51 skipped, 1525 passed, 1576 total

yarn build:extension
  webpack compiled in 23116 ms
```

Prettier clean across all 35 changed files. ESLint is wired through `lint-staged` for `src/**/*.ts?(x)` only, so it doesn't apply to a `.scss`-only diff.

Post-build check confirming the fix reaches the emitted stylesheets:

```
=== var(--sds-fw-*) in emitted CSS ===
  70 index.min.css:var(--sds-fw-medium)      16 638.min.css:var(--sds-fw-medium)
  14 index.min.css:var(--sds-fw-regular)      8 638.min.css:var(--sds-fw-regular)
   8 index.min.css:var(--sds-fw-semi-bold)    7 638.min.css:var(--sds-fw-semi-bold)
   5 index.min.css:var(--sds-fw-light)        2 638.min.css:var(--sds-fw-bold)
   1 index.min.css:var(--sds-fw-bold)
```

The only remaining `--font-weight-*` in the emitted CSS is the `DeleteModal` `color:` line above, as expected.

**Not run:** the Playwright E2E suite. Given this shifts type weight app-wide, any screenshot baselines should be checked before merge.

## Draft because

Filed as a draft so the weight changes can be eyeballed on-device first — particularly the five `light` sites going thinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
