### PR TITLE
fix: fail closed on USDT0 banner dismissal lookup, announce the dialog

### DIFF
--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -2223,7 +2223,7 @@ export const getUsdt0LaunchBannerDismissed = async (): Promise<boolean> => {
   });
 
   if (error) {
-    return false;
+    throw new Error(error);
   }
 
   return !!isDismissed;

--- a/extension/src/background/messageListener/handlers/dismissUsdt0LaunchBanner.ts
+++ b/extension/src/background/messageListener/handlers/dismissUsdt0LaunchBanner.ts
@@ -7,6 +7,5 @@ export const dismissUsdt0LaunchBanner = async ({
   localStore: DataStorageAccess;
 }): Promise<{ isDismissed: boolean }> => {
   await localStore.setItem(USDT0_LAUNCH_BANNER_DISMISSED, true);
-  const isDismissed = await localStore.getItem(USDT0_LAUNCH_BANNER_DISMISSED);
-  return { isDismissed: !!isDismissed };
+  return { isDismissed: true };
 };

--- a/extension/src/popup/components/account/Usdt0LaunchBanner/index.tsx
+++ b/extension/src/popup/components/account/Usdt0LaunchBanner/index.tsx
@@ -31,8 +31,10 @@ export const Usdt0LaunchBanner = () => {
         const dismissed = await getUsdt0LaunchBannerDismissed();
         setIsDismissed(dismissed);
       } catch (error) {
+        // Default to hiding the banner on messaging failure so we never
+        // re-show it to a user who has already dismissed it.
         captureException(error);
-        setIsDismissed(false);
+        setIsDismissed(true);
       } finally {
         setIsLoading(false);
       }
@@ -62,10 +64,17 @@ export const Usdt0LaunchBanner = () => {
   return (
     <>
       <div className="Usdt0LaunchBanner" data-testid="usdt0-launch-banner">
+        {/* The sheet this opens is a Radix dialog whose Root is a sibling
+          of this button, so Radix's own Sheet.Trigger can't reach it from
+          here. These mirror what that trigger would emit; aria-controls is
+          omitted because the id is generated inside the portal and isn't
+          knowable at this level. */}
         <button
           type="button"
           className="Usdt0LaunchBanner__content"
           onClick={handleBannerClick}
+          aria-haspopup="dialog"
+          aria-expanded={isSheetOpen}
           data-testid="usdt0-launch-banner-open"
         >
           <div className="Usdt0LaunchBanner__logo">


### PR DESCRIPTION
## TL;DR

Follow-up to #2990, which merged before its last review comments were addressed. Three small fixes to the USDT0 launch banner:

- A failed "was this dismissed?" lookup was treated as "not dismissed", so a transient messaging failure could re-show the promo to someone who had already dismissed it. It now fails closed — the same call the Discover welcome modal already makes deliberately.
- The dismissal write re-read the value it had just written, which only added a second failure point that could report a successful dismissal as failed.
- The banner's launch button now tells assistive tech that it opens a dialog.

No user-visible change in the normal path.

<details>
<summary>Implementation details (for agents)</summary>

**Fail closed on unknown dismissal state** (`@shared/api/internal.ts`, `Usdt0LaunchBanner/index.tsx`): `getUsdt0LaunchBannerDismissed` now throws on a structured `error` instead of returning `false`, matching `getHasSeenDiscoverWelcome`; the component's `catch` sets `isDismissed` to `true` and keeps reporting to Sentry, with the same rationale comment `useDiscoverWelcome.ts` carries. That leaves one place deciding the default, so the helper's branch can't later disagree with the catch. Note the helper's `if (error)` branch is latent today — `popupMessageListener` returns `{ isDismissed }` and never a structured `{ error }` — so the live path this fixes is the component's `catch` when `localStore.getItem` rejects inside the handler and the rejection propagates out through `browser.runtime.sendMessage`.

**Drop the read-back** (`handlers/dismissUsdt0LaunchBanner.ts`): return `{ isDismissed: true }` immediately after `setItem`, as `dismissDiscoverWelcome` does. Previously a successful write followed by a failed read reported `false`, leaving the banner up for that popup session even though the dismissal had persisted.

**Dialog semantics** (`Usdt0LaunchBanner/index.tsx`): `aria-haspopup="dialog"` + `aria-expanded={isSheetOpen}` on the launch button. The sheet is opened by local state and its Radix Root is a sibling of the button, so `SheetTrigger` can't reach it — the same constraint as `AddCollectibles/index.tsx:212-226`, whose comment and attribute pair this mirrors. `aria-controls` is omitted because the dialog id is generated inside the portal.

**Verification:** `yarn build:extension` clean; `yarn test:ci` 1772 passed, 1 failed — the failure is `remoteConfig.test.ts` "defaults use_balances_v2 to true", caused by an unrelated local working-tree edit, not by this change and not part of this PR.

**Backport:** the same three fixes are applied to #2997 (the v5.48.0 backport of #2990).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
