### PR TITLE
test: verify PR Preview pipeline end to end (DO NOT MERGE)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,12 @@
 # Freighter Docs
 
-This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
+This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern
+static website generator.
 
 ### Local Development
 
-First build `@stellar/freighter-api` (a dependency of this project) by cd'ing to `@stellar/freighter-api` and running `yarn build`.
+First build `@stellar/freighter-api` (a dependency of this project) by cd'ing to
+`@stellar/freighter-api` and running `yarn build`.
 
 Then, come back to this directory and run:
 
@@ -12,4 +14,7 @@ Then, come back to this directory and run:
 $ yarn start
 ```
 
-This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
+This command starts a local development server and open up a browser window.
+Most changes are reflected live without having to restart the server.
+
+<!-- PR Preview pipeline verification — this line exists only to trigger a preview build and will not be merged. -->


### PR DESCRIPTION
## TL;DR

Throwaway PR that exists only to run the PR Preview workflow merged in #2917 against a real pull request for the first time. **Do not merge** — it will be closed once verified.

The change is a single HTML comment in a docs file, so the build is exercised without touching anything shipped.

<details>
<summary>What this is verifying (for agents/reviewers)</summary>

The full preview chain, none of which had run on a non-author PR before:

1. `freighter-config` is fetched with the read-only deploy key
2. The author's sandbox URLs resolve (expected: `Backend: sandbox (piyalbasu)`)
3. The extension builds with those URLs baked in
4. A draft release `pr-preview-<N>` is published with `build.zip`
5. A sticky comment links it
6. Closing this PR triggers the cleanup job, which should delete the draft release

Then the `preview` skill (stellar/sdfeng-claude-marketplace#13) gets pointed at this PR to confirm the reviewer-side path works: find the draft release, read the `Backend:` line, decide whether sshuttle is needed, download, and unpack for `chrome://extensions`.