### PR TITLE
Use the usb-flash-drive icon on the hardware wallet card

### DIFF
--- a/extension/src/popup/components/account/AddWallet/index.tsx
+++ b/extension/src/popup/components/account/AddWallet/index.tsx
@@ -29,7 +29,7 @@ export const AddWallet = ({ onBack }: AddWalletProps) => {
       link: ROUTES.importAccount,
     },
     {
-      icon: <Icon.ShieldPlus />,
+      icon: <Icon.UsbFlashDrive />,
       title: t("Connect a hardware wallet"),
       description: t("Add a wallet from a hardware wallet"),
       link: ROUTES.connectWallet,


### PR DESCRIPTION
Swaps the icon on the "Connect a hardware wallet" card in the Add Wallet view from `Icon.ShieldPlus` to the SDS `Icon.UsbFlashDrive`, which follows the updated [Figma design](https://www.figma.com/design/C3G0a4Gd6RQyplRBppGDsL/Freighter-Extension?node-id=9800-21178&t=9Ps4eS0B7gMnVRa8-1).

Single-line change in `extension/src/popup/components/account/AddWallet/index.tsx`:

```diff
-      icon: <Icon.ShieldPlus />,
+      icon: <Icon.UsbFlashDrive />,
       title: t("Connect a hardware wallet"),
```

<img width="359" height="599" alt="Screenshot 2026-08-18 at 09 46 06" src="https://github.com/user-attachments/assets/7c844733-9fdf-4303-80c2-3681a871d581" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
