### PR TITLE
fix(wallets): size the Add wallet chip to match the list avatars

### DIFF
--- a/extension/src/popup/views/Wallets/styles.scss
+++ b/extension/src/popup/views/Wallets/styles.scss
@@ -153,8 +153,20 @@
     justify-content: center;
 
     svg {
-      width: #{pxToRem(14px)};
-      height: #{pxToRem(14px)};
+      width: #{pxToRem(16px)};
+      height: #{pxToRem(16px)};
+    }
+
+    // Must target the path, not the svg. SDS ships these through SVGR, so the
+    // path keeps its own `stroke-width="2"` presentation attribute -- which
+    // loses to a rule matching the path, but beats a value inherited from the
+    // svg.
+    //
+    // The value is 3, not 2, because the viewBox is 24x24 while the glyph
+    // renders at 16px: strokes scale by 2/3, so 3 user units draw as 2px.
+    // Same treatment as FloatingAddButton's plus.
+    svg path {
+      stroke-width: 3;
     }
   }
 

--- a/extension/src/popup/views/Wallets/styles.scss
+++ b/extension/src/popup/views/Wallets/styles.scss
@@ -135,13 +135,15 @@
     padding-left: 0;
   }
 
-  // The chip. The plus glyph uses `stroke="currentColor"`, inheriting
-  // whatever `color` it finds — which would otherwise be the button's own
-  // (lighter) text color above. Setting `color` here keeps it the spec's
-  // more saturated fill purple.
+  // The chip. Sized to the list rows' 40px avatars so the two circles read as
+  // one column — with the 16px gap above, that also lines the "Add wallet"
+  // label up with each row's name. The plus glyph uses `stroke="currentColor"`,
+  // inheriting whatever `color` it finds — which would otherwise be the
+  // button's own (lighter) text color above. Setting `color` here keeps it the
+  // spec's more saturated fill purple.
   .Button__icon {
-    width: #{pxToRem(34px)};
-    height: #{pxToRem(34px)};
+    width: #{pxToRem(40px)};
+    height: #{pxToRem(40px)};
     flex-shrink: 0;
     border-radius: 100px;
     background-color: var(--sds-clr-lilac-02);


### PR DESCRIPTION
### What

Note: this change came from the [design review pass](https://github.com/stellar/freighter/pull/2931#issuecomment-5318239287).

On the wallets list screen, the purple "+" chip in the `Add wallet` footer was 34px while every row's identicon avatar is 40px. Sized the chip to 40px so the two circles match down the same column.

Also fixes the plus glyph inside that chip: it was 14px with SDS's default stroke, which renders ~1.2px at that size and reads thin. It now sits at 16px with a 2px stroke.

### Why

The two circled elements sit in one vertical column and read as different sizes. As a bonus, the button already zeroes its left padding and uses a 16px gap, so matching the chip width also lines the `Add wallet` label up with each row's account name.

### Scope

Two SCSS rules in one file — the chip's size (`34px` → `40px`) and the glyph's size + stroke — plus the comments above them. No TSX, no behavior change.

On the stroke: `stroke-width` goes on the `path`, not the `svg`. SDS ships these through SVGR, so the path keeps its own `stroke-width="2"` presentation attribute, which beats a value inherited from the svg but loses to a rule matching the path directly. The value is `3` because the viewBox is 24x24 against a 16px box — strokes scale by 2/3, so 3 user units draw as 2px. This is the same treatment `FloatingAddButton` already applies to this exact icon, so the two plus glyphs now render identically.

The other two spacing values were already correct and are untouched:

- `.WalletRow__identicon` — already `40px`
- `.Wallets__list` — already `gap: 16px`

<img width="358" height="599" alt="Screenshot 2026-08-17 at 17 05 05" src="https://github.com/user-attachments/assets/bc0b00f1-a0f2-4d84-adc9-f406da054d46" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
