### PR TITLE
refactor(assets): consolidate asset identity checks

### DIFF
--- a/@shared/api/helpers/addBlockaidScanResults.ts
+++ b/@shared/api/helpers/addBlockaidScanResults.ts
@@ -2,6 +2,7 @@ import { captureException } from "@sentry/browser";
 
 import { INDEXER_URL } from "@shared/constants/mercury";
 import { NETWORKS, NetworkDetails } from "@shared/constants/stellar";
+import { isNativeAssetId } from "@shared/helpers/assetIdentity";
 import { defaultBlockaidScanAssetResult } from "@shared/helpers/stellar";
 import { BlockAidScanAssetResult } from "../types";
 import { AccountBalancesInterface, BalanceMap } from "../types/backend-api";
@@ -37,7 +38,7 @@ export const addBlockaidScanResults = async (
   // swap the separator: `CODE-ISSUER` (same convention as v1 and the
   // standalone path).
   const scannableIds = keys.filter(
-    (key) => key !== "native" && !key.includes(":lp"),
+    (key) => !isNativeAssetId(key) && !key.includes(":lp"),
   );
 
   if (

--- a/@shared/api/internal.ts
+++ b/@shared/api/internal.ts
@@ -35,6 +35,7 @@ import {
   getSdk,
   isCustomNetwork,
   makeDisplayableBalances,
+  splitCanonical,
   xlmToStroop,
 } from "@shared/helpers/stellar";
 import {
@@ -1385,7 +1386,7 @@ export const getAssetIcons = async ({
   // Unheld extras run the same cache -> token lists -> issuer-toml chain as
   // the held balances above (toml via the shared domainsToFetch batch below).
   for (const canonical of additionalAssetIds || []) {
-    const [code, key] = canonical.split(":");
+    const { code, issuer: key } = splitCanonical(canonical);
     if (!key || canonical in assetIcons) {
       // native (no issuer segment) or already covered by a held balance
       continue;

--- a/@shared/api/types/account-balance.ts
+++ b/@shared/api/types/account-balance.ts
@@ -17,7 +17,7 @@ export interface NativeAsset {
 
 export interface ClassicAsset {
   token: {
-    type: Omit<SdkAssetType, "native">;
+    type: Exclude<SdkAssetType, "native">;
     code: string;
     issuer: { key: string };
   };

--- a/@shared/api/types/backend-api.ts
+++ b/@shared/api/types/backend-api.ts
@@ -1,4 +1,5 @@
 import { AssetBalance, NativeBalance, TokenBalance } from "./types";
+import { AssetType as SdkAssetType } from "stellar-sdk";
 
 export interface BalanceMap {
   [key: string]: AssetBalance | NativeBalance | TokenBalance;
@@ -79,7 +80,11 @@ export interface V2NativeBalance extends V2BalanceBase {
 export interface V2ClassicBalance extends V2BalanceBase {
   token_type: "CLASSIC";
   // `type` is the trustline's asset type verbatim (e.g. credit_alphanum4).
-  token: { type: string; code: string; issuer: V2TokenIssuer };
+  token: {
+    type: Exclude<SdkAssetType, "native">;
+    code: string;
+    issuer: V2TokenIssuer;
+  };
   code?: string;
   issuer?: string;
   type: string;
@@ -94,7 +99,11 @@ export interface V2ClassicBalance extends V2BalanceBase {
 export interface V2SacBalance extends V2BalanceBase {
   token_type: "SAC";
   // `type` is derived server-side from the code length (credit_alphanum4/12).
-  token: { type: string; code: string; issuer: V2TokenIssuer };
+  token: {
+    type: Exclude<SdkAssetType, "native">;
+    code: string;
+    issuer: V2TokenIssuer;
+  };
   code: string;
   issuer: string;
   decimals: number;

--- a/@shared/helpers/__tests__/assetIdentity.test.ts
+++ b/@shared/helpers/__tests__/assetIdentity.test.ts
@@ -1,0 +1,150 @@
+import BigNumber from "bignumber.js";
+import { Asset, Networks } from "stellar-sdk";
+
+import { AssetType } from "@shared/api/types/account-balance";
+import {
+  getNativeContractId,
+  isNativeAsset,
+  isNativeAssetId,
+  isNativeAssetPair,
+  isNativeBalance,
+  isNativeContract,
+} from "@shared/helpers/assetIdentity";
+
+// A classic asset that uses the native asset's display code but carries its
+// own issuer. It is a different asset from the native lumen, and every
+// predicate has to say so.
+const XLM_CODED_ISSUER =
+  "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+
+// The published native SAC addresses. Pinned rather than re-derived, so these
+// tests also assert that deriving from the passphrase reproduces the values
+// getNativeContractDetails hardcodes before Task 8 removes them.
+const NATIVE_SAC_PUBLIC =
+  "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA";
+const NATIVE_SAC_TESTNET =
+  "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+
+const nativeBalance = {
+  token: { type: "native", code: "XLM" },
+  total: new BigNumber("100"),
+  available: new BigNumber("100"),
+  buyingLiabilities: "0",
+  sellingLiabilities: "0",
+  minimumBalance: "1",
+  blockaidData: {},
+} as unknown as AssetType;
+
+const xlmCodedClassicBalance = {
+  token: {
+    type: "credit_alphanum4",
+    code: "XLM",
+    issuer: { key: XLM_CODED_ISSUER },
+  },
+  total: new BigNumber("100"),
+  available: new BigNumber("100"),
+  buyingLiabilities: "0",
+  sellingLiabilities: "0",
+  blockaidData: {},
+} as unknown as AssetType;
+
+describe("isNativeAssetId", () => {
+  it("accepts the native identifier", () => {
+    expect(isNativeAssetId("native")).toBe(true);
+  });
+
+  it("rejects the display code, which is not an identifier", () => {
+    expect(isNativeAssetId("XLM")).toBe(false);
+  });
+
+  it("rejects a canonical pair that uses the native code", () => {
+    expect(isNativeAssetId(`XLM:${XLM_CODED_ISSUER}`)).toBe(false);
+  });
+
+  it("rejects an absent id", () => {
+    expect(isNativeAssetId(undefined)).toBe(false);
+    expect(isNativeAssetId(null)).toBe(false);
+  });
+});
+
+describe("isNativeAssetPair", () => {
+  it("accepts the native code with no issuer", () => {
+    expect(isNativeAssetPair("XLM", undefined)).toBe(true);
+    expect(isNativeAssetPair("XLM", "")).toBe(true);
+  });
+
+  it("rejects the native code paired with an issuer", () => {
+    expect(isNativeAssetPair("XLM", XLM_CODED_ISSUER)).toBe(false);
+  });
+
+  it("rejects a different code with no issuer", () => {
+    expect(isNativeAssetPair("USDC", undefined)).toBe(false);
+  });
+});
+
+describe("isNativeBalance", () => {
+  it("accepts a native-typed balance", () => {
+    expect(isNativeBalance(nativeBalance)).toBe(true);
+  });
+
+  it("rejects a classic balance that uses the native code", () => {
+    expect(isNativeBalance(xlmCodedClassicBalance)).toBe(false);
+  });
+});
+
+describe("isNativeAsset", () => {
+  it("accepts the SDK native asset", () => {
+    expect(isNativeAsset(Asset.native())).toBe(true);
+  });
+
+  it("rejects a classic asset that uses the native code", () => {
+    expect(isNativeAsset(new Asset("XLM", XLM_CODED_ISSUER))).toBe(false);
+  });
+
+  it("rejects the plain shape used for Soroban issuers", () => {
+    expect(
+      isNativeAsset({
+        code: "XLM",
+        issuer: "CCV3NAKLIBBNSJNNTV2AZVRX6VODUDWK4TVYILE5MW6R45SSQJS5VCAM",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("getNativeContractId", () => {
+  it("reproduces the published mainnet native SAC address", () => {
+    expect(getNativeContractId(Networks.PUBLIC)).toBe(NATIVE_SAC_PUBLIC);
+  });
+
+  it("reproduces the published testnet native SAC address", () => {
+    expect(getNativeContractId(Networks.TESTNET)).toBe(NATIVE_SAC_TESTNET);
+  });
+
+  it("returns a real address on a network the old lookup table omitted", () => {
+    const futurenet = getNativeContractId(Networks.FUTURENET);
+    expect(futurenet).toMatch(/^C[A-Z2-7]{55}$/);
+    expect(futurenet).not.toBe(NATIVE_SAC_PUBLIC);
+  });
+});
+
+describe("isNativeContract", () => {
+  it("accepts the native SAC for its own network", () => {
+    expect(isNativeContract(NATIVE_SAC_PUBLIC, Networks.PUBLIC)).toBe(true);
+  });
+
+  it("rejects the native SAC of a different network", () => {
+    expect(isNativeContract(NATIVE_SAC_TESTNET, Networks.PUBLIC)).toBe(false);
+  });
+
+  it("rejects the wrapped contract of a classic asset using the native code", () => {
+    const wrapped = new Asset("XLM", XLM_CODED_ISSUER).contractId(
+      Networks.PUBLIC,
+    );
+    expect(isNativeContract(wrapped, Networks.PUBLIC)).toBe(false);
+  });
+
+  it("rejects an empty contract id, which an absent lookup can produce", () => {
+    expect(isNativeContract("", Networks.PUBLIC)).toBe(false);
+    expect(isNativeContract(undefined, Networks.PUBLIC)).toBe(false);
+  });
+});

--- a/@shared/helpers/__tests__/assetIdentity.test.ts
+++ b/@shared/helpers/__tests__/assetIdentity.test.ts
@@ -21,9 +21,9 @@ import {
 const XLM_CODED_ISSUER =
   "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
 
-// The published native SAC addresses. Pinned rather than re-derived, so these
-// tests also assert that deriving from the passphrase reproduces the values
-// getNativeContractDetails hardcodes before Task 8 removes them.
+// The published native SAC addresses, pinned rather than re-derived, so these
+// tests assert that deriving from the passphrase reproduces the known-good
+// values rather than just agreeing with themselves.
 const NATIVE_SAC_PUBLIC =
   "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA";
 const NATIVE_SAC_TESTNET =
@@ -130,7 +130,7 @@ describe("getNativeContractId", () => {
     expect(getNativeContractId(Networks.TESTNET)).toBe(NATIVE_SAC_TESTNET);
   });
 
-  it("returns a real address on a network the old lookup table omitted", () => {
+  it("derives a distinct address on FUTURENET", () => {
     const futurenet = getNativeContractId(Networks.FUTURENET);
     expect(futurenet).toMatch(/^C[A-Z2-7]{55}$/);
     expect(futurenet).not.toBe(NATIVE_SAC_PUBLIC);

--- a/@shared/helpers/__tests__/assetIdentity.test.ts
+++ b/@shared/helpers/__tests__/assetIdentity.test.ts
@@ -3,6 +3,10 @@ import { Asset, Networks } from "stellar-sdk";
 
 import { AssetType } from "@shared/api/types/account-balance";
 import {
+  getAssetFromCanonical,
+  getCanonicalFromAsset,
+} from "@shared/helpers/stellar";
+import {
   getNativeContractId,
   isNativeAsset,
   isNativeAssetId,
@@ -108,6 +112,12 @@ describe("isNativeAsset", () => {
         issuer: "CCV3NAKLIBBNSJNNTV2AZVRX6VODUDWK4TVYILE5MW6R45SSQJS5VCAM",
       }),
     ).toBe(false);
+  });
+
+  it("rejects a contract token whose symbol contains a colon", () => {
+    const contract = "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA";
+    const canonical = getCanonicalFromAsset("XLM:", contract);
+    expect(isNativeAsset(getAssetFromCanonical(canonical))).toBe(false);
   });
 });
 

--- a/@shared/helpers/__tests__/canonical.test.ts
+++ b/@shared/helpers/__tests__/canonical.test.ts
@@ -1,0 +1,70 @@
+import { Asset } from "stellar-sdk";
+
+import {
+  LP_ISSUER_KEY,
+  getAssetFromCanonical,
+  getCanonicalFromAsset,
+  splitCanonical,
+} from "@shared/helpers/stellar";
+
+const ISSUER = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+const CONTRACT = "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA";
+const POOL_ID =
+  "dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7";
+
+describe("splitCanonical", () => {
+  it("splits a classic canonical into code and issuer", () => {
+    expect(splitCanonical(`USDC:${ISSUER}`)).toEqual({
+      code: "USDC",
+      issuer: ISSUER,
+    });
+  });
+
+  it("splits on the last colon, so a symbol containing a colon keeps it", () => {
+    expect(splitCanonical(`MY:TOKEN:${CONTRACT}`)).toEqual({
+      code: "MY:TOKEN",
+      issuer: CONTRACT,
+    });
+  });
+
+  it("returns an empty issuer when there is no separator", () => {
+    expect(splitCanonical("native")).toEqual({ code: "native", issuer: "" });
+  });
+});
+
+describe("getAssetFromCanonical", () => {
+  it("returns the SDK asset for a classic canonical", () => {
+    const asset = getAssetFromCanonical(`USDC:${ISSUER}`) as Asset;
+    expect(asset.getCode()).toBe("USDC");
+    expect(asset.getIssuer()).toBe(ISSUER);
+  });
+
+  it("returns the plain shape for a contract token", () => {
+    expect(getAssetFromCanonical(`TKN:${CONTRACT}`)).toEqual({
+      code: "TKN",
+      issuer: CONTRACT,
+    });
+  });
+
+  it("keeps a colon-bearing symbol whole and round-trips it", () => {
+    const canonical = getCanonicalFromAsset("XLM:", CONTRACT);
+    expect(getAssetFromCanonical(canonical)).toEqual({
+      code: "XLM:",
+      issuer: CONTRACT,
+    });
+  });
+
+  it("accepts the liquidity-pool sentinel issuer", () => {
+    expect(getAssetFromCanonical(`${POOL_ID}:${LP_ISSUER_KEY}`)).toEqual({
+      code: POOL_ID,
+      issuer: LP_ISSUER_KEY,
+    });
+  });
+
+  it("rejects an issuer that is neither a G address, a C address nor the pool sentinel", () => {
+    expect(() => getAssetFromCanonical("XLM:")).toThrow(
+      /invalid asset canonical id/,
+    );
+    expect(() => getAssetFromCanonical("USDC:not-an-issuer")).toThrow();
+  });
+});

--- a/@shared/helpers/assetIdentity.ts
+++ b/@shared/helpers/assetIdentity.ts
@@ -1,0 +1,79 @@
+import { Asset } from "stellar-sdk";
+
+import { AssetType, NativeAsset } from "@shared/api/types/account-balance";
+
+/**
+ * Shared asset-identity predicates.
+ *
+ * An asset's identity is the pair (code, issuer) — or, for a contract token,
+ * its contract id. Asset codes are not unique, so a code alone establishes
+ * neither that two assets are the same asset nor that an asset is the native
+ * lumen. Nativeness is a property of an asset's type, or in contract space of
+ * the contract id. Every native check in the extension goes through one of the
+ * predicates below.
+ */
+
+/**
+ * The identifier the codebase uses for the native lumen. It is simultaneously
+ * the canonical asset id, a Horizon record's `asset_type`, and a balance's
+ * `token.type`.
+ */
+const NATIVE_ASSET_ID = "native";
+
+/** The native lumen's display code. Not unique — other assets may use it. */
+const NATIVE_ASSET_CODE = "XLM";
+
+/**
+ * True if `id` is the native identifier. Use it for canonical asset ids,
+ * Horizon `asset_type` values, and balance `token.type` values.
+ */
+export const isNativeAssetId = (id: string | undefined | null): boolean =>
+  id === NATIVE_ASSET_ID;
+
+/**
+ * Native test for a raw code and issuer. Use it only where neither a token
+ * type nor a contract id is available — the native asset carries the native
+ * code and no issuer, so both halves are required.
+ */
+export const isNativeAssetPair = (
+  code: string | undefined | null,
+  issuer: string | undefined | null,
+): boolean => code === NATIVE_ASSET_CODE && !issuer;
+
+/** True only for a balance whose token declares the native type. */
+export const isNativeBalance = (balance: AssetType): balance is NativeAsset =>
+  "token" in balance &&
+  "type" in balance.token &&
+  isNativeAssetId(balance.token.type as unknown as string);
+
+/**
+ * True only for the native asset.
+ *
+ * `getAssetFromCanonical` returns an SDK `Asset` for classic assets and a plain
+ * `{ code, issuer }` for Soroban issuers, so both shapes arrive here. The SDK's
+ * own `isNative()` is authoritative when present; the plain shape only ever
+ * carries a `C…` issuer, which the pair test correctly rejects.
+ *
+ * Narrowing on the method rather than `instanceof` keeps this correct across
+ * the `stellar-sdk` / `stellar-sdk-next` dual-package split.
+ */
+export const isNativeAsset = (
+  asset: Asset | { code: string; issuer?: string },
+): boolean =>
+  typeof (asset as Asset).isNative === "function"
+    ? (asset as Asset).isNative()
+    : isNativeAssetPair(asset.code, asset.issuer);
+
+/**
+ * The native lumen's Stellar Asset Contract id, derived from the network
+ * passphrase so it is correct by construction on every network.
+ */
+export const getNativeContractId = (networkPassphrase: string): string =>
+  Asset.native().contractId(networkPassphrase);
+
+/** True only when `contractId` is the native SAC for the given network. */
+export const isNativeContract = (
+  contractId: string | undefined | null,
+  networkPassphrase: string,
+): boolean =>
+  !!contractId && contractId === getNativeContractId(networkPassphrase);

--- a/@shared/helpers/assetIdentity.ts
+++ b/@shared/helpers/assetIdentity.ts
@@ -50,9 +50,11 @@ export const isNativeBalance = (balance: AssetType): balance is NativeAsset =>
  * True only for the native asset.
  *
  * `getAssetFromCanonical` returns an SDK `Asset` for classic assets and a plain
- * `{ code, issuer }` for Soroban issuers, so both shapes arrive here. The SDK's
- * own `isNative()` is authoritative when present; the plain shape only ever
- * carries a `C…` issuer, which the pair test correctly rejects.
+ * `{ code, issuer }` for contract tokens and liquidity-pool shares, so both
+ * shapes arrive here. The SDK's own `isNative()` is authoritative when present.
+ * The plain shape's issuer is a validated `C…` address or the pool sentinel —
+ * never empty, which the parser rejects — so the pair test correctly rejects
+ * it.
  *
  * Narrowing on the method rather than `instanceof` keeps this correct across
  * the `stellar-sdk` / `stellar-sdk-next` dual-package split.

--- a/@shared/helpers/assetIdentity.ts
+++ b/@shared/helpers/assetIdentity.ts
@@ -44,7 +44,7 @@ export const isNativeAssetPair = (
 export const isNativeBalance = (balance: AssetType): balance is NativeAsset =>
   "token" in balance &&
   "type" in balance.token &&
-  isNativeAssetId(balance.token.type as unknown as string);
+  isNativeAssetId(balance.token.type);
 
 /**
  * True only for the native asset.

--- a/@shared/helpers/soroban/token.ts
+++ b/@shared/helpers/soroban/token.ts
@@ -10,7 +10,11 @@ import {
 import { buildSorobanServer } from "@shared/helpers/soroban/server";
 import { NetworkDetails } from "@shared/constants/stellar";
 import { INDEXER_URL } from "@shared/constants/mercury";
-import { getSdk, isCustomNetwork } from "@shared/helpers/stellar";
+import {
+  getSdk,
+  isCustomNetwork,
+  splitCanonical,
+} from "@shared/helpers/stellar";
 import { simulateTx } from "./server";
 import { SorobanRpcNotSupportedError } from "../../constants/errors";
 
@@ -178,7 +182,6 @@ export const getAssetSacAddress = (
   network: Networks,
 ) => {
   const Sdk = getSdk(network);
-  return new Sdk.Asset(
-    ...(canonicalName.split(":") as [string, string]),
-  ).contractId(network);
+  const { code, issuer } = splitCanonical(canonicalName);
+  return new Sdk.Asset(code, issuer).contractId(network);
 };

--- a/@shared/helpers/stellar.ts
+++ b/@shared/helpers/stellar.ts
@@ -10,6 +10,10 @@ import {
   NetworkDetails,
 } from "@shared/constants/stellar";
 import { INDEXER_URL } from "@shared/constants/mercury";
+import {
+  isNativeAssetId,
+  isNativeAssetPair,
+} from "@shared/helpers/assetIdentity";
 
 export const CUSTOM_NETWORK = "STANDALONE";
 export const LP_ISSUER_KEY = "lp";
@@ -75,7 +79,7 @@ export const makeDisplayableBalances = async (
     const url = new URL(`${INDEXER_URL}/scan-asset-bulk`);
     for (const balance of balances) {
       const balanceId = getBalanceIdentifier(balance);
-      if (balanceId !== "native" && !balanceId.includes(":lp")) {
+      if (!isNativeAssetId(balanceId) && !balanceId.includes(":lp")) {
         url.searchParams.append("asset_ids", balanceId.replace(":", "-"));
       }
     }
@@ -109,7 +113,7 @@ export const makeDisplayableBalances = async (
       buyingLiabilities = new BigNumber(balance.buying_liabilities).toString();
     }
 
-    if (identifier === "native") {
+    if (isNativeAssetId(identifier)) {
       // define the native balance line later
 
       displayableBalances.native = {
@@ -177,7 +181,7 @@ export const makeDisplayableBalances = async (
 export const isSorobanIssuer = (issuer: string) => !issuer.startsWith("G");
 
 export const getAssetFromCanonical = (canonical: string) => {
-  if (canonical === "native") {
+  if (isNativeAssetId(canonical)) {
     return StellarSdk.Asset.native();
   }
   if (canonical.includes(":")) {
@@ -199,7 +203,7 @@ export const getCanonicalFromAsset = (
   assetCode: string,
   assetIssuer?: string,
 ) => {
-  if (assetCode === "XLM" && !assetIssuer) {
+  if (isNativeAssetPair(assetCode, assetIssuer)) {
     return "native";
   }
   if (!assetIssuer) {

--- a/@shared/helpers/stellar.ts
+++ b/@shared/helpers/stellar.ts
@@ -180,19 +180,51 @@ export const makeDisplayableBalances = async (
 
 export const isSorobanIssuer = (issuer: string) => !issuer.startsWith("G");
 
+/**
+ * Splits a canonical identifier into its code and issuer halves.
+ *
+ * The split is on the last colon: an issuer is a `G…` or `C…` StrKey, or the
+ * liquidity-pool sentinel, none of which contains a colon — whereas a contract
+ * token's symbol is whatever the contract reports and may. Without a
+ * separator the whole string is the code and the issuer is empty.
+ */
+export const splitCanonical = (
+  canonical: string,
+): { code: string; issuer: string } => {
+  const separator = canonical.lastIndexOf(":");
+  if (separator === -1) {
+    return { code: canonical, issuer: "" };
+  }
+  return {
+    code: canonical.slice(0, separator),
+    issuer: canonical.slice(separator + 1),
+  };
+};
+
+/**
+ * Resolves a canonical identifier to an asset.
+ *
+ * A contract token or a liquidity-pool share comes back as the plain
+ * `{ code, issuer }` shape; a classic asset comes back as an SDK `Asset`, whose
+ * constructor validates the code and issuer. Anything else — including an
+ * issuer half that is empty or not a StrKey — is rejected here, at the parse
+ * boundary, rather than flowing on as a plausible-looking asset.
+ */
 export const getAssetFromCanonical = (canonical: string) => {
   if (isNativeAssetId(canonical)) {
     return StellarSdk.Asset.native();
   }
-  if (canonical.includes(":")) {
-    const [code, issuer] = canonical.split(":");
 
-    if (isSorobanIssuer(issuer)) {
-      return {
-        code,
-        issuer,
-      };
-    }
+  const { code, issuer } = splitCanonical(canonical);
+  if (!issuer) {
+    throw new Error(`invalid asset canonical id: ${canonical}`);
+  }
+
+  if (StellarSdk.StrKey.isValidContract(issuer) || issuer === LP_ISSUER_KEY) {
+    return { code, issuer };
+  }
+
+  if (StellarSdk.StrKey.isValidEd25519PublicKey(issuer)) {
     return new StellarSdk.Asset(code, issuer);
   }
 

--- a/config/eslint-plugin-asset-identity/__tests__/no-asset-code-comparison.test.ts
+++ b/config/eslint-plugin-asset-identity/__tests__/no-asset-code-comparison.test.ts
@@ -1,0 +1,60 @@
+import { RuleTester } from "eslint";
+
+import assetIdentity from "../index.mjs";
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+});
+
+// Prettier rewrites a double-quoted string containing double quotes to single
+// quotes, which the repo's quote rule then rejects. Quoting the sample sources
+// internally with single quotes keeps both tools satisfied; the rule reads the
+// parsed literal either way.
+//
+// RuleTester.run() drives Jest's global describe/it itself (one describe per
+// "valid"/"invalid" group, one it per case), so the call must sit at the
+// top level here rather than inside an it() — Jest's runner rejects a
+// describe/it pair started from inside an already-running test.
+ruleTester.run(
+  "no-asset-code-comparison",
+  assetIdentity.rules["no-asset-code-comparison"],
+  {
+    valid: [
+      "if (isNativeAssetId(canonical)) { go(); }",
+      "if (isNativeAssetPair(code, issuer)) { go(); }",
+      "const label = code + ':' + issuer;",
+      // Only strict equality is reported; other operators are untouched.
+      "if (code > 'XLM') { go(); }",
+      "if (code === 'USDC') { go(); }",
+    ],
+    invalid: [
+      {
+        code: "if (token.code === 'XLM') { go(); }",
+        errors: [{ messageId: "noAssetCodeComparison" }],
+      },
+      {
+        code: "if (balance.token.type !== 'native') { go(); }",
+        errors: [{ messageId: "noAssetCodeComparison" }],
+      },
+      // The sentinel on the left-hand side is the same defect.
+      {
+        code: "if ('XLM' === someCode) { go(); }",
+        errors: [{ messageId: "noAssetCodeComparison" }],
+      },
+      // Optional chaining must not hide the comparison.
+      {
+        code: "if (token?.code === 'XLM') { go(); }",
+        errors: [{ messageId: "noAssetCodeComparison" }],
+      },
+      // Any operand name is reported, so renaming a variable is no escape.
+      {
+        code: "if (srcTokenCodeFinal === 'XLM') { go(); }",
+        errors: [{ messageId: "noAssetCodeComparison" }],
+      },
+      {
+        code: "if (NATIVE_TOKEN_CODE === someCode) { go(); }",
+        errors: [{ messageId: "noAssetCodeComparison" }],
+      },
+    ],
+  },
+);

--- a/config/eslint-plugin-asset-identity/__tests__/no-asset-code-comparison.test.ts
+++ b/config/eslint-plugin-asset-identity/__tests__/no-asset-code-comparison.test.ts
@@ -26,6 +26,10 @@ ruleTester.run(
       // Only strict equality is reported; other operators are untouched.
       "if (code > 'XLM') { go(); }",
       "if (code === 'USDC') { go(); }",
+      // Comparing a contract id against the derived native contract is the
+      // sound check in contract space and must stay reportable-free.
+      "if (Asset.native().contractId(passphrase) === contractId) { go(); }",
+      "if (contractId !== getNativeContractId(passphrase)) { go(); }",
     ],
     invalid: [
       {
@@ -53,6 +57,19 @@ ruleTester.run(
       },
       {
         code: "if (NATIVE_TOKEN_CODE === someCode) { go(); }",
+        errors: [{ messageId: "noAssetCodeComparison" }],
+      },
+      // The SDK's own native code is the bare code in a different spelling.
+      {
+        code: "if (sourceAsset.code === Asset.native().code) { go(); }",
+        errors: [{ messageId: "noAssetCodeComparison" }],
+      },
+      {
+        code: "if (StellarSdk.Asset.native().code === code) { go(); }",
+        errors: [{ messageId: "noAssetCodeComparison" }],
+      },
+      {
+        code: "if (code !== Asset.native().getCode()) { go(); }",
         errors: [{ messageId: "noAssetCodeComparison" }],
       },
     ],

--- a/config/eslint-plugin-asset-identity/index.mjs
+++ b/config/eslint-plugin-asset-identity/index.mjs
@@ -1,5 +1,6 @@
 // Values that name the native asset by themselves: the display code, the
-// identifier the codebase uses for it, and the constants that hold them.
+// identifier the codebase uses for it, the constants that hold them, and the
+// SDK's own native code (`Asset.native().code`).
 //
 // An asset's identity is the pair (code, issuer) — or, for a contract token,
 // its contract id — so comparing anything directly against one of these is
@@ -16,6 +17,43 @@ const NATIVE_IDENTIFIER_NAMES = [
 const unwrapChain = (node) =>
   node.type === "ChainExpression" ? node.expression : node;
 
+// `X.native()` — the SDK's own native asset object, whatever `X` is
+// (`Asset.native()`, `StellarSdk.Asset.native()`, ...).
+const isSdkNativeCall = (rawNode) => {
+  const node = unwrapChain(rawNode);
+  return (
+    node.type === "CallExpression" &&
+    node.callee.type === "MemberExpression" &&
+    !node.callee.computed &&
+    node.callee.property.name === "native"
+  );
+};
+
+// The native display code read off the SDK object: `Asset.native().code` or
+// `Asset.native().getCode()`. Both evaluate to the bare code, so comparing
+// against them is the literal-"XLM" defect in a different spelling.
+//
+// `Asset.native().contractId(passphrase)` is deliberately NOT treated as a
+// sentinel: comparing a contract id against the derived native contract is the
+// sound check in contract space, and the codebase relies on it.
+const isSdkNativeCode = (node) => {
+  if (
+    node.type === "MemberExpression" &&
+    !node.computed &&
+    node.property.name === "code"
+  ) {
+    return isSdkNativeCall(node.object);
+  }
+
+  return (
+    node.type === "CallExpression" &&
+    node.callee.type === "MemberExpression" &&
+    !node.callee.computed &&
+    node.callee.property.name === "getCode" &&
+    isSdkNativeCall(node.callee.object)
+  );
+};
+
 const isNativeSentinel = (rawNode) => {
   const node = unwrapChain(rawNode);
 
@@ -27,9 +65,14 @@ const isNativeSentinel = (rawNode) => {
     return true;
   }
 
-  return (
-    node.type === "Identifier" && NATIVE_IDENTIFIER_NAMES.includes(node.name)
-  );
+  if (
+    node.type === "Identifier" &&
+    NATIVE_IDENTIFIER_NAMES.includes(node.name)
+  ) {
+    return true;
+  }
+
+  return isSdkNativeCode(node);
 };
 
 /** @type {import("eslint").Rule.RuleModule} */

--- a/config/eslint-plugin-asset-identity/index.mjs
+++ b/config/eslint-plugin-asset-identity/index.mjs
@@ -32,6 +32,7 @@ const isNativeSentinel = (rawNode) => {
   );
 };
 
+/** @type {import("eslint").Rule.RuleModule} */
 const noAssetCodeComparison = {
   meta: {
     type: "problem",

--- a/config/eslint-plugin-asset-identity/index.mjs
+++ b/config/eslint-plugin-asset-identity/index.mjs
@@ -1,0 +1,70 @@
+// Values that name the native asset by themselves: the display code, the
+// identifier the codebase uses for it, and the constants that hold them.
+//
+// An asset's identity is the pair (code, issuer) — or, for a contract token,
+// its contract id — so comparing anything directly against one of these is
+// unsound regardless of what the other operand is. It has to go through a
+// predicate instead.
+const NATIVE_LITERAL_VALUES = ["XLM", "native"];
+const NATIVE_IDENTIFIER_NAMES = [
+  "NATIVE_TOKEN_CODE",
+  "HORIZON_NATIVE_ASSET_TYPE",
+];
+
+// Unwraps an optional-chaining member access (`a?.b`) to the member expression
+// it wraps, so `token?.code` is inspected the same way as `token.code`.
+const unwrapChain = (node) =>
+  node.type === "ChainExpression" ? node.expression : node;
+
+const isNativeSentinel = (rawNode) => {
+  const node = unwrapChain(rawNode);
+
+  if (
+    node.type === "Literal" &&
+    typeof node.value === "string" &&
+    NATIVE_LITERAL_VALUES.includes(node.value)
+  ) {
+    return true;
+  }
+
+  return (
+    node.type === "Identifier" && NATIVE_IDENTIFIER_NAMES.includes(node.name)
+  );
+};
+
+const noAssetCodeComparison = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow comparing anything directly to a native-asset sentinel",
+      recommended: true,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      noAssetCodeComparison:
+        "Identify the native asset with a predicate from @shared/helpers/assetIdentity instead of comparing it to a native-asset sentinel.",
+    },
+  },
+
+  create(context) {
+    return {
+      BinaryExpression(node) {
+        if (node.operator !== "===" && node.operator !== "!==") {
+          return;
+        }
+
+        if (isNativeSentinel(node.left) || isNativeSentinel(node.right)) {
+          context.report({ node, messageId: "noAssetCodeComparison" });
+        }
+      },
+    };
+  },
+};
+
+export default {
+  rules: {
+    "no-asset-code-comparison": noAssetCodeComparison,
+  },
+};

--- a/docs/skills/freighter-best-practices/references/anti-patterns.md
+++ b/docs/skills/freighter-best-practices/references/anti-patterns.md
@@ -209,12 +209,15 @@ amount and a code identifies two different assets identically.
 The local plugin at `config/eslint-plugin-asset-identity/` enforces this:
 
 - **Rule:** `asset-identity/no-asset-code-comparison` (error level)
-- **What it does:** reports a `===`/`!==` comparison with a native sentinel
-  (`"XLM"`, `"native"`, or the identifier names `NATIVE_TOKEN_CODE` and
-  `HORIZON_NATIVE_ASSET_TYPE`) on either side. The last two name no constant
-  that exists anywhere in this codebase today -- they're there so that code
-  ported over from the mobile app, which does define them, is covered as soon as
-  it lands.
+- **What it does:** reports a `===`/`!==` comparison with a native sentinel on
+  either side: `"XLM"`, `"native"`, the SDK's own native code
+  (`Asset.native().code` / `Asset.native().getCode()`), or the identifier names
+  `NATIVE_TOKEN_CODE` and `HORIZON_NATIVE_ASSET_TYPE`. The last two name no
+  constant that exists anywhere in this codebase today -- they're there so that
+  code ported over from the mobile app, which does define them, is covered as
+  soon as it lands. Comparing a contract id against
+  `Asset.native().contractId(passphrase)` is _not_ reported: in contract space
+  that is the sound check.
 - **Enforcement scope:** `yarn build:extension` runs ESLint via
   `eslint-webpack-plugin`, whose lint glob is derived from the webpack context.
   That context is `<repo>/extension` under `yarn workspace extension build`, so

--- a/docs/skills/freighter-best-practices/references/anti-patterns.md
+++ b/docs/skills/freighter-best-practices/references/anti-patterns.md
@@ -210,13 +210,33 @@ The local plugin at `config/eslint-plugin-asset-identity/` enforces this:
 
 - **Rule:** `asset-identity/no-asset-code-comparison` (error level)
 - **What it does:** reports a `===`/`!==` comparison with a native sentinel
-  (`"XLM"`, `"native"`, `NATIVE_TOKEN_CODE`, `HORIZON_NATIVE_ASSET_TYPE`) on
-  either side. ESLint runs inside the webpack build, so a violation fails
-  `yarn build:extension`.
-- **What it can't do:** it cannot tell which predicate a given shape needs, so
-  choosing the wrong one still passes lint. Treat it as a safety net, not a
-  guarantee.
+  (`"XLM"`, `"native"`, or the identifier names `NATIVE_TOKEN_CODE` and
+  `HORIZON_NATIVE_ASSET_TYPE`) on either side. The last two name no constant
+  that exists anywhere in this codebase today -- they're there so that code
+  ported over from the mobile app, which does define them, is covered as soon as
+  it lands.
+- **Enforcement scope:** `yarn build:extension` runs ESLint via
+  `eslint-webpack-plugin`, whose lint glob is derived from the webpack context.
+  That context is `<repo>/extension` under `yarn workspace extension build`, so
+  the build gate only covers `extension/` -- a violation there fails the build.
+  `@shared/`, the tree the predicates themselves live in, is not covered by that
+  gate: today it's only checked when ESLint is run directly from the repo root,
+  and there is no root `lint` script that does that automatically. Closing that
+  gap is a follow-up, not something the current setup already provides.
+- **What it can't do:**
+  - It cannot tell which predicate a given shape needs, so choosing the wrong
+    one still passes lint.
+  - It only visits `===`/`!==` binary expressions, so it is silent on loose
+    equality (`==` / `!=`), `switch` / `case "native"`, template literals
+    (`` code === `native` ``), `.includes()` / `.indexOf()` / `.startsWith()` /
+    `Object.is()`, and a sentinel hoisted into a local constant
+    (`const N = "native"; token.type === N`).
+
+  Treat it as a safety net, not a guarantee.
 
 Do not add an `eslint-disable` for this rule. `@shared/helpers/assetIdentity.ts`
-is exempt because it is the module that defines the predicates; every other site
-goes through them.
+is exempt in `eslint.config.js` as a belt-and-braces safeguard, not a necessity
+-- that module compares against its own local constants (`NATIVE_ASSET_ID`,
+`NATIVE_ASSET_CODE`), which aren't in the rule's identifier list, so the rule
+would not fire there regardless. The exemption is deliberate, self-documenting
+policy: keep it.

--- a/docs/skills/freighter-best-practices/references/anti-patterns.md
+++ b/docs/skills/freighter-best-practices/references/anti-patterns.md
@@ -169,3 +169,54 @@ If leaving a TODO, create a GitHub issue and reference it:
 ```
 
 This ensures TODOs are tracked and not forgotten.
+
+## 11. Identifying Assets by Code
+
+An asset's identity is the pair `(code, issuer)` -- or, for a contract token,
+its contract id. Asset codes are not unique: more than one asset can share a
+code, so a bare code comparison never establishes that two assets are the same
+asset, or that an asset is the native lumen.
+
+```typescript
+// WRONG: a code alone doesn't identify the asset
+if (token.code === "XLM") { ... }
+
+// CORRECT: use the predicate for what you're holding
+if (isNativeAsset(asset)) { ... }
+```
+
+Use the predicate that matches what you have in hand:
+
+| What you hold                                             | Use                                               |
+| --------------------------------------------------------- | ------------------------------------------------- |
+| an SDK `Asset`, or `{ code, issuer }`                     | `isNativeAsset(asset)`                            |
+| a balance object                                          | `isNativeBalance(balance)`                        |
+| a canonical id, a Horizon `asset_type`, or a `token.type` | `isNativeAssetId(id)`                             |
+| a contract id                                             | `isNativeContract(contractId, networkPassphrase)` |
+| the native contract id itself                             | `getNativeContractId(networkPassphrase)`          |
+| a raw code and issuer, with nothing better available      | `isNativeAssetPair(code, issuer)`                 |
+
+All of these live in `@shared/helpers/assetIdentity.ts`.
+
+Nativeness is only half of it. For anything else that identifies an asset --
+equality, map keys, list membership, or a user-visible label -- use the full
+canonical from `getCanonicalFromAsset(code, issuer)` in
+`@shared/helpers/stellar.ts`, never a bare code. A review row that renders an
+amount and a code identifies two different assets identically.
+
+### ESLint Enforcement
+
+The local plugin at `config/eslint-plugin-asset-identity/` enforces this:
+
+- **Rule:** `asset-identity/no-asset-code-comparison` (error level)
+- **What it does:** reports a `===`/`!==` comparison with a native sentinel
+  (`"XLM"`, `"native"`, `NATIVE_TOKEN_CODE`, `HORIZON_NATIVE_ASSET_TYPE`) on
+  either side. ESLint runs inside the webpack build, so a violation fails
+  `yarn build:extension`.
+- **What it can't do:** it cannot tell which predicate a given shape needs, so
+  choosing the wrong one still passes lint. Treat it as a safety net, not a
+  guarantee.
+
+Do not add an `eslint-disable` for this rule. `@shared/helpers/assetIdentity.ts`
+is exempt because it is the module that defines the predicates; every other site
+goes through them.

--- a/docs/skills/freighter-best-practices/references/code-style.md
+++ b/docs/skills/freighter-best-practices/references/code-style.md
@@ -184,8 +184,10 @@ Never identify an asset with a bare code. Asset codes are not unique, so `"XLM"`
 identifies neither the native lumen nor any single asset. Use the predicates in
 `@shared/helpers/assetIdentity.ts` for nativeness, and
 `getCanonicalFromAsset(code, issuer)` for identity. See
-[Anti-Patterns 11](./anti-patterns.md) for the full convention; the
-`asset-identity/no-asset-code-comparison` ESLint rule enforces it.
+[Anti-Patterns 11](./anti-patterns.md#11-identifying-assets-by-code) for the
+full convention. The `asset-identity/no-asset-code-comparison` ESLint rule
+catches native-sentinel comparisons; it doesn't check identity, so using
+`getCanonicalFromAsset` is not something lint enforces for you.
 
 ### Action Type Strings
 

--- a/docs/skills/freighter-best-practices/references/code-style.md
+++ b/docs/skills/freighter-best-practices/references/code-style.md
@@ -19,13 +19,15 @@ The project uses Prettier (`.prettierrc.yaml`) with the following settings:
 Flat config (`eslint.config.js`) with:
 
 - **Parser:** `@typescript-eslint/parser`
-- **Plugins:** React, React Hooks, JSX A11y, Import, TypeScript ESLint
+- **Plugins:** React, React Hooks, JSX A11y, Import, TypeScript ESLint, Asset
+  Identity (local, `config/eslint-plugin-asset-identity/`)
 - **Key rules:**
   - `semi` -- error (semicolons required)
   - `react-hooks/rules-of-hooks` -- error
   - `react-hooks/exhaustive-deps` -- warn
   - `react/prop-types` -- off (TypeScript replaces prop-types)
   - `import/no-unresolved` -- warn
+  - `asset-identity/no-asset-code-comparison` -- error
 
 ## Import Ordering
 
@@ -175,6 +177,15 @@ shared messages.
 
 All `browser.storage` keys must use constants from
 `extension/src/constants/localStorageTypes.ts` — never hardcoded strings.
+
+### Asset Identifiers
+
+Never identify an asset with a bare code. Asset codes are not unique, so `"XLM"`
+identifies neither the native lumen nor any single asset. Use the predicates in
+`@shared/helpers/assetIdentity.ts` for nativeness, and
+`getCanonicalFromAsset(code, issuer)` for identity. See
+[Anti-Patterns 11](./anti-patterns.md) for the full convention; the
+`asset-identity/no-asset-code-comparison` ESLint rule enforces it.
 
 ### Action Type Strings
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ import jsxA11y from "eslint-plugin-jsx-a11y";
 import importPlugin from "eslint-plugin-import";
 import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
 import globals from "globals";
+import assetIdentity from "./config/eslint-plugin-asset-identity/index.mjs";
 
 export default [
   js.configs.recommended,
@@ -55,6 +56,7 @@ export default [
       "jsx-a11y": jsxA11y,
       import: importPlugin,
       eslintPluginPrettierRecommended,
+      "asset-identity": assetIdentity,
     },
     settings: {
       react: { version: "detect" },
@@ -93,6 +95,14 @@ export default [
       // ~42 existing violations) is tracked as a separate follow-up.
       "no-useless-assignment": "off",
       "preserve-caught-error": "off",
+
+      "asset-identity/no-asset-code-comparison": "error",
+    },
+  },
+  {
+    files: ["@shared/helpers/assetIdentity.ts"],
+    rules: {
+      "asset-identity/no-asset-code-comparison": "off",
     },
   },
 ];

--- a/extension/src/helpers/__tests__/useGetAssetDomainsWithBalances.test.tsx
+++ b/extension/src/helpers/__tests__/useGetAssetDomainsWithBalances.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Provider } from "react-redux";
 import { useLocation } from "react-router-dom";
 import { renderHook, act } from "@testing-library/react";
+import BigNumber from "bignumber.js";
 import { useGetAssetDomainsWithBalances } from "../hooks/useGetAssetDomainsWithBalances";
 import {
   makeDummyStore,
@@ -12,6 +13,11 @@ import {
 import { RequestState } from "constants/request";
 import { TESTNET_NETWORK_DETAILS } from "@shared/constants/stellar";
 import { getAssetDomains } from "@shared/api/internal";
+import { defaultBlockaidScanAssetResult } from "@shared/helpers/stellar";
+import {
+  AssetSelectType,
+  initialState as transactionSubmissionInitialState,
+} from "popup/ducks/transactionSubmission";
 
 jest.mock("@shared/api/internal", () => ({
   ...jest.requireActual("@shared/api/internal"),
@@ -309,5 +315,133 @@ describe("useGetAssetDomainsWithBalances (cached path)", () => {
         isSuspicious: true,
       },
     ]);
+  });
+});
+
+describe("useGetAssetDomainsWithBalances (native-code asset identity)", () => {
+  const publicKey = TEST_PUBLIC_KEY;
+
+  // A classic asset that reuses the native display code "XLM" but is issued
+  // by a real G-account. The display code alone doesn't make it native —
+  // only the (code, issuer) pair does — so it must be treated as an
+  // ordinary asset: its own issuer, its own domain lookup, its own
+  // Blockaid verdict, and it must not collapse into the native row.
+  const xlmCodeIssuer =
+    "GDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD";
+  const xlmCodeCanonical = `XLM:${xlmCodeIssuer}`;
+
+  const balanceData = {
+    isFunded: true,
+    subentryCount: 1,
+    error: undefined,
+    balances: {
+      native: {
+        token: { type: "native", code: "XLM" },
+        total: new BigNumber("50"),
+        available: new BigNumber("50"),
+        blockaidData: defaultBlockaidScanAssetResult,
+      },
+      [xlmCodeCanonical]: {
+        token: {
+          code: "XLM",
+          issuer: { key: xlmCodeIssuer },
+        },
+        total: new BigNumber("100"),
+        available: new BigNumber("100"),
+        // Not benign, so a correct `isSuspicious` has to come from this data
+        // — a hardcoded `false` would pin the wrong answer here.
+        blockaidData: {
+          address: `XLM-${xlmCodeIssuer}`,
+          result_type: "Spam",
+          features: [{ feature_id: "METADATA", description: "not benign" }],
+        },
+      },
+    } as any,
+  };
+
+  const preloadedState = {
+    auth: {
+      publicKey,
+      hasPrivateKey: true,
+    },
+    cache: {
+      balanceData: {
+        [TESTNET_NETWORK_DETAILS.network]: {
+          [publicKey]: { ...balanceData, updatedAt: Date.now() },
+        },
+      },
+      icons: {},
+      tokenLists: [],
+      homeDomains: {
+        [TESTNET_NETWORK_DETAILS.network]: {
+          [xlmCodeIssuer]: "notxlm.example.com",
+        },
+      },
+    },
+    settings: {
+      assetsLists: [],
+      networkDetails: TESTNET_NETWORK_DETAILS,
+    },
+    // The duck's default `assetSelect.type` is MANAGE, which skips the
+    // native row entirely (the hook's `else if (!isManagingAssets)` branch),
+    // so the native control row below would never be produced. Force a
+    // non-manage context instead.
+    transactionSubmission: {
+      ...transactionSubmissionInitialState,
+      assetSelect: { type: AssetSelectType.REGULAR, isSource: true },
+    },
+  };
+
+  it("keeps a non-native XLM-coded asset out of the native row", async () => {
+    const store = makeDummyStore(preloadedState);
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <Provider store={store}>{children}</Provider>
+    );
+
+    const { result } = renderHook(
+      () =>
+        useGetAssetDomainsWithBalances({
+          showHidden: false,
+          includeIcons: false,
+        }),
+      { wrapper: Wrapper },
+    );
+
+    await act(async () => {
+      await result.current.fetchData(true);
+    });
+
+    expect(result.current.state.state).toBe<RequestState>(RequestState.SUCCESS);
+
+    // @ts-ignore
+    const domains = result.current.state.data?.domains as any[];
+
+    // Both entries must exist as separate rows — the shared display code
+    // must not merge one into the other.
+    expect(domains).toHaveLength(2);
+
+    const nativeRow = domains.find((d) => d.issuer === "");
+    const xlmCodeRow = domains.find((d) => d.issuer === xlmCodeIssuer);
+
+    // Control: the genuine native row is unchanged — no issuer, no domain
+    // lookup, benign.
+    expect(nativeRow).toEqual({
+      code: "XLM",
+      issuer: "",
+      image: "",
+      domain: "",
+      isSuspicious: false,
+    });
+
+    // The non-native XLM-coded asset: real issuer, its own domain, and a
+    // Blockaid-derived verdict rather than the hardcoded native default.
+    expect(xlmCodeRow).toEqual({
+      code: "XLM",
+      issuer: xlmCodeIssuer,
+      image: null,
+      domain: "notxlm.example.com",
+      contract: undefined,
+      isSuspicious: true,
+    });
   });
 });

--- a/extension/src/helpers/hooks/useGetAssetDomainsWithBalances.ts
+++ b/extension/src/helpers/hooks/useGetAssetDomainsWithBalances.ts
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { NetworkDetails } from "@shared/constants/stellar";
 import { Balance } from "@shared/api/types";
-import { isNativeAssetPair } from "@shared/helpers/assetIdentity";
+import { isNativeBalance } from "@shared/helpers/assetIdentity";
 import { initialState, isError, reducer } from "helpers/request";
 
 import { ManageAssetCurrency } from "popup/components/manageAssets/ManageAssetRows";
@@ -112,7 +112,7 @@ export function useGetAssetDomainsWithBalances(getBalancesOptions: {
           continue;
         }
 
-        if (!isNativeAssetPair(code, issuer.key)) {
+        if (!isNativeBalance(balance)) {
           let domain = "";
 
           const cachedHomeDomain =

--- a/extension/src/helpers/hooks/useGetAssetDomainsWithBalances.ts
+++ b/extension/src/helpers/hooks/useGetAssetDomainsWithBalances.ts
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { NetworkDetails } from "@shared/constants/stellar";
 import { Balance } from "@shared/api/types";
+import { isNativeAssetPair } from "@shared/helpers/assetIdentity";
 import { initialState, isError, reducer } from "helpers/request";
 
 import { ManageAssetCurrency } from "popup/components/manageAssets/ManageAssetRows";
@@ -111,7 +112,7 @@ export function useGetAssetDomainsWithBalances(getBalancesOptions: {
           continue;
         }
 
-        if (code !== "XLM") {
+        if (!isNativeAssetPair(code, issuer.key)) {
           let domain = "";
 
           const cachedHomeDomain =

--- a/extension/src/helpers/transaction.ts
+++ b/extension/src/helpers/transaction.ts
@@ -2,6 +2,7 @@ import {
   AssetType,
   LiquidityPoolShareAsset,
 } from "@shared/api/types/account-balance";
+import { isNativeBalance } from "@shared/helpers/assetIdentity";
 import BigNumber from "bignumber.js";
 
 export enum AMOUNT_ERROR {
@@ -21,7 +22,7 @@ export const computeDestMinWithSlippage = (
 };
 
 export const title = (balance: Exclude<AssetType, LiquidityPoolShareAsset>) => {
-  if ("type" in balance.token && balance.token.type === "native") {
+  if (isNativeBalance(balance)) {
     return "XLM";
   }
   if ("symbol" in balance) {

--- a/extension/src/popup/components/AssetListRow/index.tsx
+++ b/extension/src/popup/components/AssetListRow/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { AssetIcon } from "popup/components/account/AccountAssets";
+import { isNativeAssetPair } from "@shared/helpers/assetIdentity";
 import { formatDomain, getCanonicalFromAsset } from "helpers/stellar";
 import { truncateString } from "helpers/stellar";
 
@@ -50,8 +51,7 @@ export const AssetListRow = ({
   codeTestId,
   domainTestId,
 }: AssetListRowProps) => {
-  const canonical =
-    code === "XLM" && !issuer ? "native" : getCanonicalFromAsset(code, issuer);
+  const canonical = getCanonicalFromAsset(code, issuer);
   const label = displayCode ?? code;
   const displayLabel = label.length > 20 ? truncateString(label) : label;
 
@@ -64,7 +64,11 @@ export const AssetListRow = ({
         role={onClick ? "button" : undefined}
       >
         <AssetIcon
-          assetIcons={code !== "XLM" ? { [canonical]: iconUrl || "" } : {}}
+          assetIcons={
+            !isNativeAssetPair(code, issuer)
+              ? { [canonical]: iconUrl || "" }
+              : {}
+          }
           code={code}
           issuerKey={issuer}
           icon={iconUrl || undefined}

--- a/extension/src/popup/components/AssetTile/index.tsx
+++ b/extension/src/popup/components/AssetTile/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import { AssetIcon } from "popup/components/account/AccountAssets";
 import { SelectionTile } from "popup/components/SelectionTile";
+import { isNativeAssetId } from "@shared/helpers/assetIdentity";
 
 interface AssetTileProps {
   asset: {
@@ -40,7 +41,7 @@ export const AssetTile = ({
         icon={
           <AssetIcon
             assetIcons={
-              asset.canonical !== "native"
+              !isNativeAssetId(asset.canonical)
                 ? { [asset.canonical]: assetIcon }
                 : {}
             }

--- a/extension/src/popup/components/BalanceRow/__tests__/index.test.tsx
+++ b/extension/src/popup/components/BalanceRow/__tests__/index.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { BalanceRow } from "popup/components/BalanceRow";
+import { Wrapper } from "popup/__testHelpers__";
+
+// A real classic-asset issuer that happens to use the native display code.
+const XLM_CODED_ISSUER =
+  "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+const FETCHED_ICON = "https://example.test/icon.png";
+
+// Bundled images resolve to this stub under the Jest file mock, so a rendered
+// src of "test-file-stub" means the bundled Stellar logo was chosen.
+const BUNDLED_LOGO = "test-file-stub";
+
+const renderRow = (props: Partial<React.ComponentProps<typeof BalanceRow>>) =>
+  render(
+    <Wrapper state={{}} routes={["/"]}>
+      <BalanceRow code="XLM" amount="100" {...props} />
+    </Wrapper>,
+  );
+
+describe("BalanceRow", () => {
+  it("renders the bundled logo for the genuine native asset (control)", () => {
+    renderRow({});
+
+    expect(
+      screen.queryByTestId("AccountAssets__asset--loading"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByAltText("XLM logo")).toHaveAttribute(
+      "src",
+      BUNDLED_LOGO,
+    );
+  });
+
+  // Pins the hazard documented in BalanceRow's own comment: AssetIcon shows a
+  // perpetual loading state when `assetIcons` is empty and the asset isn't
+  // native. A classic asset that happens to use the "XLM" display code but
+  // carries a real issuer is not native, so with no `assetIcons` prop at all
+  // (the caller has nothing to pass), BalanceRow must synthesize a one-entry
+  // map from `iconUrl` rather than leaving AssetIcon to fetch forever.
+  it("renders the fetched icon for a classic asset that uses the native code, with no assetIcons prop", () => {
+    renderRow({
+      issuerKey: XLM_CODED_ISSUER,
+      iconUrl: FETCHED_ICON,
+    });
+
+    expect(
+      screen.queryByTestId("AccountAssets__asset--loading"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByAltText("XLM logo")).toHaveAttribute(
+      "src",
+      FETCHED_ICON,
+    );
+  });
+});

--- a/extension/src/popup/components/BalanceRow/index.tsx
+++ b/extension/src/popup/components/BalanceRow/index.tsx
@@ -12,6 +12,7 @@ import {
 } from "popup/helpers/formatters";
 import { getPriceDeltaColor } from "popup/helpers/balance";
 import { getCanonicalFromAsset } from "helpers/stellar";
+import { isNativeAssetPair } from "@shared/helpers/assetIdentity";
 
 import "./styles.scss";
 
@@ -70,12 +71,9 @@ export const BalanceRow = ({
   // AssetIcon shows a perpetual loading state when assetIcons is empty (and the
   // asset isn't XLM). Callers that pass a single iconUrl (e.g. the swap picker's
   // held list) would otherwise hit that; synthesize a one-entry map for them.
-  const canonical =
-    code === "XLM" && !issuerKey
-      ? "native"
-      : getCanonicalFromAsset(code, issuerKey);
+  const canonical = getCanonicalFromAsset(code, issuerKey);
   const resolvedIcons =
-    code !== "XLM" && isEmpty(assetIcons)
+    !isNativeAssetPair(code, issuerKey) && isEmpty(assetIcons)
       ? { [canonical]: iconUrl ?? "" }
       : assetIcons;
   const deltaColor = hasDelta
@@ -84,7 +82,9 @@ export const BalanceRow = ({
 
   // XLM is the only token whose friendly name we hold locally; the rest fall
   // back to their code.
-  const displayName = code === "XLM" && !issuerKey ? t("Stellar Lumens") : code;
+  const displayName = isNativeAssetPair(code, issuerKey)
+    ? t("Stellar Lumens")
+    : code;
 
   return (
     <div

--- a/extension/src/popup/components/InternalTransaction/ReviewTransaction/components/SendDestination.tsx
+++ b/extension/src/popup/components/InternalTransaction/ReviewTransaction/components/SendDestination.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Asset } from "stellar-sdk";
 import { NetworkDetails } from "@shared/constants/stellar";
+import { isNativeAssetId } from "@shared/helpers/assetIdentity";
 import { isMainnet } from "helpers/stellar";
 import { AssetIcon } from "popup/components/account/AccountAssets";
 import { IdenticonImg } from "popup/components/identicons/IdenticonImg";
@@ -36,7 +37,7 @@ export const SendDestination: React.FC<SendDestinationProps> = ({
       <>
         <AssetIcon
           assetIcons={
-            dstAsset.canonical !== "native"
+            !isNativeAssetId(dstAsset.canonical)
               ? { [dstAsset.canonical]: dstAsset.icon }
               : {}
           }

--- a/extension/src/popup/components/InternalTransaction/ReviewTransaction/index.tsx
+++ b/extension/src/popup/components/InternalTransaction/ReviewTransaction/index.tsx
@@ -26,6 +26,7 @@ import {
   truncatedFedAddress,
   truncatedPublicKey,
 } from "helpers/stellar";
+import { isNativeAssetId } from "@shared/helpers/assetIdentity";
 import {
   getContractIdFromTransactionData,
   getAuthEntryBoundAddress,
@@ -185,7 +186,9 @@ export const ReviewTx = ({
   const dest = dstAsset ? getAssetFromCanonical(dstAsset.canonical) : null;
   // A destination asset is only present on swaps; Send has a recipient address.
   const isSwap = !!dstAsset;
-  const assetIcons = srcAsset !== "native" ? { [srcAsset]: assetIcon } : {};
+  const assetIcons = !isNativeAssetId(srcAsset)
+    ? { [srcAsset]: assetIcon }
+    : {};
   const truncatedDest = federationAddress
     ? truncatedFedAddress(federationAddress)
     : truncatedPublicKey(destination);

--- a/extension/src/popup/components/InternalTransaction/SubmitTransaction/index.tsx
+++ b/extension/src/popup/components/InternalTransaction/SubmitTransaction/index.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { Button, Icon, Loader } from "@stellar/design-system";
 
 import { isCustomNetwork } from "@shared/helpers/stellar";
+import { isNativeAssetId } from "@shared/helpers/assetIdentity";
 import { ActionStatus } from "@shared/api/types";
 import { RequestState } from "constants/request";
 import { getAssetFromCanonical, truncatedPublicKey } from "helpers/stellar";
@@ -139,7 +140,7 @@ export const SendingTransaction = ({
     submissionState.state === RequestState.LOADING;
   const isSuccess = submissionState.state === RequestState.SUCCESS;
   const assetIcon = icons[asset]!;
-  const assetIcons = asset !== "native" ? { [asset]: assetIcon } : {};
+  const assetIcons = !isNativeAssetId(asset) ? { [asset]: assetIcon } : {};
   // A new (not-yet-held) destination token has no entry in the icon cache, so
   // fall back to the iconUrl carried on the picked token's details — the same
   // source the picker and review screen use — so the icon persists through the
@@ -148,8 +149,9 @@ export const SendingTransaction = ({
     icons[destinationAsset] ||
     transactionData.destinationTokenDetails?.iconUrl ||
     "";
-  const dstAssetIcons =
-    destinationAsset !== "native" ? { [destinationAsset]: dstAssetIcon } : {};
+  const dstAssetIcons = !isNativeAssetId(destinationAsset)
+    ? { [destinationAsset]: dstAssetIcon }
+    : {};
 
   if (
     submitAccountState.state == RequestState.IDLE ||

--- a/extension/src/popup/components/InternalTransaction/TokenList/index.tsx
+++ b/extension/src/popup/components/InternalTransaction/TokenList/index.tsx
@@ -9,10 +9,7 @@ import {
   LiquidityPoolShareAsset,
 } from "@shared/api/types/account-balance";
 import { getCanonicalFromAsset } from "helpers/stellar";
-import {
-  isNativeAssetPair,
-  isNativeBalance,
-} from "@shared/helpers/assetIdentity";
+import { isNativeBalance } from "@shared/helpers/assetIdentity";
 import { ApiTokenPrices, AssetIcons } from "@shared/api/types";
 import { getAvailableBalance } from "popup/helpers/soroban";
 import {
@@ -112,11 +109,7 @@ export const TokenList = ({
                 >
                   <div className="TokenList__AssetRow__Body">
                     <AssetIcon
-                      assetIcons={
-                        !isNativeAssetPair(code, issuerKey)
-                          ? { [canonical]: icon }
-                          : {}
-                      }
+                      assetIcons={!isNative ? { [canonical]: icon } : {}}
                       code={code}
                       issuerKey={issuerKey!}
                       icon={icon}

--- a/extension/src/popup/components/InternalTransaction/TokenList/index.tsx
+++ b/extension/src/popup/components/InternalTransaction/TokenList/index.tsx
@@ -9,6 +9,10 @@ import {
   LiquidityPoolShareAsset,
 } from "@shared/api/types/account-balance";
 import { getCanonicalFromAsset } from "helpers/stellar";
+import {
+  isNativeAssetPair,
+  isNativeBalance,
+} from "@shared/helpers/assetIdentity";
 import { ApiTokenPrices, AssetIcons } from "@shared/api/types";
 import { getAvailableBalance } from "popup/helpers/soroban";
 import {
@@ -86,8 +90,7 @@ export const TokenList = ({
                   ? balance.token.issuer.key
                   : undefined;
               const isContract = "contractId" in balance;
-              const isNative =
-                "type" in balance.token && balance.token.type === "native";
+              const isNative = isNativeBalance(balance);
               const canonical = getCanonicalFromAsset(code, issuerKey);
               const icon = icons[canonical];
               const availableBalance = getAvailableBalance({
@@ -109,7 +112,11 @@ export const TokenList = ({
                 >
                   <div className="TokenList__AssetRow__Body">
                     <AssetIcon
-                      assetIcons={code !== "XLM" ? { [canonical]: icon } : {}}
+                      assetIcons={
+                        !isNativeAssetPair(code, issuerKey)
+                          ? { [canonical]: icon }
+                          : {}
+                      }
                       code={code}
                       issuerKey={issuerKey!}
                       icon={icon}

--- a/extension/src/popup/components/account/AccountAssets/__tests__/AssetIcon.test.tsx
+++ b/extension/src/popup/components/account/AccountAssets/__tests__/AssetIcon.test.tsx
@@ -45,4 +45,57 @@ describe("AssetIcon", () => {
       FETCHED_ICON,
     );
   });
+
+  // The component is memoised with a custom comparator. When only the asset's
+  // identity changes on a surviving instance — the icon map staying deeply
+  // equal — the comparator must still let the render through, or the previous
+  // asset's logo stays on screen.
+  describe("re-rendering a surviving instance with a new asset identity", () => {
+    const wrap = (props: {
+      code: string;
+      issuerKey?: string;
+      assetIcons: Record<string, string>;
+    }) => (
+      <Wrapper state={{}} routes={["/"]}>
+        <AssetIcon {...props} />
+      </Wrapper>
+    );
+
+    it("re-renders when the native asset becomes a classic asset using the native code", () => {
+      const { rerender } = renderIcon({ code: "XLM", assetIcons: {} });
+      expect(screen.getByAltText("XLM logo")).toHaveAttribute(
+        "src",
+        BUNDLED_LOGO,
+      );
+
+      rerender(
+        wrap({ code: "XLM", issuerKey: XLM_CODED_ISSUER, assetIcons: {} }),
+      );
+
+      // Same (empty) icon map, different identity: no bundled logo any more —
+      // the icon now has to be looked up, so the loading state shows.
+      expect(screen.queryByAltText("XLM logo")).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId("AccountAssets__asset--loading"),
+      ).toBeInTheDocument();
+    });
+
+    it("re-renders when a classic asset using the native code becomes the native asset", () => {
+      const { rerender } = renderIcon({
+        code: "XLM",
+        issuerKey: XLM_CODED_ISSUER,
+        assetIcons: {},
+      });
+      expect(
+        screen.getByTestId("AccountAssets__asset--loading"),
+      ).toBeInTheDocument();
+
+      rerender(wrap({ code: "XLM", assetIcons: {} }));
+
+      expect(screen.getByAltText("XLM logo")).toHaveAttribute(
+        "src",
+        BUNDLED_LOGO,
+      );
+    });
+  });
 });

--- a/extension/src/popup/components/account/AccountAssets/__tests__/AssetIcon.test.tsx
+++ b/extension/src/popup/components/account/AccountAssets/__tests__/AssetIcon.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { AssetIcon } from "popup/components/account/AccountAssets";
+import { Wrapper } from "popup/__testHelpers__";
+
+const XLM_CODED_ISSUER =
+  "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+const FETCHED_ICON = "https://example.test/icon.png";
+
+// Bundled images resolve to this stub under the Jest file mock, so a rendered
+// src of "test-file-stub" means the bundled Stellar logo was chosen.
+const BUNDLED_LOGO = "test-file-stub";
+
+const renderIcon = (props: {
+  code: string;
+  issuerKey?: string;
+  assetIcons: Record<string, string>;
+}) =>
+  render(
+    <Wrapper state={{}} routes={["/"]}>
+      <AssetIcon {...props} />
+    </Wrapper>,
+  );
+
+describe("AssetIcon", () => {
+  it("shows the bundled logo for the native asset", () => {
+    renderIcon({ code: "XLM", assetIcons: {} });
+
+    expect(screen.getByAltText("XLM logo")).toHaveAttribute(
+      "src",
+      BUNDLED_LOGO,
+    );
+  });
+
+  it("shows the fetched icon for a classic asset that uses the native code", () => {
+    renderIcon({
+      code: "XLM",
+      issuerKey: XLM_CODED_ISSUER,
+      assetIcons: { [`XLM:${XLM_CODED_ISSUER}`]: FETCHED_ICON },
+    });
+
+    expect(screen.getByAltText("XLM logo")).toHaveAttribute(
+      "src",
+      FETCHED_ICON,
+    );
+  });
+});

--- a/extension/src/popup/components/account/AccountAssets/index.tsx
+++ b/extension/src/popup/components/account/AccountAssets/index.tsx
@@ -8,6 +8,7 @@ import isEqual from "lodash/isEqual";
 
 import { ApiTokenPrices, AssetIcons, Balance } from "@shared/api/types";
 import { retryAssetIcon } from "@shared/api/internal";
+import { isNativeAssetPair } from "@shared/helpers/assetIdentity";
 import { AccountBalances } from "helpers/hooks/useGetBalances";
 
 import { getCanonicalFromAsset } from "helpers/stellar";
@@ -38,8 +39,6 @@ import { BalanceRow } from "popup/components/BalanceRow";
 
 import "./styles.scss";
 import { AssetDetail } from "../AssetDetail";
-
-const getIsXlm = (code: string) => code === "XLM";
 
 export const SorobanTokenIcon = ({ noMargin }: { noMargin?: boolean }) => (
   <div
@@ -91,7 +90,7 @@ export const AssetIcon = memo(
     Method 2. We get an icon path directly from an API (like in the trustline flow) and just pass it to this component to render
   */
 
-    const isXlm = getIsXlm(code);
+    const isXlm = isNativeAssetPair(code, issuerKey);
 
     // in Method 1, while we wait for the icon path to load, `assetIcons` will be empty until the promise resolves
     // This does not apply for XLM as there is no lookup as that logo lives in this codebase
@@ -272,8 +271,8 @@ export const AccountAssets = ({
     }
   };
 
-  const handleClick = (code: string) => {
-    setSelectedAsset(getIsXlm(code) ? "native" : code);
+  const handleClick = (canonicalAsset: string) => {
+    setSelectedAsset(canonicalAsset);
   };
 
   const getLPShareCode = (reserves: Horizon.HorizonApi.Reserve[]) => {

--- a/extension/src/popup/components/account/AccountAssets/index.tsx
+++ b/extension/src/popup/components/account/AccountAssets/index.tsx
@@ -63,11 +63,23 @@ interface AssetIconProps {
   isModal?: boolean;
 }
 
+// Skip a re-render only when nothing that affects the rendered icon changed.
+// `assetIcons` is compared deeply because callers build it per render; the
+// retry callback is left out because its identity is unstable and it does not
+// affect what is rendered. Every other prop feeds the render — the asset's
+// identity (code + issuer) decides between the bundled native logo, a Soroban
+// placeholder and an icon lookup — so each has to be compared.
 const shouldAssetIconSkipUpdate = (
   prevProps: AssetIconProps,
   nextProps: AssetIconProps,
 ) =>
   isEqual(prevProps.assetIcons, nextProps.assetIcons) &&
+  prevProps.code === nextProps.code &&
+  prevProps.issuerKey === nextProps.issuerKey &&
+  prevProps.icon === nextProps.icon &&
+  prevProps.isLPShare === nextProps.isLPShare &&
+  prevProps.isSorobanToken === nextProps.isSorobanToken &&
+  prevProps.isModal === nextProps.isModal &&
   prevProps.isSuspicious === nextProps.isSuspicious &&
   prevProps.isMalicious === nextProps.isMalicious;
 

--- a/extension/src/popup/components/account/AssetDetail/index.tsx
+++ b/extension/src/popup/components/account/AssetDetail/index.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { Button, CopyText, Icon, Link, Loader } from "@stellar/design-system";
 
 import { NetworkDetails } from "@shared/constants/stellar";
+import { isNativeBalance } from "@shared/helpers/assetIdentity";
 import IconEllipsis from "popup/assets/icon-ellipsis.svg";
 import {
   displaySorobanId,
@@ -43,7 +44,6 @@ import { title } from "helpers/transaction";
 import {
   getBalanceByAsset,
   getPriceDeltaColor,
-  isNativeBalance,
   isSorobanBalance,
 } from "popup/helpers/balance";
 import { CopyValue } from "popup/components/CopyValue";

--- a/extension/src/popup/components/account/AssetDetail/index.tsx
+++ b/extension/src/popup/components/account/AssetDetail/index.tsx
@@ -6,7 +6,10 @@ import { useNavigate } from "react-router-dom";
 import { Button, CopyText, Icon, Link, Loader } from "@stellar/design-system";
 
 import { NetworkDetails } from "@shared/constants/stellar";
-import { isNativeBalance } from "@shared/helpers/assetIdentity";
+import {
+  isNativeAssetId,
+  isNativeBalance,
+} from "@shared/helpers/assetIdentity";
 import IconEllipsis from "popup/assets/icon-ellipsis.svg";
 import {
   displaySorobanId,
@@ -123,7 +126,7 @@ export const AssetDetail = ({
   const { isHideDustEnabled } = useSelector(settingsSelector);
   const [optionsOpen, setOptionsOpen] = React.useState(false);
   const activeOptionsRef = useRef<HTMLDivElement>(null);
-  const isNative = selectedAsset === "native";
+  const isNative = isNativeAssetId(selectedAsset);
   const tokenPrices =
     cachedTokenPrices[networkDetails.networkPassphrase]?.[publicKey] || null;
 
@@ -152,12 +155,9 @@ export const AssetDetail = ({
   ) as Exclude<AssetType, LiquidityPoolShareAsset>;
 
   const icons = assetIcons || {};
-  const assetIconUrl =
-    "token" in selectedBalance &&
-    "type" in selectedBalance.token &&
-    selectedBalance.token.type === "native"
-      ? StellarLogo
-      : icons[selectedAsset];
+  const assetIconUrl = isNativeBalance(selectedBalance)
+    ? StellarLogo
+    : icons[selectedAsset];
   const assetPrice = tokenPrices ? tokenPrices[selectedAsset] : null;
   const assetIssuer = selectedBalance
     ? getIssuerFromBalance(selectedBalance)

--- a/extension/src/popup/components/accountHistory/AssetNetworkInfo/index.tsx
+++ b/extension/src/popup/components/accountHistory/AssetNetworkInfo/index.tsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 
 import { getIconUrlFromIssuer } from "@shared/api/helpers/getIconUrlFromIssuer";
-import { ClassicAsset, NativeAsset } from "@shared/api/types/account-balance";
+import { isNativeAssetId } from "@shared/helpers/assetIdentity";
 
 import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
 import { CopyValue } from "popup/components/CopyValue";
@@ -15,10 +15,8 @@ import "./styles.scss";
 interface AssetNetworkInfoProps {
   assetIssuer: string;
   assetCode: string;
-  assetType:
-    | NativeAsset["token"]["type"]
-    | ClassicAsset["token"]["type"]
-    | null;
+  /** Horizon `asset_type` value (e.g. "native", "credit_alphanum4"), or null. */
+  assetType: string | null;
   assetDomain: string;
   contractId?: string;
 }
@@ -57,7 +55,7 @@ export const AssetNetworkInfo = ({
   }, [assetCode, assetIssuer, networkDetails]);
 
   const decideNetworkIcon = () => {
-    if (networkIconUrl || assetType === "native") {
+    if (networkIconUrl || isNativeAssetId(assetType)) {
       return (
         <img src={networkIconUrl || StellarLogo} alt={t("Network icon")} />
       );

--- a/extension/src/popup/components/accountMigration/ReviewMigration/index.tsx
+++ b/extension/src/popup/components/accountMigration/ReviewMigration/index.tsx
@@ -5,6 +5,7 @@ import { Badge, Button, Checkbox, Loader } from "@stellar/design-system";
 import { Horizon } from "stellar-sdk";
 import { getAccountInfo, getMigratableAccounts } from "@shared/api/internal";
 import { BalanceToMigrate } from "@shared/api/types";
+import { isNativeAssetId } from "@shared/helpers/assetIdentity";
 import { useTranslation } from "react-i18next";
 import { BigNumber } from "bignumber.js";
 import { Field, FieldProps, Form, Formik, useFormikContext } from "formik";
@@ -78,14 +79,14 @@ const isReadyToMigrate = ({
 }) =>
   Boolean(
     xlmBalance &&
-      !dataEntries &&
-      !isSigner &&
-      calculateSenderMinBalance({
-        minBalance,
-        recommendedFee,
-        trustlineBalancesLength,
-        isMergeSelected,
-      }) < new BigNumber(xlmBalance).minus(minBalance),
+    !dataEntries &&
+    !isSigner &&
+    calculateSenderMinBalance({
+      minBalance,
+      recommendedFee,
+      trustlineBalancesLength,
+      isMergeSelected,
+    }) < new BigNumber(xlmBalance).minus(minBalance),
   );
 
 type AccountListItemRow = AccountToMigrate & { isReadyToMigrate: boolean };
@@ -287,7 +288,7 @@ export const ReviewMigration = () => {
             account.balances[account.balances.length - 1].balance;
           const dataEntries = Object.keys(account.data_attr).length;
           const trustlineBalances = account.balances.filter(
-            ({ asset_type: assetType }) => assetType !== "native",
+            ({ asset_type: assetType }) => !isNativeAssetId(assetType),
           );
 
           acctItem = {

--- a/extension/src/popup/components/amount/AmountCard/index.tsx
+++ b/extension/src/popup/components/amount/AmountCard/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import { AssetIcon } from "popup/components/account/AccountAssets";
 import { AssetIcons } from "@shared/api/types";
+import { isNativeAssetPair } from "@shared/helpers/assetIdentity";
 import { SecurityLevel } from "popup/constants/blockaid";
 import { InputType } from "helpers/transaction";
 import { formatAmountPreserveCursor } from "popup/helpers/formatters";
@@ -243,7 +244,9 @@ export const AmountCard = ({
             <>
               <AssetIcon
                 assetIcons={
-                  assetIssuerKey || assetCode !== "XLM" ? assetIcons : {}
+                  !isNativeAssetPair(assetCode, assetIssuerKey)
+                    ? assetIcons
+                    : {}
                 }
                 code={assetCode}
                 issuerKey={assetIssuerKey}

--- a/extension/src/popup/components/manageAssets/AddAsset/index.tsx
+++ b/extension/src/popup/components/manageAssets/AddAsset/index.tsx
@@ -12,7 +12,8 @@ import { isSacContractExecutable } from "@shared/helpers/soroban/token";
 import { FormRows } from "popup/basics/Forms";
 import { settingsSelector } from "popup/ducks/settings";
 import { tokensListsSelector } from "popup/ducks/cache";
-import { getNativeContractDetails } from "popup/helpers/searchAsset";
+import { buildNativeAssetRow } from "popup/helpers/searchAsset";
+import { isNativeContract } from "@shared/helpers/assetIdentity";
 import {
   getAssetListsForAsset,
   splitVerifiedAssetCurrency,
@@ -100,20 +101,12 @@ export const AddAsset = () => {
     setVerifiedAssetRows([]);
     setUnverifiedAssetRows([]);
 
-    const nativeContractDetails = getNativeContractDetails(networkDetails);
-
     // step around verification for native contract and unverifiable networks
 
-    if (nativeContractDetails.contract === contractId) {
+    if (isNativeContract(contractId, networkDetails.networkPassphrase)) {
       // override our rules for verification for XLM
       setIsVerificationInfoShowing(false);
-      setVerifiedAssetRows([
-        {
-          code: nativeContractDetails.code,
-          issuer: contractId,
-          domain: nativeContractDetails.domain,
-        },
-      ]);
+      setVerifiedAssetRows([buildNativeAssetRow(networkDetails)]);
       setIsSearching(false);
       return;
     }

--- a/extension/src/popup/components/manageAssets/SearchAsset/hooks/useAssetLookup.ts
+++ b/extension/src/popup/components/manageAssets/SearchAsset/hooks/useAssetLookup.ts
@@ -4,10 +4,11 @@ import { captureException } from "@sentry/browser";
 
 import { getTokenDetails } from "@shared/api/internal";
 import { isSacContractExecutable } from "@shared/helpers/soroban/token";
+import { isNativeContract } from "@shared/helpers/assetIdentity";
 import { INDEXER_URL } from "@shared/constants/mercury";
 import { BlockAidScanAssetResult } from "@shared/api/types";
 import {
-  getNativeContractDetails,
+  buildNativeAssetRow,
   searchAsset,
   getVerifiedTokens,
   VerifiedTokenRecord,
@@ -165,23 +166,14 @@ const useAssetLookup = () => {
   ) => {
     let assetRows = [] as ManageAssetCurrency[];
 
-    const nativeContractDetails = getNativeContractDetails(networkDetails);
     let verifiedTokens = [] as VerifiedTokenRecord[];
 
     // we already have native contract info, so just load it statically
-    if (nativeContractDetails.contract === contractId) {
+    if (isNativeContract(contractId, networkDetails.networkPassphrase)) {
       // override our rules for verification for XLM
       isVerificationInfoShowing = false;
 
-      assetRows = [
-        {
-          code: nativeContractDetails.code,
-          issuer: nativeContractDetails.issuer,
-          contract: contractId,
-          domain: nativeContractDetails.domain,
-          name: `${nativeContractDetails.code}:${nativeContractDetails.issuer}`,
-        },
-      ];
+      assetRows = [buildNativeAssetRow(networkDetails)];
 
       return assetRows;
     }

--- a/extension/src/popup/components/manageAssets/SearchAsset/hooks/useAssetLookup.ts
+++ b/extension/src/popup/components/manageAssets/SearchAsset/hooks/useAssetLookup.ts
@@ -9,8 +9,10 @@ import { INDEXER_URL } from "@shared/constants/mercury";
 import { BlockAidScanAssetResult } from "@shared/api/types";
 import {
   buildNativeAssetRow,
+  mapStellarExpertRecord,
   searchAsset,
   getVerifiedTokens,
+  StellarExpertAssetRecord,
   VerifiedTokenRecord,
 } from "popup/helpers/searchAsset";
 import { splitVerifiedAssetCurrency } from "popup/helpers/assetList";
@@ -31,20 +33,6 @@ import { getIconFromTokenLists } from "@shared/api/helpers/getIconFromTokenList"
 import { tokensListsSelector, saveTokenLists } from "popup/ducks/cache";
 import { AssetListResponse } from "@shared/constants/soroban/asset-list";
 import { AppDispatch, store } from "popup/App";
-
-interface AssetRecord {
-  asset: string;
-  domain?: string;
-  code?: string;
-  token_name?: string;
-  decimals?: number;
-  tomlInfo?: {
-    image?: string;
-    code?: string;
-    issuer?: string;
-    name?: string;
-  };
-}
 
 interface AssetLookupDetails {
   isVerifiedToken: boolean;
@@ -292,27 +280,9 @@ const useAssetLookup = () => {
       throw new Error("Failed to fetch Stellar Expert data");
     });
 
-    return resJson._embedded.records.map((record: AssetRecord) => {
-      if (isContractId(record.asset)) {
-        return {
-          code: record.code || record.tomlInfo?.code || "",
-          issuer: record.asset,
-          contract: record.asset,
-          domain: record.domain ?? null,
-          image: record.tomlInfo?.image,
-          name: record.token_name || record.tomlInfo?.name,
-          decimals: record.decimals,
-          isSuspicious: false,
-        };
-      }
-      return {
-        code: record.asset.split("-")[0],
-        issuer: record.asset.split("-")[1],
-        domain: record.domain ?? null,
-        image: record.tomlInfo?.image,
-        isSuspicious: false,
-      };
-    });
+    return resJson._embedded.records.map((record: StellarExpertAssetRecord) =>
+      mapStellarExpertRecord(record, networkDetails),
+    );
   };
 
   /*

--- a/extension/src/popup/components/manageAssets/SelectAssetRows/index.tsx
+++ b/extension/src/popup/components/manageAssets/SelectAssetRows/index.tsx
@@ -19,6 +19,7 @@ import {
   formatDomain,
   getAssetFromCanonical,
 } from "helpers/stellar";
+import { isNativeAssetPair } from "@shared/helpers/assetIdentity";
 import { AccountBalances } from "helpers/hooks/useGetBalances";
 import { getTokenBalance, isContractId } from "popup/helpers/soroban";
 import { isSorobanBalance, getBalanceByAsset } from "popup/helpers/balance";
@@ -126,7 +127,11 @@ export const SelectAssetRows = ({
                 }}
               >
                 <AssetIcon
-                  assetIcons={code !== "XLM" ? { [canonical]: image } : {}}
+                  assetIcons={
+                    !isNativeAssetPair(code, issuer)
+                      ? { [canonical]: image }
+                      : {}
+                  }
                   code={code}
                   issuerKey={issuer}
                   icon={icon}

--- a/extension/src/popup/components/manageAssets/ToggleAssetRows/index.tsx
+++ b/extension/src/popup/components/manageAssets/ToggleAssetRows/index.tsx
@@ -8,6 +8,7 @@ import {
   getCanonicalFromAsset,
   truncateString,
 } from "helpers/stellar";
+import { isNativeAssetPair } from "@shared/helpers/assetIdentity";
 import { AssetIcon } from "popup/components/account/AccountAssets";
 import { isAssetVisible } from "popup/helpers/settings";
 import { AssetVisibilityData } from "../AssetVisibility/hooks/useGetAssetData";
@@ -105,7 +106,9 @@ export const ToggleAssetRow = ({
   return (
     <>
       <AssetIcon
-        assetIcons={code !== "XLM" ? { [canonicalAsset]: image } : {}}
+        assetIcons={
+          !isNativeAssetPair(code, issuer) ? { [canonicalAsset]: image } : {}
+        }
         code={code}
         issuerKey={issuer}
         isSuspicious={isSuspicious}

--- a/extension/src/popup/components/send/SendAmount/hooks/__tests__/useSimulateTxData.test.ts
+++ b/extension/src/popup/components/send/SendAmount/hooks/__tests__/useSimulateTxData.test.ts
@@ -1,4 +1,13 @@
-import { getExpectedToFailReason } from "../useSimulateTxData";
+import {
+  Account,
+  Asset,
+  BASE_FEE,
+  Networks,
+  Operation,
+  TransactionBuilder,
+} from "stellar-sdk";
+
+import { getExpectedToFailReason, getOperation } from "../useSimulateTxData";
 
 const G_DEST = "GA4UFF2WJM7KHHG4R5D5D2MZQ6FWMDOSVITVF7C5OLD5NFP6RBBW2FGV";
 const t = (key: string) => key;
@@ -202,5 +211,96 @@ describe("getExpectedToFailReason", () => {
         }),
       ).toBeNull();
     });
+  });
+});
+
+const SOURCE_ACCOUNT =
+  "GBNZILSTVQZ4R7IKQDGHYGY2QXL5QOFJYQMXPKWRRM5PAV7Y4M67AQUA";
+const XLM_CODED_ISSUER =
+  "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+
+// Round-trips the built operation through a transaction so the assertions read
+// it the way it appears in the envelope that would actually be signed.
+const parseOperation = (operation: ReturnType<typeof getOperation>) =>
+  new TransactionBuilder(new Account(SOURCE_ACCOUNT, "0"), {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.PUBLIC,
+  })
+    .addOperation(operation)
+    .setTimeout(30)
+    .build().operations[0];
+
+const buildSendOperation = ({
+  sourceAsset,
+  isFunded,
+}: {
+  sourceAsset: Asset | { code: string; issuer: string };
+  isFunded: boolean;
+}) =>
+  getOperation(
+    sourceAsset,
+    Asset.native(),
+    "500",
+    "0",
+    G_DEST,
+    "1",
+    [],
+    false,
+    false,
+    isFunded,
+    SOURCE_ACCOUNT,
+  );
+
+describe("getOperation", () => {
+  // A classic asset that uses the native asset's display code but carries its
+  // own issuer. Every fixture below pairs it with a genuine native control, so
+  // the two cases cannot pass for the same reason.
+  const xlmCodedClassicAsset = new Asset("XLM", XLM_CODED_ISSUER);
+
+  it("builds a payment carrying the classic asset when it is sent to an unfunded destination", () => {
+    const operation = parseOperation(
+      buildSendOperation({
+        sourceAsset: xlmCodedClassicAsset,
+        isFunded: false,
+      }),
+    );
+
+    expect(operation.type).toBe("payment");
+    const payment = operation as Operation.Payment;
+    expect(payment.asset.isNative()).toBe(false);
+    expect(payment.asset.getCode()).toBe("XLM");
+    expect(payment.asset.getIssuer()).toBe(XLM_CODED_ISSUER);
+  });
+
+  it("still builds a create-account for the native asset to an unfunded destination", () => {
+    const operation = parseOperation(
+      buildSendOperation({ sourceAsset: Asset.native(), isFunded: false }),
+    );
+
+    expect(operation.type).toBe("createAccount");
+  });
+
+  it("builds a payment carrying the classic asset when the destination is funded", () => {
+    const operation = parseOperation(
+      buildSendOperation({ sourceAsset: xlmCodedClassicAsset, isFunded: true }),
+    );
+
+    expect(operation.type).toBe("payment");
+    expect((operation as Operation.Payment).asset.getIssuer()).toBe(
+      XLM_CODED_ISSUER,
+    );
+  });
+
+  it("builds different operations for the native asset and a classic asset sharing its code", () => {
+    const fromClassic = buildSendOperation({
+      sourceAsset: xlmCodedClassicAsset,
+      isFunded: false,
+    });
+    const fromNative = buildSendOperation({
+      sourceAsset: Asset.native(),
+      isFunded: false,
+    });
+
+    expect(parseOperation(fromClassic)).not.toEqual(parseOperation(fromNative));
   });
 });

--- a/extension/src/popup/components/send/SendAmount/hooks/useSimulateTxData.tsx
+++ b/extension/src/popup/components/send/SendAmount/hooks/useSimulateTxData.tsx
@@ -18,6 +18,10 @@ import { scrubStrKeys } from "helpers/stellarStrKey";
 import { METRIC_NAMES } from "popup/constants/metricsNames";
 import { NetworkDetails } from "@shared/constants/stellar";
 import {
+  getNativeContractId,
+  isNativeAssetId,
+} from "@shared/helpers/assetIdentity";
+import {
   getAssetFromCanonical,
   isMuxedAccount,
   stroopToXlm,
@@ -119,7 +123,7 @@ export const getExpectedToFailReason = ({
     return null;
   }
 
-  if (assetCanonical !== "native") {
+  if (!isNativeAssetId(assetCanonical)) {
     return t("Blockaid unfunded destination");
   }
 
@@ -387,7 +391,7 @@ function getAssetAddress(
   destination: string,
   networkDetails: NetworkDetails,
 ) {
-  if (asset === "native") {
+  if (isNativeAssetId(asset)) {
     return asset;
   }
   if (
@@ -511,10 +515,9 @@ function useSimulateTxData({
       if (!assetBalance) {
         throw new Error("asset balance not found");
       }
-      const tokenAddress =
-        currentAssetAddress === "native"
-          ? Asset.native().contractId(networkDetails.networkPassphrase)
-          : currentAssetAddress;
+      const tokenAddress = isNativeAssetId(currentAssetAddress)
+        ? getNativeContractId(networkDetails.networkPassphrase)
+        : currentAssetAddress;
       const parsedAmount = parseTokenAmount(
         cleanAmount(currentAmount),
         Number("decimals" in assetBalance ? assetBalance.decimals : 7),

--- a/extension/src/popup/components/send/SendAmount/hooks/useSimulateTxData.tsx
+++ b/extension/src/popup/components/send/SendAmount/hooks/useSimulateTxData.tsx
@@ -36,6 +36,7 @@ import {
 import { simulateTokenTransfer } from "@shared/api/internal";
 import type { BlockAidScanTxResult } from "@shared/api/types";
 import { getAssetSacAddress } from "@shared/helpers/soroban/token";
+import { isNativeAsset } from "@shared/helpers/assetIdentity";
 import {
   saveSimulation,
   saveTransactionFee,
@@ -175,7 +176,7 @@ const applyExpectedToFailReason = ({
   } as BlockAidScanTxResult;
 };
 
-const getOperation = (
+export const getOperation = (
   sourceAsset: Asset | { code: string; issuer: string },
   destAsset: Asset | { code: string; issuer: string },
   amount: string,
@@ -204,8 +205,8 @@ const getOperation = (
     });
   }
 
-  // create account if unfunded and sending xlm
-  if (!isFunded && sourceAsset.code === Asset.native().code) {
+  // create account if unfunded and sending the native asset
+  if (!isFunded && isNativeAsset(sourceAsset)) {
     let createAccountDestination = destination;
     if (isMuxedAccount(destination)) {
       // encode muxed account to address

--- a/extension/src/popup/components/send/SendAmount/hooks/useSimulateTxData.tsx
+++ b/extension/src/popup/components/send/SendAmount/hooks/useSimulateTxData.tsx
@@ -1,4 +1,5 @@
 import { useReducer } from "react";
+import { splitCanonical } from "@shared/helpers/stellar";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector, useStore } from "react-redux";
 import BigNumber from "bignumber.js";
@@ -403,8 +404,7 @@ function getAssetAddress(
       networkDetails.networkPassphrase as Networks,
     );
   }
-  const [_, issuer] = asset.split(":");
-  return issuer;
+  return splitCanonical(asset).issuer;
 }
 
 function useSimulateTxData({

--- a/extension/src/popup/components/send/SendAmount/index.tsx
+++ b/extension/src/popup/components/send/SendAmount/index.tsx
@@ -10,6 +10,7 @@ import { LoadingBackground } from "popup/basics/LoadingBackground";
 import { View } from "popup/basics/layout/View";
 import { METRIC_NAMES } from "popup/constants/metricsNames";
 import { AppDispatch } from "popup/App";
+import { isNativeAssetId } from "@shared/helpers/assetIdentity";
 import {
   getAssetFromCanonical,
   isMainnet,
@@ -768,7 +769,7 @@ export const SendAmount = ({
                     assetCode={parsedSourceAsset.code}
                     assetIcon={assetIcon}
                     assetIcons={
-                      asset !== "native" ? { [asset]: assetIcon } : {}
+                      !isNativeAssetId(asset) ? { [asset]: assetIcon } : {}
                     }
                     assetIssuerKey={srcAsset.issuer}
                     supportsUsd={Boolean(supportsUsd)}

--- a/extension/src/popup/components/swap/SwapAmount/helpers/getSwapDerivedData.ts
+++ b/extension/src/popup/components/swap/SwapAmount/helpers/getSwapDerivedData.ts
@@ -8,6 +8,7 @@ import {
   roundUsdValue,
 } from "popup/helpers/formatters";
 import { getAssetFromCanonical, isMainnet } from "helpers/stellar";
+import { isNativeAssetId } from "@shared/helpers/assetIdentity";
 import { getAssetDecimals, getAvailableBalance } from "popup/helpers/soroban";
 import {
   findAssetBalance,
@@ -129,7 +130,7 @@ export const getSwapDerivedData = ({
   // insufficient-balance check.
   const availableBalance = deductNewTrustlineReserve({
     spendable: baseAvailableBalance,
-    sourceIsXlm: asset === "native",
+    sourceIsXlm: isNativeAssetId(asset),
     // The unfiltered-balances flag, NOT destinationIsNonHeld: a hidden held
     // destination builds no changeTrust, so no reserve should be withheld.
     requiresTrustline: destRequiresTrustline,
@@ -139,7 +140,7 @@ export const getSwapDerivedData = ({
   // "Swap for 0.5 XLM" reserve-recovery affordance on the XlmReserveSheet.
   // The sell side is the current source when it's already a non-XLM
   // classic token; otherwise the largest held non-XLM classic balance.
-  const sourceIsNonXlmClassic = !!asset && asset !== "native";
+  const sourceIsNonXlmClassic = !!asset && !isNativeAssetId(asset);
 
   // Source token Blockaid verdict (from its held balance), passed to the review
   // gate so a flagged sell token also warns. XLM is never scanned.

--- a/extension/src/popup/components/swap/SwapAmount/index.tsx
+++ b/extension/src/popup/components/swap/SwapAmount/index.tsx
@@ -30,6 +30,7 @@ import {
 } from "popup/helpers/formatters";
 import { useGetSwapAmountData } from "./hooks/useGetSwapAmountData";
 import { getAssetFromCanonical } from "helpers/stellar";
+import { isNativeAssetId } from "@shared/helpers/assetIdentity";
 import { RequestState } from "constants/request";
 import { Loading } from "popup/components/Loading";
 import { AppDataType } from "helpers/hooks/useGetAppData";
@@ -214,7 +215,7 @@ export const SwapAmount = ({
     });
     const needsReserve = shouldShowXlmReservePreflight({
       requiresTrustline: destRequiresTrustline,
-      sourceIsXlm: asset === "native",
+      sourceIsXlm: isNativeAssetId(asset),
       spendableXlm: getAvailableBalance({
         assetCanonical: "native",
         balances: sendData.userBalances.balances,
@@ -607,7 +608,9 @@ export const SwapAmount = ({
                     assetCode={srcAsset ? srcAsset.code : ""}
                     assetIcon={assetIcon}
                     assetIcons={
-                      asset && asset !== "native" ? { [asset]: assetIcon } : {}
+                      asset && !isNativeAssetId(asset)
+                        ? { [asset]: assetIcon }
+                        : {}
                     }
                     assetIssuerKey={srcAsset?.issuer}
                     // Carry the sell token's Blockaid verdict onto its pill so a
@@ -723,7 +726,7 @@ export const SwapAmount = ({
                     assetCode={dstAsset ? dstAsset.code : ""}
                     assetIcon={dstAssetIcon}
                     assetIcons={
-                      destinationAsset && destinationAsset !== "native"
+                      destinationAsset && !isNativeAssetId(destinationAsset)
                         ? { [destinationAsset]: dstAssetIcon }
                         : {}
                     }

--- a/extension/src/popup/components/swap/SwapAsset/hooks/useSwapTokenLookup.ts
+++ b/extension/src/popup/components/swap/SwapAsset/hooks/useSwapTokenLookup.ts
@@ -12,6 +12,10 @@ import { AssetType } from "@shared/api/types/account-balance";
 import { initialState, reducer } from "helpers/request";
 import { RequestState } from "constants/request";
 import { isMainnet, isTestnet, getCanonicalFromAsset } from "helpers/stellar";
+import {
+  isNativeAssetId,
+  isNativeAssetPair,
+} from "@shared/helpers/assetIdentity";
 import { ManageAssetCurrency } from "popup/components/manageAssets/ManageAssetRows";
 import { BlockaidWarning, SecurityLevel } from "popup/constants/blockaid";
 import { searchAsset } from "popup/helpers/searchAsset";
@@ -112,7 +116,8 @@ const heldToRecord = (
     issuer?: { key: string };
   };
   const isNative =
-    token.type === "native" || (token.code === "XLM" && !token.issuer);
+    isNativeAssetId(token.type) ||
+    isNativeAssetPair(token.code, token.issuer?.key);
   const code = isNative ? "XLM" : token.code;
   const issuer = isNative ? "" : token.issuer?.key || "";
   const canonical = isNative ? "native" : getCanonicalFromAsset(code, issuer);
@@ -175,7 +180,7 @@ const currencyToRecord = (
   asset: ManageAssetCurrency,
   isHeld: boolean,
 ): SwapTokenRecord => {
-  const isNative = asset.code === "XLM" && !asset.issuer;
+  const isNative = isNativeAssetPair(asset.code, asset.issuer);
   const canonical = isNative
     ? "native"
     : getCanonicalFromAsset(asset.code || "", asset.issuer || "");

--- a/extension/src/popup/components/swap/SwapAsset/hooks/useSwapTokenLookup.ts
+++ b/extension/src/popup/components/swap/SwapAsset/hooks/useSwapTokenLookup.ts
@@ -13,8 +13,8 @@ import { initialState, reducer } from "helpers/request";
 import { RequestState } from "constants/request";
 import { isMainnet, isTestnet, getCanonicalFromAsset } from "helpers/stellar";
 import {
-  isNativeAssetId,
   isNativeAssetPair,
+  isNativeBalance,
 } from "@shared/helpers/assetIdentity";
 import { ManageAssetCurrency } from "popup/components/manageAssets/ManageAssetRows";
 import { BlockaidWarning, SecurityLevel } from "popup/constants/blockaid";
@@ -115,9 +115,7 @@ const heldToRecord = (
     type?: string;
     issuer?: { key: string };
   };
-  const isNative =
-    isNativeAssetId(token.type) ||
-    isNativeAssetPair(token.code, token.issuer?.key);
+  const isNative = isNativeBalance(balance);
   const code = isNative ? "XLM" : token.code;
   const issuer = isNative ? "" : token.issuer?.key || "";
   const canonical = isNative ? "native" : getCanonicalFromAsset(code, issuer);

--- a/extension/src/popup/helpers/__tests__/account.test.ts
+++ b/extension/src/popup/helpers/__tests__/account.test.ts
@@ -1,0 +1,42 @@
+import { HorizonOperation } from "@shared/api/types";
+import { operationMatchesAssetKey } from "popup/helpers/account";
+
+const XLM_CODED_ISSUER =
+  "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+const XLM_CODED_KEY = `XLM:${XLM_CODED_ISSUER}`;
+
+const nativePayment = {
+  type: "payment",
+  asset_type: "native",
+  amount: "10",
+} as unknown as HorizonOperation;
+
+const xlmCodedClassicPayment = {
+  type: "payment",
+  asset_type: "credit_alphanum4",
+  asset_code: "XLM",
+  asset_issuer: XLM_CODED_ISSUER,
+  amount: "10",
+} as unknown as HorizonOperation;
+
+describe("operationMatchesAssetKey", () => {
+  it("files a native payment under the native key", () => {
+    expect(operationMatchesAssetKey("native", nativePayment)).toBe(true);
+  });
+
+  it("does not file a native payment under a classic asset using the native code", () => {
+    expect(operationMatchesAssetKey(XLM_CODED_KEY, nativePayment)).toBe(false);
+  });
+
+  it("files a classic payment under its own key", () => {
+    expect(
+      operationMatchesAssetKey(XLM_CODED_KEY, xlmCodedClassicPayment),
+    ).toBe(true);
+  });
+
+  it("does not file a classic payment under the native key", () => {
+    expect(operationMatchesAssetKey("native", xlmCodedClassicPayment)).toBe(
+      false,
+    );
+  });
+});

--- a/extension/src/popup/helpers/__tests__/account.test.ts
+++ b/extension/src/popup/helpers/__tests__/account.test.ts
@@ -19,6 +19,39 @@ const xlmCodedClassicPayment = {
   amount: "10",
 } as unknown as HorizonOperation;
 
+// Issuer for the path payments' destination leg — distinct from XLM_CODED_ISSUER
+// so the source and destination assets never collide, which is what lets these
+// fixtures discriminate the source_asset_* arm from the primary arm.
+const DEST_ASSET_ISSUER =
+  "GB7UT5EMHRRA4TLQ7SHTXS2QL7LZPEUQP625HKVB3DEL7O5M47FCLFY6";
+
+// A path payment whose SOURCE leg is genuine native XLM; the destination leg
+// is an unrelated classic asset.
+const nativeSourcePathPayment = {
+  type: "path_payment_strict_send",
+  asset_type: "credit_alphanum4",
+  asset_code: "USD",
+  asset_issuer: DEST_ASSET_ISSUER,
+  source_asset_type: "native",
+  amount: "10",
+  source_amount: "10",
+} as unknown as HorizonOperation;
+
+// A path payment whose SOURCE leg is the classic asset coded "XLM" (same
+// code/issuer as xlmCodedClassicPayment); the destination leg is an unrelated
+// classic asset.
+const xlmCodedSourcePathPayment = {
+  type: "path_payment_strict_send",
+  asset_type: "credit_alphanum4",
+  asset_code: "USD",
+  asset_issuer: DEST_ASSET_ISSUER,
+  source_asset_type: "credit_alphanum4",
+  source_asset_code: "XLM",
+  source_asset_issuer: XLM_CODED_ISSUER,
+  amount: "10",
+  source_amount: "10",
+} as unknown as HorizonOperation;
+
 describe("operationMatchesAssetKey", () => {
   it("files a native payment under the native key", () => {
     expect(operationMatchesAssetKey("native", nativePayment)).toBe(true);
@@ -36,6 +69,30 @@ describe("operationMatchesAssetKey", () => {
 
   it("does not file a classic payment under the native key", () => {
     expect(operationMatchesAssetKey("native", xlmCodedClassicPayment)).toBe(
+      false,
+    );
+  });
+
+  it("files a path payment with a native source under the native key", () => {
+    expect(operationMatchesAssetKey("native", nativeSourcePathPayment)).toBe(
+      true,
+    );
+  });
+
+  it("does not file a path payment with a native source under a classic asset using the native code", () => {
+    expect(
+      operationMatchesAssetKey(XLM_CODED_KEY, nativeSourcePathPayment),
+    ).toBe(false);
+  });
+
+  it("files a path payment under its own key when it is the source asset", () => {
+    expect(
+      operationMatchesAssetKey(XLM_CODED_KEY, xlmCodedSourcePathPayment),
+    ).toBe(true);
+  });
+
+  it("does not file a path payment under the native key when only its source asset uses the native code", () => {
+    expect(operationMatchesAssetKey("native", xlmCodedSourcePathPayment)).toBe(
       false,
     );
   });

--- a/extension/src/popup/helpers/__tests__/assetList.test.ts
+++ b/extension/src/popup/helpers/__tests__/assetList.test.ts
@@ -1,0 +1,28 @@
+import { assetMatchesListItem } from "popup/helpers/assetList";
+
+const ISSUER = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+const CONTRACT = "CCV3NAKLIBBNSJNNTV2AZVRX6VODUDWK4TVYILE5MW6R45SSQJS5VCAM";
+
+describe("assetMatchesListItem", () => {
+  it("matches on a shared issuer", () => {
+    expect(assetMatchesListItem({ issuer: ISSUER }, { issuer: ISSUER })).toBe(
+      true,
+    );
+  });
+
+  it("matches on a shared contract", () => {
+    expect(
+      assetMatchesListItem({ contract: CONTRACT }, { contract: CONTRACT }),
+    ).toBe(true);
+  });
+
+  it("does not match when both sides are simply absent", () => {
+    expect(assetMatchesListItem({}, {})).toBe(false);
+  });
+
+  it("does not match a contract-less asset against a contract-less entry", () => {
+    expect(
+      assetMatchesListItem({ issuer: ISSUER }, { issuer: "GDIFFERENT" }),
+    ).toBe(false);
+  });
+});

--- a/extension/src/popup/helpers/__tests__/assetList.test.ts
+++ b/extension/src/popup/helpers/__tests__/assetList.test.ts
@@ -1,4 +1,12 @@
-import { assetMatchesListItem } from "popup/helpers/assetList";
+import { Networks } from "stellar-sdk";
+
+import * as TokenListHelpers from "@shared/api/helpers/token-list";
+import { NetworkDetails } from "@shared/constants/stellar";
+import {
+  assetMatchesListItem,
+  splitVerifiedAssetCurrency,
+} from "popup/helpers/assetList";
+import { mapStellarExpertRecord } from "popup/helpers/searchAsset";
 
 const ISSUER = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
 const CONTRACT = "CCV3NAKLIBBNSJNNTV2AZVRX6VODUDWK4TVYILE5MW6R45SSQJS5VCAM";
@@ -24,5 +32,65 @@ describe("assetMatchesListItem", () => {
     expect(
       assetMatchesListItem({ issuer: ISSUER }, { issuer: "GDIFFERENT" }),
     ).toBe(false);
+  });
+});
+
+describe("splitVerifiedAssetCurrency", () => {
+  const MAINNET = {
+    network: "PUBLIC",
+    networkPassphrase: Networks.PUBLIC,
+  } as NetworkDetails;
+
+  // One list with no entries: the only identity seeded into the verified set
+  // is the network's native contract, so the split is decided by identity
+  // alone rather than by list contents.
+  const emptyList = {
+    name: "Test List",
+    description: "",
+    network: "public",
+    version: "1.0",
+    provider: "test",
+    assets: [],
+  };
+
+  beforeEach(() => {
+    jest
+      .spyOn(TokenListHelpers, "schemaValidatedAssetList")
+      .mockResolvedValue({ assets: [], errors: null });
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it("files the native asset's search row as verified", async () => {
+    const nativeRow = mapStellarExpertRecord({ asset: "XLM" }, MAINNET);
+
+    const { verifiedAssets, unverifiedAssets } =
+      await splitVerifiedAssetCurrency({
+        networkDetails: MAINNET,
+        assets: [nativeRow],
+        assetsListsDetails: {} as never,
+        cachedAssetLists: [emptyList],
+      });
+
+    expect(verifiedAssets).toEqual([nativeRow]);
+    expect(unverifiedAssets).toEqual([]);
+  });
+
+  it("does not verify a classic asset that uses the native code", async () => {
+    const xlmCodedRow = mapStellarExpertRecord(
+      { asset: `XLM-${ISSUER}-1` },
+      MAINNET,
+    );
+
+    const { verifiedAssets, unverifiedAssets } =
+      await splitVerifiedAssetCurrency({
+        networkDetails: MAINNET,
+        assets: [xlmCodedRow],
+        assetsListsDetails: {} as never,
+        cachedAssetLists: [emptyList],
+      });
+
+    expect(verifiedAssets).toEqual([]);
+    expect(unverifiedAssets).toEqual([xlmCodedRow]);
   });
 });

--- a/extension/src/popup/helpers/__tests__/assetList.test.ts
+++ b/extension/src/popup/helpers/__tests__/assetList.test.ts
@@ -12,10 +12,17 @@ const ISSUER = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
 const CONTRACT = "CCV3NAKLIBBNSJNNTV2AZVRX6VODUDWK4TVYILE5MW6R45SSQJS5VCAM";
 
 describe("assetMatchesListItem", () => {
-  it("matches on a shared issuer", () => {
-    expect(assetMatchesListItem({ issuer: ISSUER }, { issuer: ISSUER })).toBe(
-      true,
-    );
+  // Issuer-alone matching is the long-standing behaviour of the verified-list
+  // membership tests, tracked in stellar/wallet-eng-monorepo#76. Pinned here as
+  // current behaviour, not as the intended contract — a fix for that issue is
+  // expected to require the code to match too, and to change this expectation.
+  it("matches on a shared issuer, without comparing the code", () => {
+    expect(
+      assetMatchesListItem(
+        { issuer: ISSUER },
+        { issuer: ISSUER, contract: undefined },
+      ),
+    ).toBe(true);
   });
 
   it("matches on a shared contract", () => {

--- a/extension/src/popup/helpers/__tests__/balance.test.ts
+++ b/extension/src/popup/helpers/__tests__/balance.test.ts
@@ -1,0 +1,61 @@
+import BigNumber from "bignumber.js";
+import { Asset, Networks } from "stellar-sdk";
+
+import { AssetType } from "@shared/api/types/account-balance";
+import { NetworkDetails } from "@shared/constants/stellar";
+import { getBalanceByKey } from "popup/helpers/balance";
+
+const XLM_CODED_ISSUER =
+  "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+
+const networkDetails = {
+  network: "PUBLIC",
+  networkPassphrase: Networks.PUBLIC,
+} as NetworkDetails;
+
+const amounts = {
+  total: new BigNumber("100"),
+  available: new BigNumber("100"),
+  buyingLiabilities: "0",
+  sellingLiabilities: "0",
+  blockaidData: {},
+};
+
+const nativeBalance = {
+  ...amounts,
+  token: { type: "native", code: "XLM" },
+  minimumBalance: "1",
+} as unknown as AssetType;
+
+// A classic asset using the native code. It sorts first in the list below, so
+// a lookup that enters the native branch on the code alone reaches it first.
+const xlmCodedClassicBalance = {
+  ...amounts,
+  token: {
+    type: "credit_alphanum4",
+    code: "XLM",
+    issuer: { key: XLM_CODED_ISSUER },
+  },
+} as unknown as AssetType;
+
+const balances = [xlmCodedClassicBalance, nativeBalance];
+
+describe("getBalanceByKey", () => {
+  it("resolves the native SAC to the native balance", () => {
+    const nativeSac = Asset.native().contractId(Networks.PUBLIC);
+
+    expect(getBalanceByKey(nativeSac, balances, networkDetails)).toBe(
+      nativeBalance,
+    );
+  });
+
+  it("resolves a classic asset's own SAC to that asset's balance", () => {
+    const wrappedSac = new Asset("XLM", XLM_CODED_ISSUER).contractId(
+      Networks.PUBLIC,
+    );
+
+    expect(getBalanceByKey(wrappedSac, balances, networkDetails)).toBe(
+      xlmCodedClassicBalance,
+    );
+  });
+});

--- a/extension/src/popup/helpers/__tests__/balance.test.ts
+++ b/extension/src/popup/helpers/__tests__/balance.test.ts
@@ -3,7 +3,7 @@ import { Asset, Networks } from "stellar-sdk";
 
 import { AssetType } from "@shared/api/types/account-balance";
 import { NetworkDetails } from "@shared/constants/stellar";
-import { getBalanceByKey } from "popup/helpers/balance";
+import { getBalanceByKey, hasEnoughXlmForFee } from "popup/helpers/balance";
 
 const XLM_CODED_ISSUER =
   "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
@@ -57,5 +57,21 @@ describe("getBalanceByKey", () => {
     expect(getBalanceByKey(wrappedSac, balances, networkDetails)).toBe(
       xlmCodedClassicBalance,
     );
+  });
+});
+
+describe("hasEnoughXlmForFee", () => {
+  const fee = new BigNumber("0.00001");
+
+  it("is true when the native balance covers the fee", () => {
+    expect(hasEnoughXlmForFee([nativeBalance], fee)).toBe(true);
+  });
+
+  it("is false when only a classic asset sharing the native code covers it", () => {
+    expect(hasEnoughXlmForFee([xlmCodedClassicBalance], fee)).toBe(false);
+  });
+
+  it("is false when there are no balances", () => {
+    expect(hasEnoughXlmForFee([], fee)).toBe(false);
   });
 });

--- a/extension/src/popup/helpers/__tests__/searchAsset.test.js
+++ b/extension/src/popup/helpers/__tests__/searchAsset.test.js
@@ -1,3 +1,5 @@
+import { Networks } from "stellar-sdk";
+
 import { validAssetList } from "popup/__testHelpers__";
 import * as SearchAsset from "../searchAsset";
 import {
@@ -49,7 +51,10 @@ describe("searchAsset", () => {
 
   it("should getNativeContractDetails for Mainnet", () => {
     expect(
-      SearchAsset.getNativeContractDetails({ network: "PUBLIC" }),
+      SearchAsset.getNativeContractDetails({
+        network: "PUBLIC",
+        networkPassphrase: Networks.PUBLIC,
+      }),
     ).toStrictEqual({
       contract: "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA",
       issuer: "GDMTVHLWJTHSUDMZVVMXXH6VJHA2ZV3HNG5LYNAZ6RTWB7GISM6PGTUV",
@@ -62,7 +67,10 @@ describe("searchAsset", () => {
   });
   it("should getNativeContractDetails for Testnet", () => {
     expect(
-      SearchAsset.getNativeContractDetails({ network: "TESTNET" }),
+      SearchAsset.getNativeContractDetails({
+        network: "TESTNET",
+        networkPassphrase: Networks.TESTNET,
+      }),
     ).toStrictEqual({
       contract: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
       issuer: "",
@@ -73,16 +81,22 @@ describe("searchAsset", () => {
       org: "",
     });
   });
-  it("should not getNativeContractDetails for non-Mainnet and non-Testnet", () => {
+  it("should derive getNativeContractDetails for a network the table doesn't cover", () => {
+    // The contract address is now derived from the passphrase rather than
+    // read from a table, so a network outside PUBLIC/TESTNET gets a real
+    // address instead of the empty string the table used to fall back to.
     expect(
-      SearchAsset.getNativeContractDetails({ network: "foo" }),
+      SearchAsset.getNativeContractDetails({
+        network: "FUTURENET",
+        networkPassphrase: Networks.FUTURENET,
+      }),
     ).toStrictEqual({
       code: "XLM",
       decimals: 7,
       domain: "https://stellar.org",
       icon: "",
       org: "",
-      contract: "",
+      contract: "CB64D3G7SM2RTH6JSGG34DDTFTQ5CFDKVDZJZSODMCX4NJ2HV2KN7OHT",
       issuer: "",
     });
   });

--- a/extension/src/popup/helpers/__tests__/searchAsset.test.js
+++ b/extension/src/popup/helpers/__tests__/searchAsset.test.js
@@ -81,10 +81,9 @@ describe("searchAsset", () => {
       org: "",
     });
   });
-  it("should derive getNativeContractDetails for a network the table doesn't cover", () => {
-    // The contract address is now derived from the passphrase rather than
-    // read from a table, so a network outside PUBLIC/TESTNET gets a real
-    // address instead of the empty string the table used to fall back to.
+  it("derives the native contract address on FUTURENET", () => {
+    // The contract address is derived from the network passphrase, so every
+    // network gets a real address.
     expect(
       SearchAsset.getNativeContractDetails({
         network: "FUTURENET",

--- a/extension/src/popup/helpers/__tests__/searchAsset.test.ts
+++ b/extension/src/popup/helpers/__tests__/searchAsset.test.ts
@@ -1,7 +1,12 @@
 import { Networks } from "stellar-sdk";
 
-import { searchAsset, getNativeContractDetails } from "../searchAsset";
+import {
+  searchAsset,
+  getNativeContractDetails,
+  buildNativeAssetRow,
+} from "../searchAsset";
 import { NetworkDetails } from "@shared/constants/stellar";
+import { getCanonicalFromAsset } from "@shared/helpers/stellar";
 
 const MAINNET: NetworkDetails = {
   network: "PUBLIC",
@@ -58,5 +63,28 @@ describe("getNativeContractDetails", () => {
         networkPassphrase: Networks.FUTURENET,
       } as never).contract,
     ).toMatch(/^C[A-Z2-7]{55}$/);
+  });
+});
+
+describe("buildNativeAssetRow", () => {
+  const mainnet = {
+    network: "PUBLIC",
+    networkPassphrase: Networks.PUBLIC,
+  } as never;
+
+  it("carries no issuer, because the native asset has none", () => {
+    expect(buildNativeAssetRow(mainnet).issuer).toBe("");
+  });
+
+  it("produces the native canonical identifier", () => {
+    const row = buildNativeAssetRow(mainnet);
+
+    expect(getCanonicalFromAsset(row.code, row.issuer)).toBe("native");
+  });
+
+  it("carries the native contract address", () => {
+    expect(buildNativeAssetRow(mainnet).contract).toBe(
+      "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA",
+    );
   });
 });

--- a/extension/src/popup/helpers/__tests__/searchAsset.test.ts
+++ b/extension/src/popup/helpers/__tests__/searchAsset.test.ts
@@ -4,6 +4,7 @@ import {
   searchAsset,
   getNativeContractDetails,
   buildNativeAssetRow,
+  mapStellarExpertRecord,
 } from "../searchAsset";
 import { NetworkDetails } from "@shared/constants/stellar";
 import { getCanonicalFromAsset } from "@shared/helpers/stellar";
@@ -86,5 +87,71 @@ describe("buildNativeAssetRow", () => {
     expect(buildNativeAssetRow(mainnet).contract).toBe(
       "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA",
     );
+  });
+});
+
+describe("mapStellarExpertRecord", () => {
+  // stellar.expert returns issued assets as `CODE-ISSUER-TYPE` and the native
+  // asset as its bare code, with no issuer and no domain.
+  const XLM_CODED_ISSUER =
+    "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+  const USDC_ISSUER =
+    "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+  const CONTRACT = "CCV3NAKLIBBNSJNNTV2AZVRX6VODUDWK4TVYILE5MW6R45SSQJS5VCAM";
+
+  it("builds the native asset's row with its contract id and no issuer", () => {
+    const row = mapStellarExpertRecord({ asset: "XLM" }, MAINNET);
+
+    expect(row.issuer).toBe("");
+    expect(row.contract).toBe(
+      "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA",
+    );
+    expect(getCanonicalFromAsset(row.code, row.issuer)).toBe("native");
+  });
+
+  it("keeps a classic asset that uses the native code as its own asset", () => {
+    const row = mapStellarExpertRecord(
+      { asset: `XLM-${XLM_CODED_ISSUER}-1`, domain: "example.test" },
+      MAINNET,
+    );
+
+    expect(row.code).toBe("XLM");
+    expect(row.issuer).toBe(XLM_CODED_ISSUER);
+    expect(row.contract).toBeUndefined();
+    expect(getCanonicalFromAsset(row.code, row.issuer)).toBe(
+      `XLM:${XLM_CODED_ISSUER}`,
+    );
+  });
+
+  it("maps an issued asset's code, issuer and domain", () => {
+    const row = mapStellarExpertRecord(
+      {
+        asset: `USDC-${USDC_ISSUER}-1`,
+        domain: "centre.io",
+        tomlInfo: { image: "https://example.test/usdc.png" },
+      },
+      MAINNET,
+    );
+
+    expect(row).toMatchObject({
+      code: "USDC",
+      issuer: USDC_ISSUER,
+      domain: "centre.io",
+      image: "https://example.test/usdc.png",
+    });
+  });
+
+  it("maps a contract token to a row keyed on its contract id", () => {
+    const row = mapStellarExpertRecord(
+      { asset: CONTRACT, code: "TKN", token_name: "Token" },
+      MAINNET,
+    );
+
+    expect(row).toMatchObject({
+      code: "TKN",
+      issuer: CONTRACT,
+      contract: CONTRACT,
+      name: "Token",
+    });
   });
 });

--- a/extension/src/popup/helpers/__tests__/searchAsset.test.ts
+++ b/extension/src/popup/helpers/__tests__/searchAsset.test.ts
@@ -1,4 +1,6 @@
-import { searchAsset } from "../searchAsset";
+import { Networks } from "stellar-sdk";
+
+import { searchAsset, getNativeContractDetails } from "../searchAsset";
 import { NetworkDetails } from "@shared/constants/stellar";
 
 const MAINNET: NetworkDetails = {
@@ -36,5 +38,25 @@ describe("searchAsset", () => {
     await expect(
       searchAsset({ asset: "usdc", networkDetails: MAINNET }),
     ).rejects.toThrow("Bad Gateway");
+  });
+});
+
+describe("getNativeContractDetails", () => {
+  it("keeps the published mainnet contract address", () => {
+    expect(
+      getNativeContractDetails({
+        network: "PUBLIC",
+        networkPassphrase: Networks.PUBLIC,
+      } as never).contract,
+    ).toBe("CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA");
+  });
+
+  it("returns a contract address on a network the table omitted", () => {
+    expect(
+      getNativeContractDetails({
+        network: "FUTURENET",
+        networkPassphrase: Networks.FUTURENET,
+      } as never).contract,
+    ).toMatch(/^C[A-Z2-7]{55}$/);
   });
 });

--- a/extension/src/popup/helpers/__tests__/searchAsset.test.ts
+++ b/extension/src/popup/helpers/__tests__/searchAsset.test.ts
@@ -57,7 +57,7 @@ describe("getNativeContractDetails", () => {
     ).toBe("CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA");
   });
 
-  it("returns a contract address on a network the table omitted", () => {
+  it("returns a derived contract address on FUTURENET", () => {
     expect(
       getNativeContractDetails({
         network: "FUTURENET",

--- a/extension/src/popup/helpers/__tests__/soroban.test.ts
+++ b/extension/src/popup/helpers/__tests__/soroban.test.ts
@@ -1,0 +1,37 @@
+import { Asset, Networks } from "stellar-sdk";
+
+import { NetworkDetails } from "@shared/constants/stellar";
+import { isAssetSac } from "popup/helpers/soroban";
+
+const futurenetDetails = {
+  network: "FUTURENET",
+  networkPassphrase: Networks.FUTURENET,
+} as NetworkDetails;
+
+describe("isAssetSac", () => {
+  it("recognises the native contract on a network the old table omitted", () => {
+    expect(
+      isAssetSac({
+        asset: {
+          code: "XLM",
+          issuer: undefined,
+          contract: Asset.native().contractId(Networks.FUTURENET),
+        },
+        networkDetails: futurenetDetails,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not recognise an unrelated contract as the native one", () => {
+    expect(
+      isAssetSac({
+        asset: {
+          code: "XLM",
+          issuer: undefined,
+          contract: Asset.native().contractId(Networks.PUBLIC),
+        },
+        networkDetails: futurenetDetails,
+      }),
+    ).toBe(false);
+  });
+});

--- a/extension/src/popup/helpers/__tests__/soroban.test.ts
+++ b/extension/src/popup/helpers/__tests__/soroban.test.ts
@@ -9,7 +9,7 @@ const futurenetDetails = {
 } as NetworkDetails;
 
 describe("isAssetSac", () => {
-  it("recognises the native contract on a network the old table omitted", () => {
+  it("recognises the native contract on FUTURENET", () => {
     expect(
       isAssetSac({
         asset: {

--- a/extension/src/popup/helpers/account.ts
+++ b/extension/src/popup/helpers/account.ts
@@ -12,7 +12,10 @@ import { Balances, BalanceMap } from "@shared/api/types/backend-api";
 import { AssetType } from "@shared/api/types/account-balance";
 import { NetworkDetails } from "@shared/constants/stellar";
 import { SorobanTokenInterface } from "@shared/constants/soroban/token";
-import { isNativeAssetId } from "@shared/helpers/assetIdentity";
+import {
+  isNativeAssetId,
+  isNativeBalance,
+} from "@shared/helpers/assetIdentity";
 export { isSorobanIssuer } from "@shared/helpers/stellar";
 
 import {
@@ -48,7 +51,7 @@ export const sortBalances = (
 
   // put XLM at the top of the balance list, LP shares last
   Object.entries(balances).forEach(([k, v]) => {
-    if (k === "native") {
+    if (isNativeAssetId(k)) {
       collection.unshift(v);
     } else if (k.includes(LP_IDENTIFIER)) {
       lpBalances.push(v);
@@ -88,7 +91,7 @@ export const getIsDustPayment = (
 ) =>
   getIsPayment(operation.type) &&
   "asset_type" in operation &&
-  operation.asset_type === "native" &&
+  isNativeAssetId(operation.asset_type) &&
   "to" in operation &&
   operation.to === publicKey &&
   "amount" in operation &&
@@ -299,11 +302,7 @@ export const getAvailableBalance = ({
   if (!balance) {
     return availBalance;
   }
-  if (
-    "token" in balance &&
-    "type" in balance.token &&
-    balance.token.type === "native"
-  ) {
+  if (isNativeBalance(balance)) {
     // take base reserve into account for XLM payments
     const baseReserve = (2 + subentryCount) * 0.5;
 
@@ -373,7 +372,7 @@ export const filterHiddenBalances = (
 ) => {
   const balanceKeys = Object.keys(balances);
   const hiddenKeys = balanceKeys.filter((key) => {
-    if (key === "native") {
+    if (isNativeAssetId(key)) {
       return false;
     }
     const [code, issuer] = key.split(":");

--- a/extension/src/popup/helpers/account.ts
+++ b/extension/src/popup/helpers/account.ts
@@ -12,6 +12,7 @@ import { Balances, BalanceMap } from "@shared/api/types/backend-api";
 import { AssetType } from "@shared/api/types/account-balance";
 import { NetworkDetails } from "@shared/constants/stellar";
 import { SorobanTokenInterface } from "@shared/constants/soroban/token";
+import { isNativeAssetId } from "@shared/helpers/assetIdentity";
 export { isSorobanIssuer } from "@shared/helpers/stellar";
 
 import {
@@ -125,6 +126,47 @@ export interface AssetOperations {
   [key: string]: OperationDataRow[];
 }
 
+/**
+ * True when `operation` moves the asset that `assetKey` identifies.
+ *
+ * The two sides identify assets in different spaces: `assetKey` is a canonical
+ * identifier, while a Horizon operation carries an asset type alongside a
+ * code/issuer pair. Each arm therefore tests in its own space rather than
+ * comparing a code against a type.
+ */
+export const operationMatchesAssetKey = (
+  assetKey: string,
+  operation: HorizonOperation,
+): boolean => {
+  const asset = getAssetFromCanonical(assetKey);
+  const isNativeKey = isNativeAssetId(assetKey);
+
+  const matchesAsset = isNativeKey
+    ? "asset_type" in operation && isNativeAssetId(operation.asset_type)
+    : "asset_code" in operation &&
+      "asset_issuer" in operation &&
+      operation.asset_code === asset.code &&
+      operation.asset_issuer === asset.issuer;
+
+  if (matchesAsset) {
+    return true;
+  }
+
+  if (
+    !("source_asset_type" in operation) &&
+    !("source_asset_code" in operation)
+  ) {
+    return false;
+  }
+
+  return isNativeKey
+    ? "source_asset_type" in operation &&
+        isNativeAssetId(operation.source_asset_type)
+    : "source_asset_issuer" in operation &&
+        operation.source_asset_code === asset.code &&
+        operation.source_asset_issuer === asset.issuer;
+};
+
 export const sortOperationsByAsset = async ({
   balances,
   operations,
@@ -196,27 +238,8 @@ export const sortOperationsByAsset = async ({
     );
     if (getIsPayment(op.type)) {
       Object.keys(assetOperationMap).forEach((assetKey) => {
-        const asset = getAssetFromCanonical(assetKey);
-        const assetCode = asset.code === "XLM" ? "native" : asset.code;
-        const assetIssuer = asset.issuer;
-
-        if (
-          ("asset_code" in op &&
-            "asset_issuer" in op &&
-            op.asset_code === assetCode &&
-            op.asset_issuer === assetIssuer) ||
-          ("asset_type" in op && op.asset_type === assetCode)
-        ) {
+        if (operationMatchesAssetKey(assetKey, op)) {
           assetOperationMap[assetKey].push(opRowData);
-        } else if ("source_asset_type" in op || "source_asset_code" in op) {
-          if (
-            ("source_asset_type" in op && op.source_asset_type === assetCode) ||
-            (op.source_asset_code === assetCode &&
-              "source_asset_issuer" in op &&
-              op.source_asset_issuer === assetIssuer)
-          ) {
-            assetOperationMap[assetKey].push(opRowData);
-          }
         }
       });
     }

--- a/extension/src/popup/helpers/account.ts
+++ b/extension/src/popup/helpers/account.ts
@@ -1,4 +1,5 @@
 import { Federation, Horizon, MuxedAccount } from "stellar-sdk";
+import { splitCanonical } from "@shared/helpers/stellar";
 import { BigNumber } from "bignumber.js";
 import {
   Account,
@@ -375,7 +376,7 @@ export const filterHiddenBalances = (
     if (isNativeAssetId(key)) {
       return false;
     }
-    const [code, issuer] = key.split(":");
+    const { code, issuer } = splitCanonical(key);
     if (!issuer) {
       return true;
     }

--- a/extension/src/popup/helpers/assetList.ts
+++ b/extension/src/popup/helpers/assetList.ts
@@ -82,6 +82,20 @@ interface GetAssetListsForAssetParams {
   cachedAssetLists?: AssetListResponse[];
 }
 
+/**
+ * True when `asset` and `item` name the same asset.
+ *
+ * Both halves of an identity are optional on these records, so each comparison
+ * requires its own side to actually be present — two absent values are not a
+ * match.
+ */
+export const assetMatchesListItem = (
+  asset: { issuer?: string; contract?: string },
+  item: { issuer?: string; contract?: string },
+): boolean =>
+  (!!asset.issuer && asset.issuer === item.issuer) ||
+  (!!asset.contract && asset.contract === item.contract);
+
 export const getAssetListsForAsset = async ({
   asset,
   assetsListsDetails,
@@ -105,10 +119,7 @@ export const getAssetListsForAsset = async ({
 
   return Object.entries(validatedAssets)
     .filter(([_, items]) =>
-      items.some(
-        ({ issuer, contract }) =>
-          asset.issuer === issuer || asset.contract === contract,
-      ),
+      items.some((item) => assetMatchesListItem(asset, item)),
     )
     .map(([name]) => name);
 };

--- a/extension/src/popup/helpers/assetList.ts
+++ b/extension/src/popup/helpers/assetList.ts
@@ -83,11 +83,16 @@ interface GetAssetListsForAssetParams {
 }
 
 /**
- * True when `asset` and `item` name the same asset.
+ * True when `asset` and `item` share an issuer, or share a contract id.
  *
  * Both halves of an identity are optional on these records, so each comparison
  * requires its own side to actually be present — two absent values are not a
  * match.
+ *
+ * Note this is not full identity: a classic asset is the pair (code, issuer),
+ * and matching on the issuer alone accepts a different asset from the same
+ * issuer. That is the long-standing behaviour of the verified-list membership
+ * tests, tracked in stellar/wallet-eng-monorepo#76; this helper preserves it.
  */
 export const assetMatchesListItem = (
   asset: { issuer?: string; contract?: string },

--- a/extension/src/popup/helpers/balance.ts
+++ b/extension/src/popup/helpers/balance.ts
@@ -15,7 +15,10 @@ import {
   SorobanAsset,
 } from "@shared/api/types/account-balance";
 import { NetworkDetails } from "@shared/constants/stellar";
-import { isNativeBalance } from "@shared/helpers/assetIdentity";
+import {
+  isNativeAssetId,
+  isNativeBalance,
+} from "@shared/helpers/assetIdentity";
 import { getAssetSacAddress } from "@shared/helpers/soroban/token";
 import { LP_IDENTIFIER } from "./account";
 import { NO_FIAT_VALUE, formatFiatAmount } from "./formatters";
@@ -32,12 +35,9 @@ export const findAssetBalance = (
   asset: Asset | { issuer?: string; code: string },
 ) => {
   if (isAsset(asset) && asset.isNative()) {
-    return balances.find(
-      (balance) =>
-        "token" in balance &&
-        "type" in balance.token &&
-        balance.token.type === "native",
-    ) as Exclude<AssetType, SorobanAsset | LiquidityPoolShareAsset> | undefined;
+    return balances.find((balance) => isNativeBalance(balance)) as
+      | Exclude<AssetType, SorobanAsset | LiquidityPoolShareAsset>
+      | undefined;
   }
   if (isContractId(asset.issuer)) {
     return balances.find(
@@ -64,8 +64,8 @@ export const getBalanceByAsset = (
   const issuer = asset.issuer;
 
   return balances.find((balance) => {
-    if ("token" in balance && "type" in balance.token && !issuer) {
-      return balance.token.type === "native";
+    if (!issuer) {
+      return isNativeBalance(balance);
     }
     if (isContractId(issuer)) {
       return "contractId" in balance && balance.contractId === issuer;
@@ -143,13 +143,8 @@ export const findAddressBalance = (
   address: string,
   network: Networks,
 ) => {
-  if (address === "native") {
-    return balances.find(
-      (balance) =>
-        "token" in balance &&
-        "type" in balance.token &&
-        balance.token.type === "native",
-    );
+  if (isNativeAssetId(address)) {
+    return balances.find((balance) => isNativeBalance(balance));
   }
   if (isContractId(address)) {
     // first check for contract ID match, then check for SAC match

--- a/extension/src/popup/helpers/balance.ts
+++ b/extension/src/popup/helpers/balance.ts
@@ -15,6 +15,7 @@ import {
   SorobanAsset,
 } from "@shared/api/types/account-balance";
 import { NetworkDetails } from "@shared/constants/stellar";
+import { isNativeBalance } from "@shared/helpers/assetIdentity";
 import { getAssetSacAddress } from "@shared/helpers/soroban/token";
 import { LP_IDENTIFIER } from "./account";
 import { NO_FIAT_VALUE, formatFiatAmount } from "./formatters";
@@ -98,8 +99,8 @@ export const getBalanceByKey = (
       "contractId" in balance && contractId === balance.contractId;
 
     try {
-      // if xlm, check for a SAC match
-      if ("token" in balance && balance.token.code === "XLM") {
+      // if this is the native balance, check for a SAC match
+      if (isNativeBalance(balance)) {
         const matchesSac =
           Asset.native().contractId(networkDetails.networkPassphrase) ===
           contractId;

--- a/extension/src/popup/helpers/balance.ts
+++ b/extension/src/popup/helpers/balance.ts
@@ -316,3 +316,17 @@ export const getTotalUsdLabel = ({
 
   return formatFiatAmount(totalUsd?.toString());
 };
+
+/**
+ * True when the account holds enough native lumens to cover `feeXlm`.
+ *
+ * Only the native balance can pay a fee, so this is anchored on the balance's
+ * type rather than its code.
+ */
+export const hasEnoughXlmForFee = (
+  balances: AssetType[],
+  feeXlm: BigNumber,
+): boolean =>
+  balances.some(
+    (balance) => isNativeBalance(balance) && balance.available.gt(feeXlm),
+  );

--- a/extension/src/popup/helpers/balance.ts
+++ b/extension/src/popup/helpers/balance.ts
@@ -12,7 +12,6 @@ import {
   AssetType,
   ClassicAsset,
   LiquidityPoolShareAsset,
-  NativeAsset,
   SorobanAsset,
 } from "@shared/api/types/account-balance";
 import { NetworkDetails } from "@shared/constants/stellar";
@@ -26,11 +25,6 @@ export const isClassicBalance = (balance: AssetType): balance is ClassicAsset =>
 
 export const isSorobanBalance = (balance: AssetType): balance is SorobanAsset =>
   "contractId" in balance;
-
-export const isNativeBalance = (balance: AssetType): balance is NativeAsset =>
-  "token" in balance &&
-  "type" in balance.token &&
-  balance.token.type === "native";
 
 export const findAssetBalance = (
   balances: AssetType[],

--- a/extension/src/popup/helpers/searchAsset.ts
+++ b/extension/src/popup/helpers/searchAsset.ts
@@ -5,7 +5,11 @@ import {
   AssetListResponse,
   AssetListReponseItem,
 } from "@shared/constants/soroban/asset-list";
-import { getNativeContractId } from "@shared/helpers/assetIdentity";
+import {
+  getNativeContractId,
+  isNativeAssetPair,
+} from "@shared/helpers/assetIdentity";
+import { isContractId } from "@shared/api/helpers/soroban";
 
 import { getApiStellarExpertUrl } from "popup/helpers/account";
 import { getCombinedAssetListData } from "@shared/api/helpers/token-list";
@@ -176,5 +180,64 @@ export const buildNativeAssetRow = (networkDetails: NetworkDetails) => {
     contract: nativeContractDetails.contract,
     domain: nativeContractDetails.domain,
     name: nativeContractDetails.code,
+  };
+};
+
+/**
+ * A record from stellar.expert's asset search. Issued assets arrive as
+ * `CODE-ISSUER-TYPE`, contract tokens as their contract id, and the native
+ * asset as its bare code with no issuer and no domain.
+ */
+export interface StellarExpertAssetRecord {
+  asset: string;
+  domain?: string;
+  code?: string;
+  token_name?: string;
+  decimals?: number;
+  tomlInfo?: {
+    image?: string;
+    code?: string;
+    issuer?: string;
+    name?: string;
+  };
+}
+
+/**
+ * Maps a stellar.expert search record to an asset row.
+ *
+ * The native asset's record carries only its code, so its row is built from
+ * the network's own native details instead — that gives it its contract id,
+ * which is how the verified-list split and the held-balance check recognise
+ * it. Every other record carries its identity (issuer or contract id) itself.
+ */
+export const mapStellarExpertRecord = (
+  record: StellarExpertAssetRecord,
+  networkDetails: NetworkDetails,
+) => {
+  if (isContractId(record.asset)) {
+    return {
+      code: record.code || record.tomlInfo?.code || "",
+      issuer: record.asset,
+      contract: record.asset,
+      domain: record.domain ?? null,
+      image: record.tomlInfo?.image,
+      name: record.token_name || record.tomlInfo?.name,
+      decimals: record.decimals,
+      isSuspicious: false,
+    };
+  }
+
+  const [code, issuer] = record.asset.split("-");
+
+  if (isNativeAssetPair(code, issuer)) {
+    return { ...buildNativeAssetRow(networkDetails), isSuspicious: false };
+  }
+
+  return {
+    code,
+    issuer,
+    domain: record.domain ?? null,
+    image: record.tomlInfo?.image,
+    isSuspicious: false,
   };
 };

--- a/extension/src/popup/helpers/searchAsset.ts
+++ b/extension/src/popup/helpers/searchAsset.ts
@@ -159,3 +159,22 @@ export const getVerifiedTokens = async ({
 
   return verifiedTokens;
 };
+
+/**
+ * The search-result row for the native asset.
+ *
+ * The native asset has no issuer, so the row carries none. That keeps the
+ * canonical identifier built from this row equal to the native identifier,
+ * which is what lets it match the held native balance.
+ */
+export const buildNativeAssetRow = (networkDetails: NetworkDetails) => {
+  const nativeContractDetails = getNativeContractDetails(networkDetails);
+
+  return {
+    code: nativeContractDetails.code,
+    issuer: "",
+    contract: nativeContractDetails.contract,
+    domain: nativeContractDetails.domain,
+    name: nativeContractDetails.code,
+  };
+};

--- a/extension/src/popup/helpers/searchAsset.ts
+++ b/extension/src/popup/helpers/searchAsset.ts
@@ -5,6 +5,7 @@ import {
   AssetListResponse,
   AssetListReponseItem,
 } from "@shared/constants/soroban/asset-list";
+import { getNativeContractId } from "@shared/helpers/assetIdentity";
 
 import { getApiStellarExpertUrl } from "popup/helpers/account";
 import { getCombinedAssetListData } from "@shared/api/helpers/token-list";
@@ -39,21 +40,20 @@ export const getNativeContractDetails = (networkDetails: NetworkDetails) => {
     icon: "",
     org: "",
   };
+
+  // The native SAC address derives deterministically from the network
+  // passphrase, which keeps every network correct by construction.
+  const contract = getNativeContractId(networkDetails.networkPassphrase);
+
   switch (networkDetails.network as keyof typeof NETWORKS) {
     case NETWORKS.PUBLIC:
       return {
         ...NATIVE_CONTRACT_DEFAULTS,
-        contract: "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA",
+        contract,
         issuer: "GDMTVHLWJTHSUDMZVVMXXH6VJHA2ZV3HNG5LYNAZ6RTWB7GISM6PGTUV",
       };
-    case NETWORKS.TESTNET:
-      return {
-        ...NATIVE_CONTRACT_DEFAULTS,
-        contract: "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
-        issuer: "",
-      };
     default:
-      return { ...NATIVE_CONTRACT_DEFAULTS, contract: "", issuer: "" };
+      return { ...NATIVE_CONTRACT_DEFAULTS, contract, issuer: "" };
   }
 };
 

--- a/extension/src/popup/helpers/sendWarnings.ts
+++ b/extension/src/popup/helpers/sendWarnings.ts
@@ -1,4 +1,5 @@
 import { isContractId } from "@shared/api/helpers/soroban";
+import { isNativeAssetId } from "@shared/helpers/assetIdentity";
 
 /**
  * Returns true when the "destination is unfunded" warning rule applies to
@@ -32,7 +33,7 @@ export const shouldCheckUnfundedDestinationWarning = ({
     return false;
   }
 
-  if (assetCanonical && assetCanonical !== "native") {
+  if (assetCanonical && !isNativeAssetId(assetCanonical)) {
     const [, issuer] = assetCanonical.split(":");
     if (issuer && isContractId(issuer)) {
       return false;

--- a/extension/src/popup/helpers/sendWarnings.ts
+++ b/extension/src/popup/helpers/sendWarnings.ts
@@ -1,4 +1,5 @@
 import { isContractId } from "@shared/api/helpers/soroban";
+import { splitCanonical } from "@shared/helpers/stellar";
 import { isNativeAssetId } from "@shared/helpers/assetIdentity";
 
 /**
@@ -34,7 +35,7 @@ export const shouldCheckUnfundedDestinationWarning = ({
   }
 
   if (assetCanonical && !isNativeAssetId(assetCanonical)) {
-    const [, issuer] = assetCanonical.split(":");
+    const { issuer } = splitCanonical(assetCanonical);
     if (issuer && isContractId(issuer)) {
       return false;
     }

--- a/extension/src/popup/helpers/soroban.ts
+++ b/extension/src/popup/helpers/soroban.ts
@@ -24,7 +24,10 @@ import { AccountBalances } from "helpers/hooks/useGetBalances";
 import { getAssetFromCanonical, getCanonicalFromAsset } from "helpers/stellar";
 import { findAssetBalance, isSorobanBalance } from "./balance";
 import { getSdk } from "@shared/helpers/stellar";
-import { isNativeContract } from "@shared/helpers/assetIdentity";
+import {
+  isNativeAssetId,
+  isNativeContract,
+} from "@shared/helpers/assetIdentity";
 import { AssetType } from "@shared/api/types/account-balance";
 import { getNativeContractDetails } from "./searchAsset";
 import { getTokenDetails } from "@shared/api/internal";
@@ -220,7 +223,7 @@ export const getContractIdFromTokenId = (
   tokenId: string,
   networkDetails: NetworkDetails,
 ): string | undefined => {
-  if (tokenId === "native") {
+  if (isNativeAssetId(tokenId)) {
     return getNativeContractDetails(networkDetails).contract;
   }
 

--- a/extension/src/popup/helpers/soroban.ts
+++ b/extension/src/popup/helpers/soroban.ts
@@ -24,6 +24,7 @@ import { AccountBalances } from "helpers/hooks/useGetBalances";
 import { getAssetFromCanonical, getCanonicalFromAsset } from "helpers/stellar";
 import { findAssetBalance, isSorobanBalance } from "./balance";
 import { getSdk } from "@shared/helpers/stellar";
+import { isNativeContract } from "@shared/helpers/assetIdentity";
 import { AssetType } from "@shared/api/types/account-balance";
 import { getNativeContractDetails } from "./searchAsset";
 import { getTokenDetails } from "@shared/api/internal";
@@ -1022,10 +1023,8 @@ export const isAssetSac = ({
     return false;
   }
 
-  const nativeContract = getNativeContractDetails(networkDetails);
-
-  // Check if it's the native XLM contract
-  if (asset.contract === nativeContract.contract) {
+  // Check if it's the native contract
+  if (isNativeContract(asset.contract, networkDetails.networkPassphrase)) {
     return true;
   }
 

--- a/extension/src/popup/helpers/soroban.ts
+++ b/extension/src/popup/helpers/soroban.ts
@@ -23,7 +23,7 @@ import {
 import { AccountBalances } from "helpers/hooks/useGetBalances";
 import { getAssetFromCanonical, getCanonicalFromAsset } from "helpers/stellar";
 import { findAssetBalance, isSorobanBalance } from "./balance";
-import { getSdk } from "@shared/helpers/stellar";
+import { getSdk, splitCanonical } from "@shared/helpers/stellar";
 import {
   isNativeAssetId,
   isNativeContract,
@@ -232,12 +232,11 @@ export const getContractIdFromTokenId = (
     return tokenId;
   }
 
-  // Check if it's SYMBOL:CONTRACTID format (Soroban token)
-  // Split by : and check if the second part is a contract ID
-  const parts = tokenId.split(":");
-  if (parts.length === 2 && isContractId(parts[1])) {
-    // This is a Soroban token in SYMBOL:CONTRACTID format
-    return parts[1];
+  // SYMBOL:CONTRACTID format (Soroban token). The symbol may itself contain
+  // a colon, so read the issuer half from the last separator.
+  const { issuer } = splitCanonical(tokenId);
+  if (isContractId(issuer)) {
+    return issuer;
   }
 
   // Classic token format: CODE:ISSUER (no contract ID)
@@ -989,9 +988,10 @@ export const isSacContract = (
   if (name.includes(":")) {
     try {
       return (
-        new Sdk.Asset(...(name.split(":") as [string, string])).contractId(
-          networkPassphrase,
-        ) === contractId
+        new Sdk.Asset(
+          splitCanonical(name).code,
+          splitCanonical(name).issuer,
+        ).contractId(networkPassphrase) === contractId
       );
     } catch (error) {
       return false;

--- a/extension/src/popup/helpers/useTokenLookup.ts
+++ b/extension/src/popup/helpers/useTokenLookup.ts
@@ -14,9 +14,10 @@ import {
 } from "popup/ducks/settings";
 import {
   getVerifiedTokens,
-  getNativeContractDetails,
+  buildNativeAssetRow,
   VerifiedTokenRecord,
 } from "popup/helpers/searchAsset";
+import { isNativeContract } from "@shared/helpers/assetIdentity";
 import { scanAsset, useIsAssetSuspicious } from "popup/helpers/blockaid";
 import { isAssetSac } from "popup/helpers/soroban";
 import { ManageAssetCurrency } from "popup/components/manageAssets/ManageAssetRows";
@@ -69,22 +70,15 @@ export const useTokenLookup = ({
         setIsVerificationInfoShowing(false);
         setAssetRows([]);
 
-        const nativeContractDetails =
-          getNativeContractDetails(lookupNetworkDetails);
         let verifiedTokens = [] as VerifiedTokenRecord[];
 
         // step around verification for native contract and unverifiable networks
-        if (nativeContractDetails.contract === contractId) {
+        if (
+          isNativeContract(contractId, lookupNetworkDetails.networkPassphrase)
+        ) {
           // override our rules for verification for XLM
           setIsVerificationInfoShowing(false);
-          setAssetRows([
-            {
-              code: nativeContractDetails.code,
-              contract: contractId,
-              issuer: contractId,
-              domain: nativeContractDetails.domain,
-            },
-          ]);
+          setAssetRows([buildNativeAssetRow(lookupNetworkDetails)]);
           return;
         }
 

--- a/extension/src/popup/helpers/xlmReserve.ts
+++ b/extension/src/popup/helpers/xlmReserve.ts
@@ -2,12 +2,9 @@ import BigNumber from "bignumber.js";
 
 import { BASE_RESERVE } from "@shared/constants/stellar";
 import { AssetType } from "@shared/api/types/account-balance";
+import { isNativeBalance } from "@shared/helpers/assetIdentity";
 import { getCanonicalFromAsset } from "@shared/helpers/stellar";
-import {
-  isClassicBalance,
-  isNativeBalance,
-  isSorobanBalance,
-} from "popup/helpers/balance";
+import { isClassicBalance, isSorobanBalance } from "popup/helpers/balance";
 
 // Pre-flight: does a NEW-token swap risk failing on-chain because the source
 // account can't cover the extra 0.5 XLM trustline reserve?

--- a/extension/src/popup/views/Account/hooks/useGetIcons.tsx
+++ b/extension/src/popup/views/Account/hooks/useGetIcons.tsx
@@ -7,6 +7,7 @@ import { initialState, reducer } from "helpers/request";
 import { AppDataType, NeedsReRoute } from "helpers/hooks/useGetAppData";
 import { AppDispatch } from "popup/App";
 import { Balances } from "@shared/api/types/backend-api";
+import { isNativeAssetId } from "@shared/helpers/assetIdentity";
 import {
   balancesSelector,
   saveIconsForBalances,
@@ -117,7 +118,7 @@ function useGetIcons() {
         const assetsWithoutIcons = {} as NonNullable<Balances>;
 
         Object.entries(accountBalances).forEach(([asset, balance]) => {
-          if (!icons[asset] && asset !== "native") {
+          if (!icons[asset] && !isNativeAssetId(asset)) {
             assetsWithoutIcons[asset] = balance;
           }
         });

--- a/extension/src/popup/views/AccountHistory/hooks/__tests__/useGetHistoryData.test.tsx
+++ b/extension/src/popup/views/AccountHistory/hooks/__tests__/useGetHistoryData.test.tsx
@@ -1,3 +1,5 @@
+import { Asset, Networks } from "stellar-sdk";
+
 import { TESTNET_NETWORK_DETAILS } from "@shared/constants/stellar";
 import { SorobanTokenInterface } from "@shared/constants/soroban/token";
 import { HistoryItemOperation } from "popup/components/accountHistory/HistoryItem";
@@ -218,5 +220,58 @@ describe("getRowDataByOpType - Soroban asset balance changes muxed classificatio
 
     expect(row.metadata.isReceiving).toBe(true);
     expect(row.amount).toMatch(/^\+/);
+  });
+});
+
+const NON_NATIVE_CONTRACT =
+  "CCV3NAKLIBBNSJNNTV2AZVRX6VODUDWK4TVYILE5MW6R45SSQJS5VCAM";
+
+describe("getRowDataByOpType - Soroban transfer identity", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // A contract's symbol() is self-reported, so it cannot establish which asset
+  // the contract is. Only the contract address can.
+  it("does not label a contract as the native asset because it reports that symbol", async () => {
+    jest.spyOn(sorobanHelpers, "getAttrsFromSorobanHorizonOp").mockReturnValue({
+      fnName: SorobanTokenInterface.transfer,
+      contractId: NON_NATIVE_CONTRACT,
+      amount: "10000000",
+      from: COUNTERPARTY,
+      to: PUBLIC_KEY,
+    } as any);
+    fetchTokenDetails.mockResolvedValue({ symbol: "native", decimals: 7 });
+
+    // asset_issuer as a contract id keeps icon resolution offline in tests
+    const operation = buildInvokeHostFnOperation({
+      asset_issuer: NON_NATIVE_CONTRACT,
+    });
+    const row = await callGetRowData(operation);
+
+    expect(row.amount).not.toContain("XLM");
+  });
+
+  it("labels the native contract as the native asset", async () => {
+    const nativeContractId = Asset.native().contractId(
+      TESTNET_NETWORK_DETAILS.networkPassphrase as Networks,
+    );
+
+    jest.spyOn(sorobanHelpers, "getAttrsFromSorobanHorizonOp").mockReturnValue({
+      fnName: SorobanTokenInterface.transfer,
+      contractId: nativeContractId,
+      amount: "10000000",
+      from: COUNTERPARTY,
+      to: PUBLIC_KEY,
+    } as any);
+    fetchTokenDetails.mockResolvedValue({ symbol: "native", decimals: 7 });
+
+    // asset_issuer as a contract id keeps icon resolution offline in tests
+    const operation = buildInvokeHostFnOperation({
+      asset_issuer: nativeContractId,
+    });
+    const row = await callGetRowData(operation);
+
+    expect(row.amount).toContain("XLM");
   });
 });

--- a/extension/src/popup/views/AccountHistory/hooks/useGetHistoryData.tsx
+++ b/extension/src/popup/views/AccountHistory/hooks/useGetHistoryData.tsx
@@ -83,6 +83,7 @@ import IconSoroban from "popup/assets/icon-soroban.svg?react";
 import { batchFetchCollectibles } from "helpers/utils/collectibles/collectiblesBatchFetcher";
 import { ContractIdentifier } from "helpers/utils/collectibles/collectiblesCache";
 import {
+  isNativeAssetId,
   isNativeAssetPair,
   isNativeContract,
 } from "@shared/helpers/assetIdentity";
@@ -457,7 +458,7 @@ const processAssetBalanceChanges = async (
     let assetCode: string;
     let assetIssuer: string | null = null;
 
-    if (change.asset_type === "native") {
+    if (isNativeAssetId(change.asset_type)) {
       assetCode = "XLM";
       assetIssuer = null;
     } else {

--- a/extension/src/popup/views/AccountHistory/hooks/useGetHistoryData.tsx
+++ b/extension/src/popup/views/AccountHistory/hooks/useGetHistoryData.tsx
@@ -82,6 +82,10 @@ import { getIconFromTokenLists } from "@shared/api/helpers/getIconFromTokenList"
 import IconSoroban from "popup/assets/icon-soroban.svg?react";
 import { batchFetchCollectibles } from "helpers/utils/collectibles/collectiblesBatchFetcher";
 import { ContractIdentifier } from "helpers/utils/collectibles/collectiblesCache";
+import {
+  isNativeAssetPair,
+  isNativeContract,
+} from "@shared/helpers/assetIdentity";
 
 export type HistorySection = {
   monthYear: string; // in format {month}:{year}
@@ -467,17 +471,16 @@ const processAssetBalanceChanges = async (
     const destination = isCredit ? change.from : change.to;
 
     // Get asset icon
-    const icon =
-      assetCode === "XLM"
-        ? StellarLogo
-        : await getIconUrl({
-            key: assetIssuer || "",
-            code: assetCode,
-            networkDetails,
-            homeDomains,
-            icons,
-            cachedTokenLists,
-          });
+    const icon = isNativeAssetPair(assetCode, assetIssuer)
+      ? StellarLogo
+      : await getIconUrl({
+          key: assetIssuer || "",
+          code: assetCode,
+          networkDetails,
+          homeDomains,
+          icons,
+          cachedTokenLists,
+        });
 
     // Fetch decimals based on whether it's a Soroban contract
     let decimals: number;
@@ -635,28 +638,26 @@ export const getRowDataByOpType = async (
       ? formatAmount(new BigNumber(srcAmount).toString())
       : null;
 
-    const destIcon =
-      destAssetCode === "XLM"
-        ? StellarLogo
-        : await getIconUrl({
-            key: assetIssuer || "",
-            code: destAssetCode || "",
-            networkDetails,
-            homeDomains,
-            icons,
-            cachedTokenLists,
-          });
-    const sourceIcon =
-      srcAssetCode === "XLM"
-        ? StellarLogo
-        : await getIconUrl({
-            key: sourceAssetIssuer || "",
-            code: srcAssetCode || "",
-            networkDetails,
-            homeDomains,
-            icons,
-            cachedTokenLists,
-          });
+    const destIcon = isNativeAssetPair(destAssetCode, assetIssuer)
+      ? StellarLogo
+      : await getIconUrl({
+          key: assetIssuer || "",
+          code: destAssetCode || "",
+          networkDetails,
+          homeDomains,
+          icons,
+          cachedTokenLists,
+        });
+    const sourceIcon = isNativeAssetPair(srcAssetCode, sourceAssetIssuer)
+      ? StellarLogo
+      : await getIconUrl({
+          key: sourceAssetIssuer || "",
+          code: srcAssetCode || "",
+          networkDetails,
+          homeDomains,
+          icons,
+          cachedTokenLists,
+        });
 
     return {
       action: "Swapped",
@@ -702,17 +703,16 @@ export const getRowDataByOpType = async (
     const nonLabelAmount = formatAmount(new BigNumber(amount!).toString());
     const formattedAmount = `${paymentDifference}${nonLabelAmount} ${destAssetCode}`;
 
-    const destIcon =
-      destAssetCode === "XLM"
-        ? StellarLogo
-        : await getIconUrl({
-            key: assetIssuer || "",
-            code: destAssetCode || "",
-            networkDetails,
-            homeDomains,
-            icons,
-            cachedTokenLists,
-          });
+    const destIcon = isNativeAssetPair(destAssetCode, assetIssuer)
+      ? StellarLogo
+      : await getIconUrl({
+          key: assetIssuer || "",
+          code: destAssetCode || "",
+          networkDetails,
+          homeDomains,
+          icons,
+          cachedTokenLists,
+        });
 
     return {
       action: isReceiving ? i18n.t("Received") : i18n.t("Sent"),
@@ -864,7 +864,10 @@ export const getRowDataByOpType = async (
           }
 
           const { symbol, decimals } = tokenDetailsResponse!;
-          const isNative = symbol === "native";
+          const isNative = isNativeContract(
+            attrs.contractId,
+            networkDetails.networkPassphrase,
+          );
           const code = isNative ? "XLM" : symbol;
           const formattedTokenAmount = formatTokenAmount(
             new BigNumber(attrs.amount),

--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -60,7 +60,7 @@ import {
 import { HardwareSign } from "popup/components/hardwareConnect/HardwareSign";
 import { Loading } from "popup/components/Loading";
 import { VerifyAccount } from "popup/views/VerifyAccount";
-import { NativeAsset } from "@shared/api/types/account-balance";
+import { hasEnoughXlmForFee } from "popup/helpers/balance";
 
 import { RequestState } from "constants/request";
 import { useGetSignTxData } from "./hooks/useGetSignTxData";
@@ -371,12 +371,7 @@ export const SignTransaction = () => {
   // Check if user has enough XLM for the fee - skip warning if balances unavailable
   const balances = signTxState.data?.balances;
   const hasEnoughXlm = balances
-    ? balances.balances.some(
-        (balance) =>
-          "token" in balance &&
-          balance.token.code === "XLM" &&
-          (balance as NativeAsset).available.gt(stroopToXlm(_fee as string)),
-      )
+    ? hasEnoughXlmForFee(balances.balances, stroopToXlm(_fee as string))
     : true; // If balances unavailable, assume user can proceed
 
   if (

--- a/extension/src/popup/views/SignTransaction/index.tsx
+++ b/extension/src/popup/views/SignTransaction/index.tsx
@@ -35,6 +35,7 @@ import {
   isMuxedAccount,
   stroopToXlm,
 } from "helpers/stellar";
+import { isNativeAssetPair } from "@shared/helpers/assetIdentity";
 import { decodeMemo } from "popup/helpers/parseTransaction";
 import { useIsDomainListedAllowed } from "popup/helpers/useIsDomainListedAllowed";
 import { openTab } from "popup/helpers/navigate";
@@ -754,7 +755,7 @@ const AssetDiffs = ({ assetDiffs, icons }: AssetDiffsProps) => {
       <div className="SignTransaction__AssetDiffRow">
         <div className="SignTransaction__AssetDiffRow__Asset">
           <AssetIcon
-            assetIcons={code !== "XLM" ? icons : {}}
+            assetIcons={!isNativeAssetPair(code, issuer) ? icons : {}}
             code={code}
             issuerKey={issuer}
           />
@@ -797,7 +798,7 @@ export const Trustline = ({ operations, icons }: TrustlineProps) => {
         return (
           <>
             <AssetIcon
-              assetIcons={code !== "XLM" ? icons : {}}
+              assetIcons={!isNativeAssetPair(code, issuer) ? icons : {}}
               code={code}
               issuerKey={issuer}
             />

--- a/extension/src/popup/views/Swap/index.tsx
+++ b/extension/src/popup/views/Swap/index.tsx
@@ -31,6 +31,7 @@ import { ROUTES } from "popup/constants/routes";
 import { resetSimulation } from "popup/ducks/token-payment";
 import { settingsNetworkDetailsSelector } from "popup/ducks/settings";
 import { getAssetFromCanonical } from "helpers/stellar";
+import { isNativeAssetId } from "@shared/helpers/assetIdentity";
 import {
   DEFAULT_SWAP_DEST_CANONICAL,
   NETWORKS,
@@ -129,7 +130,7 @@ export const Swap = () => {
       }
     }
     dispatch(saveAsset(sourceAsset));
-    if (sourceAsset === "native") {
+    if (isNativeAssetId(sourceAsset)) {
       dispatch(saveIsToken(false));
     }
 

--- a/extension/src/popup/views/__tests__/AccountHistory.test.tsx
+++ b/extension/src/popup/views/__tests__/AccountHistory.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   fireEvent,
 } from "@testing-library/react";
+import { Asset, Networks } from "stellar-sdk";
 import {
   APPLICATION_STATE,
   APPLICATION_STATE as ApplicationState,
@@ -747,8 +748,17 @@ describe("AccountHistory", () => {
   });
 
   it("uses icons from token lists for Soroban token transfer transactions", async () => {
+    // This fixture models a contract that reports the symbol "TEST" — row
+    // identity is decided by contract address, not by that self-reported
+    // symbol, so the address here must not be the native SAC for this test's
+    // network or the row would (correctly) render as the native lumen instead.
     const contractId =
-      "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+      "CCV3NAKLIBBNSJNNTV2AZVRX6VODUDWK4TVYILE5MW6R45SSQJS5VCAM";
+    expect(contractId).not.toBe(
+      Asset.native().contractId(
+        TESTNET_NETWORK_DETAILS.networkPassphrase as Networks,
+      ),
+    );
     const tokenSymbol = "TEST";
     const tokenListIconUrl = "https://example.com/token-transfer-icon.png";
     const tokenList: AssetListResponse = {


### PR DESCRIPTION
## TL;DR

This PR consolidates the extension's native-asset identity checks into a small set of shared predicates, each keyed on the authoritative discriminant for its layer: a token's **type**, the native contract address **derived from the network passphrase**, or the full canonical identifier.

The flows themselves are unchanged; what changes is how the identity checks are made, and where that logic lives.

It also adds a lint rule that reports a `===`/`!==` with a native-asset sentinel on either side, so new code reaches for an existing predicate instead of re-deriving one; `@shared/helpers/assetIdentity.ts` is exempt as the module that defines them, and the convention is written up in `docs/skills/freighter-best-practices/references/anti-patterns.md`.

Closes https://github.com/stellar/wallet-eng-monorepo/issues/61

### Size

Most of the diff is tests — the production surface is small (net +200).

| | Files | Lines |
|---|---|---|
| Production source | 38 | +475 / −275 (net +200) |
| Tests | 14 | +1131 / −8 |
| Lint rule (plugin + config) | 2 | +124 / −0 |
| Docs | 2 | +88 / −1 |
| **Total** | **56** | **+1818 / −284** |

<details>
<summary>Implementation details (for agents)</summary>

**The shared predicates.** `@shared/helpers/assetIdentity.ts` (new) holds one predicate per identifier layer: `isNativeBalance` / `isNativeAsset` (type-based, for a balance object or an SDK `Asset`), `isNativeAssetId` (the canonical id, a Horizon `asset_type`, or a `token.type` — matches `"native"` only), `getNativeContractId` / `isNativeContract` (contract space, derived via `Asset.native().contractId(passphrase)`), and `isNativeAssetPair(code, issuer)` for the raw-strings layer where nothing better is available. `isNativeBalance` moves here from `popup/helpers/balance.ts`. Identity for anything other than nativeness — equality, map keys, labels — goes through the existing `getCanonicalFromAsset`.

**Transaction building.** `useSimulateTxData`'s `getOperation` decides its create-account branch from the asset's type via `isNativeAsset`, and is exported so the operation it builds is pinned on parsed operations.

**Balances and signing.** `getBalanceByKey` enters its native-contract branch on the balance's type. The signing screen's fee pre-flight is extracted to `hasEnoughXlmForFee` in `popup/helpers/balance.ts`, anchored on the native balance.

**Icons, history and display.** `AssetIcon` resolves the native icon from code and issuer together, and its memo comparator compares every render-affecting prop; the callers that build its icon map use the same pair. History icon selection pairs each code with its issuer, the Soroban transfer row decides nativeness from the contract address, and asset-detail operation matching is extracted to `operationMatchesAssetKey` with separate native and classic arms.

**Contract space and add-a-token.** `getNativeContractDetails` derives the native contract address from the passphrase for every network. `isAssetSac`'s native branch, `useAssetLookup`, `useTokenLookup` and `AddAsset` resolve the native contract through `isNativeContract`; the native search row is built by `buildNativeAssetRow`, and stellar.expert records are mapped by `mapStellarExpertRecord` alongside it. `getAssetListsForAsset` requires both sides of an identity to be present before comparing them.

**The lint rule and the convention.** `config/eslint-plugin-asset-identity/` (new local plugin, wired into `eslint.config.js` at error level) adds `no-asset-code-comparison`: it reports a `===`/`!==` with `"XLM"`, `"native"`, the SDK's own native code (`Asset.native().code` / `.getCode()`), or the identifier names `NATIVE_TOKEN_CODE` / `HORIZON_NATIVE_ASSET_TYPE` on either side. `Asset.native().contractId(...)` is not reported: a contract-id comparison is the sound check in contract space. Every site the rule flags was migrated in this branch — 62 comparisons across 31 files, each routed to the predicate matching what its operand holds — so it reports zero hits on the tree. The convention is written up in `anti-patterns.md §11` with a what-you-hold → which-predicate table, and `code-style.md` records the rule.

**Verification.** Full Jest suite green: 1851 passed / 51 skipped across 234 suites. `yarn build:extension` is clean with the rule live (ESLint runs inside the webpack build for `extension/`), and the rule was confirmed to fire before the tree was declared clean. Each migrated site has tests covering its predicate's discriminating cases — a genuine native control alongside a classic asset that uses the code `XLM` with its own issuer — and derived contract ids are pinned against the published PUBLIC and TESTNET addresses. No user-facing strings were added.

**Follow-ups / out of scope.** Extending the build's lint gate from `extension/` to `@shared` (the docs state the current scope). Issuer rows on the liquidity-pool branch of the trustline approval pane. Worth a smoke test before release: the add-a-token search and icon surfaces, which now resolve the native asset through the shared predicates.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
