### PR TITLE
Keep the SignMessage trust warning inside the footer

### DIFF
--- a/extension/src/popup/views/SignMessage/index.tsx
+++ b/extension/src/popup/views/SignMessage/index.tsx
@@ -359,7 +359,10 @@ export const SignMessage = () => {
             </div>
           )}
         </View.Content>
-        <View.Footer>
+        {/* The default footer is a fixed 80px, which this footer's warning line
+            plus button row overflows — the text then spills up over the content
+            pane. Size to content so it grows instead. */}
+        <View.Footer customHeight="auto">
           {!shouldShowWarning && (
             <span className="SignMessage__Warning">
               {t("Only confirm if you trust this site")}

--- a/extension/src/popup/views/SignMessage/styles.scss
+++ b/extension/src/popup/views/SignMessage/styles.scss
@@ -64,6 +64,10 @@
   }
 
   &__Warning {
+    // The footer clears 36px below the buttons (24px footer padding + the 12px
+    // Actions margin). The content pane's own bottom padding contributes 24px
+    // above this line, so add 12px to match, keeping the line evenly inset.
+    margin-top: pxToRem(12px);
     color: var(--sds-clr-gray-10);
     text-align: center;
     font-size: pxToRem(14px);


### PR DESCRIPTION
## TL;DR

The "Only confirm if you trust this site" line was rendering *on top of* the Wallet/Network card instead of inside the footer, whenever the message being signed was long enough to fill the scroll area. The footer was a fixed height that its own contents overflowed; it now sizes to its content, and the warning line is evenly spaced above the buttons.

### Before fix

<img width="472" height="744" alt="sign-message-bug" src="https://github.com/user-attachments/assets/68acd918-da48-48d6-b7fc-75f51b4e6ac7" />

### After fix

<img width="472" height="744" alt="Screenshot 2026-08-19 at 16 51 45" src="https://github.com/user-attachments/assets/ebdc65f7-f56b-40eb-8f72-1f022003c696" />
<img width="472" height="744" alt="Screenshot 2026-08-19 at 16 52 56" src="https://github.com/user-attachments/assets/b6529aa8-2bd1-4157-87c7-13372010061d" />
<img width="472" height="744" alt="Screenshot 2026-08-19 at 16 53 03" src="https://github.com/user-attachments/assets/ab66855b-aa44-4a56-a1f7-5b06aa3bc83e" />

https://github.com/user-attachments/assets/0b2cdc00-04e9-429d-a6d3-fc1799d6531e


<details>
<summary>Implementation details (for agents)</summary>

**Root cause:** `.View__footer` is pinned to a fixed `height: var(--View-footer-height)` (80px), with its inset at `height: 100%; justify-content: flex-end`:

https://github.com/stellar/freighter/blob/07a55b8418e23dd809c5bf86c3afe10194c4d5ff/extension/src/popup/basics/layout/View/styles.scss#L98-L111

SignMessage's footer needs ~120px (20px warning + 16px gap + 48px buttons + 12px margin + 24px padding), so the warning line overflowed 40px *upward* out of the footer box and painted over the content pane. The markup was already correct — the warning has always been inside `View.Footer`, above the buttons.

It only showed up with a long message because that is when the Metadata card is pushed to the bottom of the scroll area; with a short message the overflow lands on empty space.

**What changed:**

- `views/SignMessage/index.tsx` — pass `customHeight="auto"` to `View.Footer`. This is the prop the component already exposes for exactly this case (it sets `--View-footer-height`), so the footer sizes to its content and `View__content` shrinks and scrolls instead. `auto` rather than a hardcoded `120px` because the label wraps in translation.
- `views/SignMessage/styles.scss` — `margin-top: 12px` on `.SignMessage__Warning`. The content pane's bottom padding gives 24px above the line, while the footer clears 36px below the buttons (24px footer padding + the 12px `Actions` margin), so this evens the two up.

The 16px between the warning and the buttons is left alone — that is `--View-footer-gap`, the standard spacing between stacked footer elements.

**Verification:** reproduced the layout in headless Chromium with the exact CSS rules and measured it:

| | footer height | warning overflow above footer | overlaps "Network" row |
|---|---|---|---|
| before | 80px | **40px** | **yes** |
| after | 120px | 0px | no |

The 40px matches the reported screenshot. Spacing after the second commit: 36px above the string, 36px below the buttons. Re-checked with the longer `pt` translation, which wraps to two lines — the footer grows to 140px and still does not overlap.

`yarn build:extension` compiles clean, eslint clean, `yarn test:ci` 1605 passing / 0 failing.

**Follow-ups / out of scope:** `views/GrantAccess/index.tsx` has the identical footer shape and the same latent 40px overflow. It is not visibly broken today only because its content is short and never reaches the bottom of the pane, so it is left out of this PR — it is the same one-line fix if we want it.

</details>
