### PR TITLE
feat(send): verify assembled collectible transfer matches intent before signing

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -29,6 +29,7 @@ import {
   getSymbol,
   transfer,
 } from "@shared/helpers/soroban/token";
+import { verifyFlatTransferPreparedTransaction } from "@shared/helpers/soroban/verifyPreparedTransaction";
 import {
   getAssetFromCanonical,
   getCanonicalFromAsset,
@@ -2211,6 +2212,17 @@ export const simulateSendCollectible = async (args: {
       simulationResponse: SorobanRpc.Api.SimulateTransactionSuccessResponse;
     };
   };
+
+  // The backend derives this transaction's authorization entries from simulating
+  // the target contract, not from what the wallet built. Confirm the assembled
+  // transaction still matches the flat transfer we intended before it can be
+  // signed, so no additional authorization can ride along on the user's
+  // source-account signature.
+  verifyFlatTransferPreparedTransaction({
+    builtTransaction: transaction,
+    preparedTransactionXdr: simulationResponse.response.preparedTransaction,
+    networkPassphrase: networkDetails.networkPassphrase,
+  });
 
   return simulationResponse;
 };

--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -2213,16 +2213,20 @@ export const simulateSendCollectible = async (args: {
     };
   };
 
-  // The backend derives this transaction's authorization entries from simulating
-  // the target contract, not from what the wallet built. Confirm the assembled
-  // transaction still matches the flat transfer we intended before it can be
-  // signed, so no additional authorization can ride along on the user's
-  // source-account signature.
-  verifyFlatTransferPreparedTransaction({
-    builtTransaction: transaction,
-    preparedTransactionXdr: simulationResponse.response.preparedTransaction,
-    networkPassphrase: networkDetails.networkPassphrase,
-  });
+  // The backend derives this transaction's authorization entries, fee, and
+  // resource data from simulating the target contract, not from what the wallet
+  // built. Confirm the assembled transaction still matches the flat transfer we
+  // intended before it can be signed, so no additional authorization or fee can
+  // ride along on the user's source-account signature.
+  if (simulationResponse.ok) {
+    verifyFlatTransferPreparedTransaction({
+      builtTransaction: transaction,
+      preparedTransactionXdr: simulationResponse.response.preparedTransaction,
+      networkPassphrase: networkDetails.networkPassphrase,
+      maxResourceFee:
+        simulationResponse.response.simulationResponse.minResourceFee,
+    });
+  }
 
   return simulationResponse;
 };

--- a/@shared/helpers/soroban/__tests__/verifyPreparedTransaction.test.ts
+++ b/@shared/helpers/soroban/__tests__/verifyPreparedTransaction.test.ts
@@ -65,11 +65,14 @@ const authorizedInvocation = (
   });
 
 // Rebuild the transaction the way an assembling backend does: reuse the invoked
-// host function verbatim and attach the given auth entries.
+// host function verbatim (or tamper with it), set a fee, and attach auth entries.
 const buildPreparedXdr = (
   built: Transaction,
   auth: xdr.SorobanAuthorizationEntry[],
-  { tamperFunc = false }: { tamperFunc?: boolean } = {},
+  {
+    tamperFunc = false,
+    fee = BASE_FEE,
+  }: { tamperFunc?: boolean; fee?: string } = {},
 ): string => {
   const originalOp = built.operations[0];
   if (originalOp.type !== "invokeHostFunction") {
@@ -90,25 +93,55 @@ const buildPreparedXdr = (
   const op = Operation.invokeHostFunction({ func, auth });
 
   const builder = new TransactionBuilder(new Account(SOURCE, "0"), {
-    fee: BASE_FEE,
+    fee,
     networkPassphrase: NETWORK,
   });
   return builder.addOperation(op).setTimeout(0).build().toXDR();
 };
 
+const rootTransferInvocation = (
+  subInvocations: xdr.SorobanAuthorizedInvocation[] = [],
+) =>
+  authorizedInvocation(
+    COLLECTION,
+    "transfer",
+    [
+      new Address(SOURCE).toScVal(),
+      new Address(DESTINATION).toScVal(),
+      xdr.ScVal.scvU32(TOKEN_ID),
+    ],
+    subInvocations,
+  );
+
 const sourceAccountAuth = (subInvocations: xdr.SorobanAuthorizedInvocation[]) =>
   new xdr.SorobanAuthorizationEntry({
     credentials: xdr.SorobanCredentials.sorobanCredentialsSourceAccount(),
-    rootInvocation: authorizedInvocation(
-      COLLECTION,
-      "transfer",
-      [
-        new Address(SOURCE).toScVal(),
-        new Address(DESTINATION).toScVal(),
-        xdr.ScVal.scvU32(TOKEN_ID),
-      ],
-      subInvocations,
+    rootInvocation: rootTransferInvocation(subInvocations),
+  });
+
+const addressCredentialsAuth = () =>
+  new xdr.SorobanAuthorizationEntry({
+    credentials: xdr.SorobanCredentials.sorobanCredentialsAddress(
+      new xdr.SorobanAddressCredentials({
+        address: new Address(ATTACKER).toScAddress(),
+        nonce: xdr.Int64.fromString("0"),
+        signatureExpirationLedger: 0,
+        signature: xdr.ScVal.scvVoid(),
+      }),
     ),
+    rootInvocation: rootTransferInvocation(),
+  });
+
+const verify = (
+  built: Transaction,
+  preparedXdr: string,
+  maxResourceFee = "0",
+) =>
+  verifyFlatTransferPreparedTransaction({
+    builtTransaction: built,
+    preparedTransactionXdr: preparedXdr,
+    networkPassphrase: NETWORK,
+    maxResourceFee,
   });
 
 describe("verifyFlatTransferPreparedTransaction", () => {
@@ -116,26 +149,23 @@ describe("verifyFlatTransferPreparedTransaction", () => {
     const built = buildFlatTransfer();
     const preparedXdr = buildPreparedXdr(built, [sourceAccountAuth([])]);
 
-    expect(() =>
-      verifyFlatTransferPreparedTransaction({
-        builtTransaction: built,
-        preparedTransactionXdr: preparedXdr,
-        networkPassphrase: NETWORK,
-      }),
-    ).not.toThrow();
+    expect(() => verify(built, preparedXdr)).not.toThrow();
   });
 
   it("accepts a transfer with no auth entries at all", () => {
     const built = buildFlatTransfer();
     const preparedXdr = buildPreparedXdr(built, []);
 
-    expect(() =>
-      verifyFlatTransferPreparedTransaction({
-        builtTransaction: built,
-        preparedTransactionXdr: preparedXdr,
-        networkPassphrase: NETWORK,
-      }),
-    ).not.toThrow();
+    expect(() => verify(built, preparedXdr)).not.toThrow();
+  });
+
+  it("accepts a fee raised by up to the simulated resource fee", () => {
+    const built = buildFlatTransfer(); // fee = BASE_FEE (100)
+    const preparedXdr = buildPreparedXdr(built, [sourceAccountAuth([])], {
+      fee: "600",
+    });
+
+    expect(() => verify(built, preparedXdr, "500")).not.toThrow();
   });
 
   it("rejects sub-invocations injected under the source-account entry", () => {
@@ -153,13 +183,9 @@ describe("verifyFlatTransferPreparedTransaction", () => {
     ]);
     const preparedXdr = buildPreparedXdr(built, [sourceAccountAuth([drain])]);
 
-    expect(() =>
-      verifyFlatTransferPreparedTransaction({
-        builtTransaction: built,
-        preparedTransactionXdr: preparedXdr,
-        networkPassphrase: NETWORK,
-      }),
-    ).toThrow(PreparedTransactionMismatchError);
+    expect(() => verify(built, preparedXdr)).toThrow(
+      PreparedTransactionMismatchError,
+    );
   });
 
   it("rejects a tampered invoked host function (different arguments)", () => {
@@ -168,12 +194,22 @@ describe("verifyFlatTransferPreparedTransaction", () => {
       tamperFunc: true,
     });
 
-    expect(() =>
-      verifyFlatTransferPreparedTransaction({
-        builtTransaction: built,
-        preparedTransactionXdr: preparedXdr,
-        networkPassphrase: NETWORK,
-      }),
-    ).toThrow(/host function/);
+    expect(() => verify(built, preparedXdr)).toThrow(/host function/);
+  });
+
+  it("rejects a fee larger than the built fee plus the simulated resource fee", () => {
+    const built = buildFlatTransfer(); // fee = BASE_FEE (100)
+    const preparedXdr = buildPreparedXdr(built, [sourceAccountAuth([])], {
+      fee: "100000000",
+    });
+
+    expect(() => verify(built, preparedXdr, "500")).toThrow(/fee/);
+  });
+
+  it("rejects non-source-account (address) credentials", () => {
+    const built = buildFlatTransfer();
+    const preparedXdr = buildPreparedXdr(built, [addressCredentialsAuth()]);
+
+    expect(() => verify(built, preparedXdr)).toThrow(/source-account/);
   });
 });

--- a/@shared/helpers/soroban/__tests__/verifyPreparedTransaction.test.ts
+++ b/@shared/helpers/soroban/__tests__/verifyPreparedTransaction.test.ts
@@ -72,7 +72,8 @@ const buildPreparedXdr = (
   {
     tamperFunc = false,
     fee = BASE_FEE,
-  }: { tamperFunc?: boolean; fee?: string } = {},
+    opSource,
+  }: { tamperFunc?: boolean; fee?: string; opSource?: string } = {},
 ): string => {
   const originalOp = built.operations[0];
   if (originalOp.type !== "invokeHostFunction") {
@@ -90,7 +91,7 @@ const buildPreparedXdr = (
       )
     : originalOp.func;
 
-  const op = Operation.invokeHostFunction({ func, auth });
+  const op = Operation.invokeHostFunction({ func, auth, source: opSource });
 
   const builder = new TransactionBuilder(new Account(SOURCE, "0"), {
     fee,
@@ -130,6 +131,23 @@ const addressCredentialsAuth = () =>
       }),
     ),
     rootInvocation: rootTransferInvocation(),
+  });
+
+// A source-account auth entry whose root invocation is an unrelated contract
+// call (a token transfer to the attacker) with no sub-invocations.
+const unrelatedRootAuth = () =>
+  new xdr.SorobanAuthorizationEntry({
+    credentials: xdr.SorobanCredentials.sorobanCredentialsSourceAccount(),
+    rootInvocation: authorizedInvocation(SAC, "transfer", [
+      new Address(SOURCE).toScVal(),
+      new Address(ATTACKER).toScVal(),
+      xdr.ScVal.scvI128(
+        new xdr.Int128Parts({
+          hi: xdr.Int64.fromString("0"),
+          lo: xdr.Uint64.fromString("99884944477"),
+        }),
+      ),
+    ]),
   });
 
 const verify = (
@@ -211,5 +229,32 @@ describe("verifyFlatTransferPreparedTransaction", () => {
     const preparedXdr = buildPreparedXdr(built, [addressCredentialsAuth()]);
 
     expect(() => verify(built, preparedXdr)).toThrow(/source-account/);
+  });
+
+  it("rejects a source-account auth entry whose root is an unrelated call", () => {
+    const built = buildFlatTransfer();
+    const preparedXdr = buildPreparedXdr(built, [unrelatedRootAuth()]);
+
+    expect(() => verify(built, preparedXdr)).toThrow(/authorization root/);
+  });
+
+  it("rejects a changed operation source", () => {
+    const built = buildFlatTransfer();
+    const preparedXdr = buildPreparedXdr(built, [sourceAccountAuth([])], {
+      opSource: ATTACKER,
+    });
+
+    expect(() => verify(built, preparedXdr)).toThrow(/operation source/);
+  });
+
+  it("rejects a non-finite simulated resource fee (fee ceiling cannot fail open)", () => {
+    const built = buildFlatTransfer();
+    const preparedXdr = buildPreparedXdr(built, [sourceAccountAuth([])], {
+      fee: "100000000",
+    });
+
+    expect(() => verify(built, preparedXdr, "Infinity")).toThrow(
+      /resource fee/,
+    );
   });
 });

--- a/@shared/helpers/soroban/__tests__/verifyPreparedTransaction.test.ts
+++ b/@shared/helpers/soroban/__tests__/verifyPreparedTransaction.test.ts
@@ -1,0 +1,179 @@
+import {
+  Account,
+  Address,
+  Networks,
+  Operation,
+  StrKey,
+  Transaction,
+  TransactionBuilder,
+  BASE_FEE,
+  xdr,
+} from "stellar-sdk";
+
+import { transfer } from "@shared/helpers/soroban/token";
+import {
+  verifyFlatTransferPreparedTransaction,
+  PreparedTransactionMismatchError,
+} from "@shared/helpers/soroban/verifyPreparedTransaction";
+
+const NETWORK = Networks.TESTNET;
+
+// Deterministic, valid strkey addresses for the test.
+const SOURCE = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+const DESTINATION = StrKey.encodeEd25519PublicKey(Buffer.alloc(32, 2));
+const ATTACKER = StrKey.encodeEd25519PublicKey(Buffer.alloc(32, 9));
+const COLLECTION = StrKey.encodeContract(Buffer.alloc(32, 1));
+const SAC = StrKey.encodeContract(Buffer.alloc(32, 7));
+const TOKEN_ID = 1;
+
+const buildFlatTransfer = (): Transaction => {
+  const builder = new TransactionBuilder(new Account(SOURCE, "0"), {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK,
+  });
+  const params = [
+    new Address(SOURCE).toScVal(),
+    new Address(DESTINATION).toScVal(),
+    xdr.ScVal.scvU32(TOKEN_ID),
+  ];
+  return transfer(COLLECTION, params, undefined, builder);
+};
+
+const invokeContractArgs = (
+  contractId: string,
+  fn: string,
+  args: xdr.ScVal[],
+) =>
+  new xdr.InvokeContractArgs({
+    contractAddress: new Address(contractId).toScAddress(),
+    functionName: fn,
+    args,
+  });
+
+const authorizedInvocation = (
+  contractId: string,
+  fn: string,
+  args: xdr.ScVal[],
+  subInvocations: xdr.SorobanAuthorizedInvocation[] = [],
+) =>
+  new xdr.SorobanAuthorizedInvocation({
+    function:
+      xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
+        invokeContractArgs(contractId, fn, args),
+      ),
+    subInvocations,
+  });
+
+// Rebuild the transaction the way an assembling backend does: reuse the invoked
+// host function verbatim and attach the given auth entries.
+const buildPreparedXdr = (
+  built: Transaction,
+  auth: xdr.SorobanAuthorizationEntry[],
+  { tamperFunc = false }: { tamperFunc?: boolean } = {},
+): string => {
+  const originalOp = built.operations[0];
+  if (originalOp.type !== "invokeHostFunction") {
+    throw new Error("test setup: expected invokeHostFunction");
+  }
+
+  const func = tamperFunc
+    ? xdr.HostFunction.hostFunctionTypeInvokeContract(
+        // Same contract/function, but a different destination argument.
+        invokeContractArgs(COLLECTION, "transfer", [
+          new Address(SOURCE).toScVal(),
+          new Address(ATTACKER).toScVal(),
+          xdr.ScVal.scvU32(TOKEN_ID),
+        ]),
+      )
+    : originalOp.func;
+
+  const op = Operation.invokeHostFunction({ func, auth });
+
+  const builder = new TransactionBuilder(new Account(SOURCE, "0"), {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK,
+  });
+  return builder.addOperation(op).setTimeout(0).build().toXDR();
+};
+
+const sourceAccountAuth = (subInvocations: xdr.SorobanAuthorizedInvocation[]) =>
+  new xdr.SorobanAuthorizationEntry({
+    credentials: xdr.SorobanCredentials.sorobanCredentialsSourceAccount(),
+    rootInvocation: authorizedInvocation(
+      COLLECTION,
+      "transfer",
+      [
+        new Address(SOURCE).toScVal(),
+        new Address(DESTINATION).toScVal(),
+        xdr.ScVal.scvU32(TOKEN_ID),
+      ],
+      subInvocations,
+    ),
+  });
+
+describe("verifyFlatTransferPreparedTransaction", () => {
+  it("accepts an honest flat transfer (source-account auth, no sub-invocations)", () => {
+    const built = buildFlatTransfer();
+    const preparedXdr = buildPreparedXdr(built, [sourceAccountAuth([])]);
+
+    expect(() =>
+      verifyFlatTransferPreparedTransaction({
+        builtTransaction: built,
+        preparedTransactionXdr: preparedXdr,
+        networkPassphrase: NETWORK,
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts a transfer with no auth entries at all", () => {
+    const built = buildFlatTransfer();
+    const preparedXdr = buildPreparedXdr(built, []);
+
+    expect(() =>
+      verifyFlatTransferPreparedTransaction({
+        builtTransaction: built,
+        preparedTransactionXdr: preparedXdr,
+        networkPassphrase: NETWORK,
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects sub-invocations injected under the source-account entry", () => {
+    const built = buildFlatTransfer();
+    // A token transfer recorded as a sub-invocation under the root entry.
+    const drain = authorizedInvocation(SAC, "transfer", [
+      new Address(SOURCE).toScVal(),
+      new Address(ATTACKER).toScVal(),
+      xdr.ScVal.scvI128(
+        new xdr.Int128Parts({
+          hi: xdr.Int64.fromString("0"),
+          lo: xdr.Uint64.fromString("99884944477"),
+        }),
+      ),
+    ]);
+    const preparedXdr = buildPreparedXdr(built, [sourceAccountAuth([drain])]);
+
+    expect(() =>
+      verifyFlatTransferPreparedTransaction({
+        builtTransaction: built,
+        preparedTransactionXdr: preparedXdr,
+        networkPassphrase: NETWORK,
+      }),
+    ).toThrow(PreparedTransactionMismatchError);
+  });
+
+  it("rejects a tampered invoked host function (different arguments)", () => {
+    const built = buildFlatTransfer();
+    const preparedXdr = buildPreparedXdr(built, [sourceAccountAuth([])], {
+      tamperFunc: true,
+    });
+
+    expect(() =>
+      verifyFlatTransferPreparedTransaction({
+        builtTransaction: built,
+        preparedTransactionXdr: preparedXdr,
+        networkPassphrase: NETWORK,
+      }),
+    ).toThrow(/host function/);
+  });
+});

--- a/@shared/helpers/soroban/verifyPreparedTransaction.ts
+++ b/@shared/helpers/soroban/verifyPreparedTransaction.ts
@@ -1,3 +1,4 @@
+import BigNumber from "bignumber.js";
 import { Transaction, TransactionBuilder, xdr } from "stellar-sdk";
 
 /**
@@ -11,21 +12,33 @@ export class PreparedTransactionMismatchError extends Error {
   }
 }
 
+// Decode a transaction to its XDR body so individual fields can be compared
+// without depending on SDK accessor shapes.
+const txBody = (transactionXdr: string): xdr.Transaction =>
+  xdr.TransactionEnvelope.fromXDR(transactionXdr, "base64").v1().tx();
+
 /**
- * Verify that a backend-assembled `preparedTransaction` still matches the flat
+ * Verify that a backend-assembled `preparedTransactionXdr` still matches the flat
  * Soroban transfer the wallet built, before it is signed.
  *
  * When the wallet builds a transfer with no authorization entries and delegates
- * simulation and assembly to a backend, the authorization entries are derived
- * from simulating the target contract rather than constructed by the wallet.
- * The wallet is the only party that knows the intended call, so it must confirm
- * the assembled transaction still matches that intent before signing.
+ * simulation and assembly to a backend, the authorization entries, resource fee,
+ * and Soroban resource data are derived from simulating the target contract
+ * rather than constructed by the wallet. The wallet is the only party that knows
+ * the intended call, so it must confirm the assembled transaction still matches
+ * that intent before signing.
  *
- * For a flat transfer we refuse to sign anything where:
- *  - the invoked host function is not byte-identical to what we built (simulation
- *    may only add fee / sorobanData / auth, never change the call), or
- *  - any auth entry is not source-account credentials, or
- *  - any auth entry authorizes sub-invocations below the root.
+ * Assembly is only allowed to change three things: the transaction `fee` (raising
+ * it by at most the simulated resource fee), the Soroban resource data
+ * (`ext` / sorobanData), and the operation's authorization entries. Everything
+ * else must be identical to what the wallet built. Concretely we refuse to sign
+ * when:
+ *  - the operation set is not the single invokeHostFunction we built, or its host
+ *    function (contract, function, args) is not byte-identical, or
+ *  - any other envelope field (source, sequence, memo, preconditions) differs, or
+ *  - the fee exceeds the built fee plus the simulated resource fee, or
+ *  - any auth entry is not source-account credentials, or authorizes
+ *    sub-invocations below the root.
  *
  * A flat transfer never legitimately needs sub-invocations. Flows that do (e.g.
  * swaps) must not use this helper — they need effect-bounded verification.
@@ -34,10 +47,13 @@ export const verifyFlatTransferPreparedTransaction = ({
   builtTransaction,
   preparedTransactionXdr,
   networkPassphrase,
+  maxResourceFee,
 }: {
   builtTransaction: Transaction;
   preparedTransactionXdr: string;
   networkPassphrase: string;
+  // The resource fee reported by simulation and shown to the user, in stroops.
+  maxResourceFee: string;
 }): void => {
   const prepared = TransactionBuilder.fromXDR(
     preparedTransactionXdr,
@@ -69,11 +85,44 @@ export const verifyFlatTransferPreparedTransaction = ({
   }
 
   // The invoked host function — contract, function name, and arguments — must be
-  // exactly what the wallet constructed. Simulation is only allowed to add
-  // fee / sorobanData / auth, never to alter the call itself.
+  // exactly what the wallet constructed.
   if (builtOp.func.toXDR("base64") !== preparedOp.func.toXDR("base64")) {
     throw new PreparedTransactionMismatchError(
       "invoked host function does not match the transaction the wallet built",
+    );
+  }
+
+  // Every other envelope field must be identical to what the wallet built. Only
+  // fee, sorobanData (ext), and the operation's auth are allowed to change during
+  // assembly, and those are checked separately below.
+  const builtBody = txBody(builtTransaction.toXDR());
+  const preparedBody = txBody(preparedTransactionXdr);
+  const envelopeFields: [
+    string,
+    (tx: xdr.Transaction) => { toXDR(format: "base64"): string },
+  ][] = [
+    ["source account", (tx) => tx.sourceAccount()],
+    ["sequence number", (tx) => tx.seqNum()],
+    ["memo", (tx) => tx.memo()],
+    ["preconditions", (tx) => tx.cond()],
+  ];
+  envelopeFields.forEach(([label, get]) => {
+    if (get(builtBody).toXDR("base64") !== get(preparedBody).toXDR("base64")) {
+      throw new PreparedTransactionMismatchError(
+        `${label} does not match the transaction the wallet built`,
+      );
+    }
+  });
+
+  // The fee may only be raised by the simulated resource fee that the user was
+  // shown. A larger fee means the signed envelope authorizes spending more than
+  // the review screen displayed.
+  const maxFee = new BigNumber(builtTransaction.fee).plus(
+    maxResourceFee || "0",
+  );
+  if (new BigNumber(prepared.fee).isGreaterThan(maxFee)) {
+    throw new PreparedTransactionMismatchError(
+      "fee exceeds the built fee plus the simulated resource fee",
     );
   }
 

--- a/@shared/helpers/soroban/verifyPreparedTransaction.ts
+++ b/@shared/helpers/soroban/verifyPreparedTransaction.ts
@@ -1,0 +1,99 @@
+import { Transaction, TransactionBuilder, xdr } from "stellar-sdk";
+
+/**
+ * Thrown when an assembled transaction does not match the transaction the wallet
+ * built. Callers must treat this as "do not sign".
+ */
+export class PreparedTransactionMismatchError extends Error {
+  constructor(reason: string) {
+    super(`Prepared transaction failed verification: ${reason}`);
+    this.name = "PreparedTransactionMismatchError";
+  }
+}
+
+/**
+ * Verify that a backend-assembled `preparedTransaction` still matches the flat
+ * Soroban transfer the wallet built, before it is signed.
+ *
+ * When the wallet builds a transfer with no authorization entries and delegates
+ * simulation and assembly to a backend, the authorization entries are derived
+ * from simulating the target contract rather than constructed by the wallet.
+ * The wallet is the only party that knows the intended call, so it must confirm
+ * the assembled transaction still matches that intent before signing.
+ *
+ * For a flat transfer we refuse to sign anything where:
+ *  - the invoked host function is not byte-identical to what we built (simulation
+ *    may only add fee / sorobanData / auth, never change the call), or
+ *  - any auth entry is not source-account credentials, or
+ *  - any auth entry authorizes sub-invocations below the root.
+ *
+ * A flat transfer never legitimately needs sub-invocations. Flows that do (e.g.
+ * swaps) must not use this helper — they need effect-bounded verification.
+ */
+export const verifyFlatTransferPreparedTransaction = ({
+  builtTransaction,
+  preparedTransactionXdr,
+  networkPassphrase,
+}: {
+  builtTransaction: Transaction;
+  preparedTransactionXdr: string;
+  networkPassphrase: string;
+}): void => {
+  const prepared = TransactionBuilder.fromXDR(
+    preparedTransactionXdr,
+    networkPassphrase,
+  );
+
+  if (!(prepared instanceof Transaction)) {
+    throw new PreparedTransactionMismatchError(
+      "prepared transaction is a fee-bump, not a plain transaction",
+    );
+  }
+
+  if (prepared.operations.length !== 1) {
+    throw new PreparedTransactionMismatchError(
+      `expected exactly 1 operation, got ${prepared.operations.length}`,
+    );
+  }
+
+  const builtOp = builtTransaction.operations[0];
+  const preparedOp = prepared.operations[0];
+
+  if (
+    builtOp.type !== "invokeHostFunction" ||
+    preparedOp.type !== "invokeHostFunction"
+  ) {
+    throw new PreparedTransactionMismatchError(
+      "operation is not invokeHostFunction",
+    );
+  }
+
+  // The invoked host function — contract, function name, and arguments — must be
+  // exactly what the wallet constructed. Simulation is only allowed to add
+  // fee / sorobanData / auth, never to alter the call itself.
+  if (builtOp.func.toXDR("base64") !== preparedOp.func.toXDR("base64")) {
+    throw new PreparedTransactionMismatchError(
+      "invoked host function does not match the transaction the wallet built",
+    );
+  }
+
+  // Every auth entry must be covered by the plain source-account signature and
+  // must not authorize anything beneath the root invocation.
+  const auths = preparedOp.auth || [];
+  for (const auth of auths) {
+    if (
+      auth.credentials().switch() !==
+      xdr.SorobanCredentialsType.sorobanCredentialsSourceAccount()
+    ) {
+      throw new PreparedTransactionMismatchError(
+        "authorization entry is not source-account credentials",
+      );
+    }
+
+    if (auth.rootInvocation().subInvocations().length > 0) {
+      throw new PreparedTransactionMismatchError(
+        "authorization entry authorizes sub-invocations",
+      );
+    }
+  }
+};

--- a/@shared/helpers/soroban/verifyPreparedTransaction.ts
+++ b/@shared/helpers/soroban/verifyPreparedTransaction.ts
@@ -92,6 +92,16 @@ export const verifyFlatTransferPreparedTransaction = ({
     );
   }
 
+  // The operation source determines the source-account credential identity, so it
+  // is part of the wallet's intent and must not be changed during assembly. The
+  // wallet builds the operation with no explicit source (it inherits the tx
+  // source), so both must be undefined here.
+  if (builtOp.source !== preparedOp.source) {
+    throw new PreparedTransactionMismatchError(
+      "operation source does not match the transaction the wallet built",
+    );
+  }
+
   // Every other envelope field must be identical to what the wallet built. Only
   // fee, sorobanData (ext), and the operation's auth are allowed to change during
   // assembly, and those are checked separately below.
@@ -116,18 +126,30 @@ export const verifyFlatTransferPreparedTransaction = ({
 
   // The fee may only be raised by the simulated resource fee that the user was
   // shown. A larger fee means the signed envelope authorizes spending more than
-  // the review screen displayed.
-  const maxFee = new BigNumber(builtTransaction.fee).plus(
-    maxResourceFee || "0",
-  );
+  // the review screen displayed. Validate the resource fee first: a non-finite
+  // or negative value would otherwise make the ceiling non-finite and pass any
+  // fee.
+  const resourceFee = new BigNumber(maxResourceFee || "0");
+  if (
+    !resourceFee.isFinite() ||
+    !resourceFee.isInteger() ||
+    resourceFee.isNegative()
+  ) {
+    throw new PreparedTransactionMismatchError(
+      "simulated resource fee is not a valid non-negative integer",
+    );
+  }
+  const maxFee = new BigNumber(builtTransaction.fee).plus(resourceFee);
   if (new BigNumber(prepared.fee).isGreaterThan(maxFee)) {
     throw new PreparedTransactionMismatchError(
       "fee exceeds the built fee plus the simulated resource fee",
     );
   }
 
-  // Every auth entry must be covered by the plain source-account signature and
-  // must not authorize anything beneath the root invocation.
+  // Every auth entry must be covered by the plain source-account signature, must
+  // authorize exactly the transfer we invoked (not some other contract call), and
+  // must not authorize anything beneath that root invocation.
+  const intendedCall = builtOp.func.invokeContract().toXDR("base64");
   const auths = preparedOp.auth || [];
   for (const auth of auths) {
     if (
@@ -136,6 +158,21 @@ export const verifyFlatTransferPreparedTransaction = ({
     ) {
       throw new PreparedTransactionMismatchError(
         "authorization entry is not source-account credentials",
+      );
+    }
+
+    const rootFunction = auth.rootInvocation().function();
+    if (
+      rootFunction.switch() !==
+      xdr.SorobanAuthorizedFunctionType.sorobanAuthorizedFunctionTypeContractFn()
+    ) {
+      throw new PreparedTransactionMismatchError(
+        "authorization root is not a contract-function call",
+      );
+    }
+    if (rootFunction.contractFn().toXDR("base64") !== intendedCall) {
+      throw new PreparedTransactionMismatchError(
+        "authorization root does not match the invoked transfer",
       );
     }
 

--- a/extension/e2e-tests/helpers/stubs.ts
+++ b/extension/e2e-tests/helpers/stubs.ts
@@ -187,10 +187,18 @@ export const stubHorizonTransactions = async (page: Page) => {
 
 export const stubBackendSimulateTx = async (page: Page) => {
   await page.route("**/simulate-tx**", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.continue();
+      return;
+    }
+    // Echo the submitted transaction back as the prepared transaction, the way
+    // the real backend assembles the same tx. A canned, unrelated XDR would be
+    // rejected by verifyFlatTransferPreparedTransaction, which requires the
+    // prepared transaction to match the one the wallet built.
+    const body = JSON.parse(route.request().postData() || "{}");
     await route.fulfill({
       json: {
-        preparedTransaction:
-          "AAAAAgAAAABNGU5jYvjfSepLUbRF52FIw18Fm1F76RViTI0pjWF7VAAAAZAAAAABAAAAAAAAAAEAAAAAAAAAAAAAAAEAAAAAAAAABAAAAAAAAAAAAAA=",
+        preparedTransaction: body.xdr,
         simulationResponse: {
           minResourceFee: "100",
           cost: {
@@ -2838,9 +2846,17 @@ export const stubMemoRequiredAccounts = async (
 
 export const stubSimulateSendCollectible = async (page: Page) => {
   await page.route("**/simulate-tx", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.continue();
+      return;
+    }
+    // Echo the submitted transaction back as the prepared transaction, the way
+    // the real backend assembles the same tx. A canned, unrelated XDR would be
+    // rejected by verifyFlatTransferPreparedTransaction, which requires the
+    // prepared transaction to match the one the wallet built.
+    const body = JSON.parse(route.request().postData() || "{}");
     const json = {
-      preparedTransaction:
-        "AAAAAgAAAABngBTmbmUycqG2cAMHcomSR80dRzGtKzxM6gb3yySD5AACQ3sCjnUGAAABkQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABp4YjrCeaVIvf6/Qjtqbnv4gmHScnZ/YgfjDVWV8aKUEAAAAIdHJhbnNmZXIAAAADAAAAEgAAAAAAAAAAZ4AU5m5lMnKhtnADB3KJkkfNHUcxrSs8TOoG98skg+QAAAASAAAAAAAAAABVZkfzT8IUCc68cala6hWfNx8vR5j+La0nQf3V+7AGYwAAAAMAAAACAAAAAQAAAAAAAAAAAAAAAaeGI6wnmlSL3+v0I7am57+IJh0nJ2f2IH4w1VlfGilBAAAACHRyYW5zZmVyAAAAAwAAABIAAAAAAAAAAGeAFOZuZTJyobZwAwdyiZJHzR1HMa0rPEzqBvfLJIPkAAAAEgAAAAAAAAAAVWZH80/CFAnOvHGpWuoVnzcfL0eY/i2tJ0H91fuwBmMAAAADAAAAAgAAAAAAAAABAAAAAAAAAAIAAAAGAAAAAaeGI6wnmlSL3+v0I7am57+IJh0nJ2f2IH4w1VlfGilBAAAAFAAAAAEAAAAHP3eS4onfldMZntnbNaDPKlFUqmTNcpioxEG3FwIwY1sAAAAGAAAABgAAAAGnhiOsJ5pUi9/r9CO2pue/iCYdJydn9iB+MNVZXxopQQAAABAAAAABAAAAAgAAAA8AAAAIQXBwcm92YWwAAAADAAAAAgAAAAAAAAAGAAAAAaeGI6wnmlSL3+v0I7am57+IJh0nJ2f2IH4w1VlfGilBAAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAAAAAAAAFVmR/NPwhQJzrxxqVrqFZ83Hy9HmP4trSdB/dX7sAZjAAAAAQAAAAYAAAABp4YjrCeaVIvf6/Qjtqbnv4gmHScnZ/YgfjDVWV8aKUEAAAAQAAAAAQAAAAIAAAAPAAAAB0JhbGFuY2UAAAAAEgAAAAAAAAAAZ4AU5m5lMnKhtnADB3KJkkfNHUcxrSs8TOoG98skg+QAAAABAAAABgAAAAGnhiOsJ5pUi9/r9CO2pue/iCYdJydn9iB+MNVZXxopQQAAABAAAAABAAAAAgAAAA8AAAAFT3duZXIAAAAAAAADAAAAAgAAAAEAAAAGAAAAAaeGI6wnmlSL3+v0I7am57+IJh0nJ2f2IH4w1VlfGilBAAAAEAAAAAEAAAACAAAADwAAAAtPd25lclRva2VucwAAAAASAAAAAAAAAABVZkfzT8IUCc68cala6hWfNx8vR5j+La0nQf3V+7AGYwAAAAEAAAAGAAAAAaeGI6wnmlSL3+v0I7am57+IJh0nJ2f2IH4w1VlfGilBAAAAEAAAAAEAAAACAAAADwAAAAtPd25lclRva2VucwAAAAASAAAAAAAAAABngBTmbmUycqG2cAMHcomSR80dRzGtKzxM6gb3yySD5AAAAAEAGSIiAAAAAAAAAsgAAAAAAAJDewAAAAA=",
+      preparedTransaction: body.xdr,
       simulationResponse: {
         minResourceFee: "100",
       },

--- a/extension/e2e-tests/reviewTxFees.test.ts
+++ b/extension/e2e-tests/reviewTxFees.test.ts
@@ -147,10 +147,13 @@ test("Collectible simulation falls back to BASE_FEE on first mount when Redux tr
         return;
       }
       simulateTxCallCount += 1;
+      // Echo the submitted transaction back as the prepared transaction, the way
+      // the real backend assembles the same tx. verifyFlatTransferPreparedTransaction
+      // rejects a prepared transaction that does not match the one the wallet built.
+      const body = JSON.parse(route.request().postData() || "{}");
       await route.fulfill({
         json: {
-          preparedTransaction:
-            "AAAAAgAAAABngBTmbmUycqG2cAMHcomSR80dRzGtKzxM6gb3yySD5AACQ3sCjnUGAAABkQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABp4YjrCeaVIvf6/Qjtqbnv4gmHScnZ/YgfjDVWV8aKUEAAAAIdHJhbnNmZXIAAAADAAAAEgAAAAAAAAAAZ4AU5m5lMnKhtnADB3KJkkfNHUcxrSs8TOoG98skg+QAAAASAAAAAAAAAABVZkfzT8IUCc68cala6hWfNx8vR5j+La0nQf3V+7AGYwAAAAMAAAACAAAAAQAAAAAAAAAAAAAAAaeGI6wnmlSL3+v0I7am57+IJh0nJ2f2IH4w1VlfGilBAAAACHRyYW5zZmVyAAAAAwAAABIAAAAAAAAAAGeAFOZuZTJyobZwAwdyiZJHzR1HMa0rPEzqBvfLJIPkAAAAEgAAAAAAAAAAVWZH80/CFAnOvHGpWuoVnzcfL0eY/i2tJ0H91fuwBmMAAAADAAAAAgAAAAA=",
+          preparedTransaction: body.xdr,
           simulationResponse: { minResourceFee: "100" },
         },
       });


### PR DESCRIPTION
### What

The collectible send flow builds a Soroban transfer with no authorization entries and delegates simulation and assembly to the backend. The authorization entries on the returned transaction are therefore derived from simulating the target contract, not built by the wallet.

The wallet is the only party that knows the call it intended, so it should confirm the assembled transaction still matches that intent before signing, rather than adopting the returned bytes verbatim.


###  Why

Simulation is used to discover the fee and authorization a transaction needs, but the wallet should not treat the simulated result as the definition of what it signs. Re-deriving and comparing against the locally built call keeps the wallet the authority on its own transactions, and holds even if the assembling
service returns something unexpected.

### Known Limitation 

To fix this we can't just copy paste auth-entry guard onto `/simulate-tx` in the freighter-backend, due to Soroswap flow, which also calls this endpoint and legitimately produces sub-invocations.

### Testing
- `verifyPreparedTransaction.test.ts` covers: honest flat transfer accepted, empty auth accepted, sub-invocation under the root rejected, tampered host  function rejected.
- `tsc --noEmit` clean; full jest suite green.
