### PR TITLE
Skip the Blockaid bulk scan when no scannable assets are present

### DIFF
--- a/@shared/helpers/stellar.ts
+++ b/@shared/helpers/stellar.ts
@@ -84,12 +84,16 @@ export const makeDisplayableBalances = async (
       }
     }
 
-    try {
-      const response = await fetch(url.href);
-      const data = await response.json();
-      blockaidScanResults = data.data.results;
-    } catch (e) {
-      console.error(e);
+    // Skip the scan entirely when there is nothing to scan: an empty token
+    // list makes the Blockaid call error out and wastes rate limit.
+    if (url.searchParams.has("asset_ids")) {
+      try {
+        const response = await fetch(url.href);
+        const data = await response.json();
+        blockaidScanResults = data.data.results;
+      } catch (e) {
+        console.error(e);
+      }
     }
   }
 


### PR DESCRIPTION
## What and why

In \`makeDisplayableBalances\`, the \`scan-asset-bulk\` request went out whenever the account was on mainnet, even when every balance was native XLM or an LP share and nothing was appended to \`asset_ids\`. The empty token list made the Blockaid call error and consumed rate limit for nothing.

The v2 balance path (\`addBlockaidScanResults\`) already skips the scan when the scannable id list is empty; this mirrors that guard on the standalone path by checking \`url.searchParams.has("asset_ids")\` before fetching.

Fixes #2905

## Testing

The touched helper is covered by existing suites; the behavior change only affects accounts with no scannable assets, which previously errored into the catch block.
