### PR TITLE
discover: support hyperlinks and newlines in protocol descriptions (port to v5.47.0)

### DIFF
--- a/@shared/api/types/types.ts
+++ b/@shared/api/types/types.ts
@@ -430,6 +430,11 @@ export interface ApiTokenPrices {
 }
 
 export interface ProtocolEntry {
+  /**
+   * Rendered via LinkifiedText (popup/basics/LinkifiedText): supports
+   * markdown-style `[text](https://...)` links and bare `https://` URLs,
+   * which render as clickable links. No other markdown/HTML is parsed.
+   */
   description: string;
   iconUrl: string;
   name: string;

--- a/extension/src/popup/basics/LinkifiedText/__tests__/parseLinkedText.test.ts
+++ b/extension/src/popup/basics/LinkifiedText/__tests__/parseLinkedText.test.ts
@@ -1,0 +1,144 @@
+import { parseLinkedText } from "../parseLinkedText";
+
+describe("parseLinkedText", () => {
+  it("returns a single plain-text segment when there are no links", () => {
+    expect(parseLinkedText("just plain text")).toEqual([
+      { text: "just plain text" },
+    ]);
+  });
+
+  it("parses a markdown-style link", () => {
+    expect(
+      parseLinkedText("See the [incident update](https://example.com/x) now."),
+    ).toEqual([
+      { text: "See the " },
+      { text: "incident update", url: "https://example.com/x" },
+      { text: " now." },
+    ]);
+  });
+
+  it("linkifies a bare URL", () => {
+    expect(parseLinkedText("Visit https://example.com/x today")).toEqual([
+      { text: "Visit " },
+      { text: "https://example.com/x", url: "https://example.com/x" },
+      { text: " today" },
+    ]);
+  });
+
+  it("strips trailing punctuation from a bare URL", () => {
+    expect(parseLinkedText("See https://example.com/x.")).toEqual([
+      { text: "See " },
+      { text: "https://example.com/x", url: "https://example.com/x" },
+      { text: "." },
+    ]);
+  });
+
+  it("handles multiple links in the same string", () => {
+    expect(
+      parseLinkedText(
+        "First https://a.com then [second](https://b.com) link.",
+      ),
+    ).toEqual([
+      { text: "First " },
+      { text: "https://a.com", url: "https://a.com" },
+      { text: " then " },
+      { text: "second", url: "https://b.com" },
+      { text: " link." },
+    ]);
+  });
+
+  it("does not linkify non-https schemes", () => {
+    expect(parseLinkedText("Run javascript:alert(1) please")).toEqual([
+      { text: "Run javascript:alert(1) please" },
+    ]);
+  });
+
+  it("does not linkify a bare http (non-https) URL", () => {
+    expect(parseLinkedText("Visit http://example.com/x today")).toEqual([
+      { text: "Visit http://example.com/x today" },
+    ]);
+  });
+
+  it("keeps balanced parentheses inside a bare URL", () => {
+    expect(
+      parseLinkedText(
+        "See https://en.wikipedia.org/wiki/Function_(mathematics) for details.",
+      ),
+    ).toEqual([
+      { text: "See " },
+      {
+        text: "https://en.wikipedia.org/wiki/Function_(mathematics)",
+        url: "https://en.wikipedia.org/wiki/Function_(mathematics)",
+      },
+      { text: " for details." },
+    ]);
+  });
+
+  it("keeps balanced parentheses inside a markdown-style URL", () => {
+    expect(
+      parseLinkedText(
+        "See [Function](https://en.wikipedia.org/wiki/Function_(mathematics)) for details.",
+      ),
+    ).toEqual([
+      { text: "See " },
+      {
+        text: "Function",
+        url: "https://en.wikipedia.org/wiki/Function_(mathematics)",
+      },
+      { text: " for details." },
+    ]);
+  });
+
+  it("does not let a stray unmatched bracket swallow the real link", () => {
+    expect(
+      parseLinkedText("Rates [APY vary. See the [docs](https://b.com)."),
+    ).toEqual([
+      { text: "Rates [APY vary. See the " },
+      { text: "docs", url: "https://b.com" },
+      { text: "." },
+    ]);
+  });
+
+  it("does not double-linkify a markdown label that is itself a URL", () => {
+    expect(
+      parseLinkedText("[https://label.example](https://target.example)"),
+    ).toEqual([
+      { text: "https://label.example", url: "https://target.example" },
+    ]);
+  });
+
+  it("does not absorb a quote that closes a quoted bare URL", () => {
+    expect(parseLinkedText('See "https://example.com/x" now.')).toEqual([
+      { text: 'See "' },
+      { text: "https://example.com/x", url: "https://example.com/x" },
+      { text: '" now.' },
+    ]);
+  });
+
+  it("does not linkify a malformed bare URL with no host", () => {
+    expect(parseLinkedText("See https:// for syntax")).toEqual([
+      { text: "See https:// for syntax" },
+    ]);
+    expect(parseLinkedText("See https://?query for syntax")).toEqual([
+      { text: "See https://?query for syntax" },
+    ]);
+  });
+
+  it("does not linkify a malformed markdown URL with no host", () => {
+    expect(parseLinkedText("[bad](https://)")).toEqual([
+      { text: "[bad](https://)" },
+    ]);
+  });
+
+  it("keeps square brackets inside a markdown destination", () => {
+    expect(
+      parseLinkedText(
+        "Search [tags](https://example.com/search?tag[]=security) here.",
+      ),
+    ).toEqual([
+      { text: "Search " },
+      { text: "tags", url: "https://example.com/search?tag[]=security" },
+      { text: " here." },
+    ]);
+  });
+});

--- a/extension/src/popup/basics/LinkifiedText/index.tsx
+++ b/extension/src/popup/basics/LinkifiedText/index.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+import { parseLinkedText } from "./parseLinkedText";
+
+interface LinkifiedTextProps {
+  text: string;
+}
+
+/**
+ * Renders text while turning markdown-style `[text](https://...)` links and
+ * bare `https://` URLs into clickable links. Everything else is rendered
+ * as plain text - no other markdown/HTML is parsed, so this is safe to use
+ * directly on untrusted/external strings (e.g. API responses).
+ */
+export const LinkifiedText = ({ text }: LinkifiedTextProps) => (
+  <>
+    {parseLinkedText(text).map((segment, index) =>
+      segment.url ? (
+        <a
+          key={`${index}-${segment.url}`}
+          href={segment.url}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {segment.text}
+        </a>
+      ) : (
+        <React.Fragment key={`${index}-text`}>{segment.text}</React.Fragment>
+      ),
+    )}
+  </>
+);

--- a/extension/src/popup/basics/LinkifiedText/parseLinkedText.ts
+++ b/extension/src/popup/basics/LinkifiedText/parseLinkedText.ts
@@ -1,0 +1,212 @@
+export interface LinkedTextSegment {
+  text: string;
+  url?: string;
+}
+
+// Only https:// is ever recognized as a link - no other scheme (e.g.
+// `http:`, `javascript:`) matches, matching the isSafeHttpsUrl convention
+// used elsewhere for protocol.websiteUrl.
+const HTTPS_PREFIX = "https://";
+
+// Characters that always end a URL: whitespace, angle brackets, and quotes
+// (prose delimiters - a quoted URL shouldn't swallow the closing quote).
+// Parentheses are handled separately in findUrlEnd, since a URL may
+// legitimately contain balanced ones (e.g. a Wikipedia article title).
+const BARE_URL_BOUNDARY_CHAR = /[\s<>[\]"']/;
+
+// Inside a markdown link's `(https://...)` destination, square brackets are
+// valid URL characters (e.g. the common `?tag[]=value` query syntax) - only
+// the balanced closing paren, whitespace, angle brackets, or a quote can end
+// it. Brackets are excluded from a *bare* URL's boundary set above only to
+// avoid ambiguity with an immediately following markdown link.
+const MARKDOWN_URL_BOUNDARY_CHAR = /[\s<>"']/;
+
+const TRAILING_PUNCTUATION = /[.,!?;:]+$/;
+
+const splitTrailingPunctuation = (
+  url: string,
+): { url: string; trailing: string } => {
+  const match = url.match(TRAILING_PUNCTUATION);
+  if (!match) {
+    return { url, trailing: "" };
+  }
+  return {
+    url: url.slice(0, url.length - match[0].length),
+    trailing: match[0],
+  };
+};
+
+// A candidate is only treated as a link if it's an actual parseable https
+// URL with a host - e.g. bare "https://" or "https://?query" (no host) are
+// rejected and left as plain text, matching the isSafeHttpsUrl convention
+// used elsewhere for protocol.websiteUrl. The original text is still used
+// for display/navigation (never `url.href`), since the WHATWG URL parser
+// normalizes some inputs (e.g. adding a trailing slash to a bare origin).
+const isValidHttpsUrl = (candidate: string): boolean => {
+  try {
+    return new URL(candidate).protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+// Extends a URL starting at `start` as far as possible per `boundary`,
+// allowing balanced parentheses inside it (e.g.
+// https://en.wikipedia.org/wiki/Function_(maths)) so a legitimate paren in
+// the URL path isn't mistaken for markdown/prose punctuation. An unmatched
+// closing paren ends the URL instead of being consumed by it, since it's
+// almost always the boundary of a markdown link or the prose wrapping a
+// link in parens.
+const findUrlEnd = (text: string, start: number, boundary: RegExp): number => {
+  let depth = 0;
+  let index = start;
+
+  while (index < text.length) {
+    const char = text[index];
+    if (boundary.test(char)) {
+      break;
+    }
+    if (char === "(") {
+      depth += 1;
+    } else if (char === ")") {
+      if (depth === 0) {
+        break;
+      }
+      depth -= 1;
+    }
+    index += 1;
+  }
+
+  return index;
+};
+
+interface MarkdownLink {
+  label: string;
+  url: string;
+  end: number;
+}
+
+// Tries to parse a complete markdown link `[label](https://...)` starting
+// at the `[` found at `openIndex`. Returns null if it isn't one - e.g. no
+// matching `]`, the label itself contains an unescaped `[` (meaning
+// `openIndex` isn't the real opening bracket - see the "nested brackets"
+// test case), there's no `(https://...)` immediately after the `]`, or the
+// URL itself isn't a valid https URL with a host.
+// Parsing forward like this (rather than scanning backward from a `https://`
+// occurrence) means a label that itself contains a URL - e.g.
+// `[https://a.example](https://b.example)` - is handled as a single link
+// instead of the label's URL being matched as a stray bare link first.
+const tryParseMarkdownLink = (
+  text: string,
+  openIndex: number,
+): MarkdownLink | null => {
+  const closeBracket = text.indexOf("]", openIndex + 1);
+  if (closeBracket === -1) {
+    return null;
+  }
+
+  const label = text.slice(openIndex + 1, closeBracket);
+  if (label.includes("[")) {
+    return null;
+  }
+
+  if (text[closeBracket + 1] !== "(") {
+    return null;
+  }
+
+  const urlStart = closeBracket + 2;
+  if (!text.startsWith(HTTPS_PREFIX, urlStart)) {
+    return null;
+  }
+
+  const urlEnd = findUrlEnd(text, urlStart, MARKDOWN_URL_BOUNDARY_CHAR);
+  if (text[urlEnd] !== ")") {
+    return null;
+  }
+
+  const url = text.slice(urlStart, urlEnd);
+  if (!isValidHttpsUrl(url)) {
+    return null;
+  }
+
+  return { label, url, end: urlEnd + 1 };
+};
+
+/**
+ * Parses plain text for markdown-style links (`[text](https://...)`) and
+ * bare `https://` URLs, returning an ordered list of segments to render.
+ * A segment with a `url` should be rendered as a clickable link; a segment
+ * without one is plain text.
+ *
+ * This never parses or renders any other markdown/HTML - it's safe to use
+ * on untrusted/external strings (e.g. an API response) since the output is
+ * always plain text plus a small, whitelisted set of link segments.
+ */
+export const parseLinkedText = (text: string): LinkedTextSegment[] => {
+  const segments: LinkedTextSegment[] = [];
+  let emitted = 0;
+  let searchFrom = 0;
+
+  while (searchFrom < text.length) {
+    const bracketIndex = text.indexOf("[", searchFrom);
+    const httpsIndex = text.indexOf(HTTPS_PREFIX, searchFrom);
+
+    if (
+      bracketIndex !== -1 &&
+      (httpsIndex === -1 || bracketIndex < httpsIndex)
+    ) {
+      const link = tryParseMarkdownLink(text, bracketIndex);
+      if (link) {
+        if (bracketIndex > emitted) {
+          segments.push({ text: text.slice(emitted, bracketIndex) });
+        }
+        segments.push({ text: link.label, url: link.url });
+        emitted = link.end;
+        searchFrom = link.end;
+        continue;
+      }
+
+      // Not a complete markdown link - this "[" is just literal text.
+      // Keep it pending and resume searching right after it (e.g. it may
+      // be a stray bracket preceding the real link, per the nested-bracket
+      // test case).
+      searchFrom = bracketIndex + 1;
+      continue;
+    }
+
+    if (httpsIndex === -1) {
+      break;
+    }
+
+    const urlEnd = findUrlEnd(text, httpsIndex, BARE_URL_BOUNDARY_CHAR);
+    const { url, trailing } = splitTrailingPunctuation(
+      text.slice(httpsIndex, urlEnd),
+    );
+
+    if (!isValidHttpsUrl(url)) {
+      // Not a real URL (e.g. bare "https://" with no host) - leave it as
+      // plain text and keep scanning past the prefix.
+      searchFrom = httpsIndex + HTTPS_PREFIX.length;
+      continue;
+    }
+
+    if (httpsIndex > emitted) {
+      segments.push({ text: text.slice(emitted, httpsIndex) });
+    }
+    segments.push({ text: url, url });
+    emitted = httpsIndex + url.length;
+    searchFrom = emitted;
+
+    if (trailing) {
+      segments.push({ text: trailing });
+      emitted += trailing.length;
+      searchFrom = emitted;
+    }
+  }
+
+  if (emitted < text.length) {
+    segments.push({ text: text.slice(emitted) });
+  }
+
+  return segments;
+};

--- a/extension/src/popup/views/Discover/components/ProtocolDetailsPanel/index.tsx
+++ b/extension/src/popup/views/Discover/components/ProtocolDetailsPanel/index.tsx
@@ -3,6 +3,7 @@ import { Icon, Text } from "@stellar/design-system";
 import { useTranslation } from "react-i18next";
 
 import { ProtocolEntry } from "@shared/api/types";
+import { LinkifiedText } from "popup/basics/LinkifiedText";
 import { trackDiscoverProtocolDetailsViewed } from "popup/metrics/discover";
 
 import "./styles.scss";
@@ -101,7 +102,7 @@ export const ProtocolDetailsPanel = ({
         </div>
         <div className="ProtocolDetailsPanel__description">
           <Text as="div" size="sm" weight="regular">
-            {protocol.description}
+            <LinkifiedText text={protocol.description} />
           </Text>
         </div>
       </div>

--- a/extension/src/popup/views/Discover/components/ProtocolDetailsPanel/styles.scss
+++ b/extension/src/popup/views/Discover/components/ProtocolDetailsPanel/styles.scss
@@ -89,5 +89,16 @@
 
   &__description {
     color: var(--sds-clr-gray-12);
+    white-space: pre-line;
+    word-break: break-word;
+
+    a {
+      color: var(--sds-clr-lilac-11);
+      // The global `a { text-decoration: none; }` reset means color alone
+      // isn't enough to distinguish a link from surrounding text - restore
+      // an underline so links embedded in prose remain visible without
+      // relying on color perception.
+      text-decoration: underline;
+    }
   }
 }


### PR DESCRIPTION
Port https://github.com/stellar/freighter/pull/2985 to the `emergency-release` branch so we can release it on `5.47.0` independently of other bigger changes present on `master` branch (e.g. balances-v2 migration).